### PR TITLE
Update org.gnome.shell.extensions.dash-to-dock.gschema.xml

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -72,8 +72,8 @@
       <summary>Switch worskpace one at a time</summary>
       <description>Switch only one workspace on each scroll event</description>
     </key>
-    <key type="i" name="scroll-switch-workspace-dead-time">
-      <default>250</default>
+    <key type="d" name="scroll-switch-workspace-dead-time">
+      <default>0.25</default>
       <summary>A deadtime in ms</summary>
       <description>A deadtime between each worskapace switch triggere by mouse scroll</description>
     </key>


### PR DESCRIPTION
'scroll-switch-workspace-dead-time' is a double, and is stored value is divided by 1000.
