### PR TITLE
Expand height changed

### DIFF
--- a/dockedDash.js
+++ b/dockedDash.js
@@ -545,7 +545,7 @@ dockedDash.prototype = {
                 panelActor.set_width(this.staticBox.x1);
                 panelActor.set_margin_right(this.staticBox.x2);
             } else {
-                panelActor.set_width(this._monitor.width - this.staticBox.x2);
+                panelActor.set_width(this._monitor.width - this.staticBox.x2 + 1);
                 panelActor.set_margin_left(this.staticBox.x2 - 1);
             }
         } else {


### PR DESCRIPTION
Ok, so here is the result of my work:

![top-left-corner](https://f.cloud.github.com/assets/4481613/625424/a71dbd3e-cf9f-11e2-9804-574d3ee69a63.png)

I changed the behavior so when "Dock is fixed and always visible" and "Expand" options are selected then the dock is expanded over all height of the screen.

The reason for this is that the height of my screen is valuable on my laptop, so I use extension which hides the main panel. With current behavior it didn't look good. I also noticed that my change is what you mentioned in "Feature Request: Full-Height Dock".

I tested it with normal and RTL and with/without secondary monitor. It is OK.
