### PR TITLE
Opacity when no maximized window

### DIFF
--- a/dockedDash.js
+++ b/dockedDash.js
@@ -151,7 +151,7 @@ dockedDash.prototype = {
             this._updateWindowListeners();
             this._updateBackgroundOpacity();
         }));
-        global.screen.connect('workspace-switched', Lang.bind(this, this._updateBackgroundOpacity));
+        global.screen.connect('restacked', Lang.bind(this, this._updateBackgroundOpacity));
         Main.overview.connect('showing', Lang.bind(this, this._updateBackgroundOpacity));
         Main.overview.connect('hidden', Lang.bind(this, this._updateBackgroundOpacity));
 
@@ -193,15 +193,11 @@ dockedDash.prototype = {
 
     _updateWindowListeners: function() {
         let windowActors = global.get_window_actors();
-        let updateCallback = Lang.bind(this, this._updateBackgroundOpacity);
         for (let i = 0; i < windowActors.length; i++) {
             let windowActor = windowActors[i];
             if (!windowActor.listenersRegistered) {
                 windowActor.listenersRegistered = true;
-                windowActor.connect('size-changed', updateCallback);
-                windowActor.connect('position-changed', updateCallback);
-                let metaWindow = windowActor.get_meta_window();
-                metaWindow.connect('unmanaged', updateCallback);
+                windowActor.connect('size-changed', Lang.bind(this, this._updateBackgroundOpacity));
             }
         }
     },

--- a/dockedDash.js
+++ b/dockedDash.js
@@ -199,6 +199,7 @@ dockedDash.prototype = {
             if (!windowActor.listenersRegistered) {
                 windowActor.listenersRegistered = true;
                 windowActor.connect('size-changed', updateCallback);
+                windowActor.connect('position-changed', updateCallback);
                 let metaWindow = windowActor.get_meta_window();
                 metaWindow.connect('unmanaged', updateCallback);
                 metaWindow.connect('workspace-changed', updateCallback);

--- a/dockedDash.js
+++ b/dockedDash.js
@@ -152,6 +152,8 @@ dockedDash.prototype = {
             this._updateBackgroundOpacity();
         }));
         global.screen.connect('workspace-switched', Lang.bind(this, this._updateBackgroundOpacity));
+        Main.overview.connect('showing', Lang.bind(this, this._updateBackgroundOpacity));
+        Main.overview.connect('hidden', Lang.bind(this, this._updateBackgroundOpacity));
 
         // Restore dash accessibility
         Main.ctrlAltTabManager.addGroup(
@@ -512,6 +514,10 @@ dockedDash.prototype = {
     },
 
     _isAnyMaximizedWindow: function() {
+        if (Main.overview.visible) {
+            return false;
+        }
+
         let windows = global.get_screen().get_active_workspace().list_windows();
         for (let i = 0; i < windows.length; i++) {
             let metaWindow = windows[i];

--- a/dockedDash.js
+++ b/dockedDash.js
@@ -515,14 +515,23 @@ dockedDash.prototype = {
         let windows = global.get_screen().get_active_workspace().list_windows();
         for (let i = 0; i < windows.length; i++) {
             let metaWindow = windows[i];
-            // window is maximized both horizontaly and verticaly
-            if (metaWindow.get_maximized() == 3 && !metaWindow.is_hidden()) {
+            let monitorIndex = metaWindow.get_monitor();
+
+            // window is on monitor with dash
+            if (this._isSameMonitor(this._monitor, global.get_screen().get_monitor_geometry(monitorIndex)) &&
+                // window is maximized both horizontaly and verticaly
+                metaWindow.get_maximized() == 3 &&
+                !metaWindow.is_hidden()) {
                 return true;
             }
         }
         return false;
     },
 
+    // comparing monitor geometry
+    _isSameMonitor: function(m1, m2) {
+        return m1.x == m2.x && m1.y == m2.y;
+    },
 
     _updateYPosition: function() {
 
@@ -530,9 +539,7 @@ dockedDash.prototype = {
         let unavailableBottomSpace = 0;
 
         // check if the dock is on the primary monitor
-        if ( this._monitor.x == Main.layoutManager.primaryMonitor.x &&
-             this._monitor.y == Main.layoutManager.primaryMonitor.y ){
-
+        if (this._isSameMonitor(this._monitor, Main.layoutManager.primaryMonitor)) {
             unavailableTopSpace = Main.panel.actor.height;
         }
 

--- a/dockedDash.js
+++ b/dockedDash.js
@@ -202,8 +202,6 @@ dockedDash.prototype = {
                 windowActor.connect('position-changed', updateCallback);
                 let metaWindow = windowActor.get_meta_window();
                 metaWindow.connect('unmanaged', updateCallback);
-                metaWindow.connect('workspace-changed', updateCallback);
-                metaWindow.connect('focus', updateCallback);
             }
         }
     },

--- a/prefs.js
+++ b/prefs.js
@@ -297,10 +297,11 @@ const WorkspaceSettingsWidget = new GObject.Class({
     opaqueLayerControl.add(opaqueLayer);
     customization.add(opaqueLayerControl);
 
-    let opaqueLayerMain = new Gtk.Box({spacing:30, orientation:Gtk.Orientation.HORIZONTAL, homogeneous:false,
-                                       margin:10});
+    let opaqueLayerMain = new Gtk.Box({orientation:Gtk.Orientation.VERTICAL, homogeneous:false,
+                                       margin_left:10, margin_top:5, margin_bottom:10, margin_right:10});
     indentWidget(opaqueLayerMain);
 
+    let opaqueLayerOpacity = new Gtk.Box({spacing:30, homogeneous:false});
     let opacityLayerTimeout=0; // Used to avoid to continuosly update the opacity
     let layerOpacityLabel = new Gtk.Label({label: _("Opacity"), use_markup: true, xalign: 0});
     let layerOpacity =  new Gtk.Scale({orientation: Gtk.Orientation.HORIZONTAL, valuePos: Gtk.PositionType.RIGHT});
@@ -308,7 +309,7 @@ const WorkspaceSettingsWidget = new GObject.Class({
         layerOpacity.set_value(this.settings.get_double('background-opacity')*100);
         layerOpacity.set_digits(0);
         layerOpacity.set_increments(5,5);
-        layerOpacity.set_size_request(200, -1);
+        //layerOpacity.set_size_request(-1, -1);
         layerOpacity.connect('value-changed', Lang.bind(this, function(button){
             let s = button.get_value()/100;
             if(opacityLayerTimeout>0)
@@ -318,18 +319,27 @@ const WorkspaceSettingsWidget = new GObject.Class({
                 return false;
             }));
         }));
-     let opaqueLayeralwaysVisible =  new Gtk.CheckButton({label: _("Only when in autohide")});
+    opaqueLayerOpacity.add(layerOpacityLabel);
+    opaqueLayerOpacity.pack_end(layerOpacity, true, true, 0);
+
+    let opaqueLayeralwaysVisible =  new Gtk.CheckButton({label: _("Only when in autohide")});
         opaqueLayeralwaysVisible.set_active(!this.settings.get_boolean('opaque-background-always'));
         opaqueLayeralwaysVisible.connect('toggled', Lang.bind(this, function(check){
             this.settings.set_boolean('opaque-background-always', !check.get_active());
         }));
 
+    let opaqueLayerDisableMax =  new Gtk.CheckButton({label: _("Disable when maximized window")});
+        opaqueLayerDisableMax.set_active(this.settings.get_boolean('opaque-background-disable-max'));
+        opaqueLayerDisableMax.connect('toggled', Lang.bind(this, function(check){
+            this.settings.set_boolean('opaque-background-disable-max', check.get_active());
+        }));
+
     this.settings.bind('opaque-background', opaqueLayerMain, 'sensitive', Gio.SettingsBindFlags.DEFAULT);
 
 
-    opaqueLayerMain.add(layerOpacityLabel);
-    opaqueLayerMain.add(layerOpacity);
+    opaqueLayerMain.add(opaqueLayerOpacity);
     opaqueLayerMain.add(opaqueLayeralwaysVisible);
+    opaqueLayerMain.add(opaqueLayerDisableMax);
 
     customization.add(opaqueLayerMain);
 

--- a/prefs.js
+++ b/prefs.js
@@ -328,10 +328,10 @@ const WorkspaceSettingsWidget = new GObject.Class({
             this.settings.set_boolean('opaque-background-always', !check.get_active());
         }));
 
-    let opaqueLayerDisableMax =  new Gtk.CheckButton({label: _("Disable when maximized window")});
-        opaqueLayerDisableMax.set_active(this.settings.get_boolean('opaque-background-disable-max'));
+    let opaqueLayerDisableMax =  new Gtk.CheckButton({label: _("Only when no maximized window")});
+        opaqueLayerDisableMax.set_active(this.settings.get_boolean('opaque-background-no-max'));
         opaqueLayerDisableMax.connect('toggled', Lang.bind(this, function(check){
-            this.settings.set_boolean('opaque-background-disable-max', check.get_active());
+            this.settings.set_boolean('opaque-background-no-max', check.get_active());
         }));
 
     this.settings.bind('opaque-background', opaqueLayerMain, 'sensitive', Gio.SettingsBindFlags.DEFAULT);

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -32,7 +32,7 @@
       <summary>Dash background always opaque</summary>
       <description>Makes the background of the dash opaque improving readability even when not in autohide mode.</description>
     </key>
-    <key type="b" name="opaque-background-disable-max">
+    <key type="b" name="opaque-background-no-max">
       <default>false</default>
       <summary>Dash background opaque with not maximized windows</summary>
       <description>Makes the background of the dash opaque only when all windows on current desktop are not maximized.</description>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -32,6 +32,11 @@
       <summary>Dash background always opaque</summary>
       <description>Makes the background of the dash opaque improving readability even when not in autohide mode.</description>
     </key>
+    <key type="b" name="opaque-background-disable-max">
+      <default>false</default>
+      <summary>Dash background opaque with not maximized windows</summary>
+      <description>Makes the background of the dash opaque only when all windows on current desktop are not maximized.</description>
+    </key>
     <key type="d" name="background-opacity">
       <default>0.8</default>
       <summary>Opacity of the dash background</summary>


### PR DESCRIPTION
I added new option for opacity "Only when no maximized window":

![opacity-when-no-maximized](https://f.cloud.github.com/assets/4481613/630285/37239134-d19d-11e2-8bc3-6522dbcc03b5.png)

I like transparent background, but it's little disturbing when I have the dash visible, expanded over all height and some window is maximized.
