### PR TITLE
[GNOME 3.9+ ONLY] Removed "affectsInputRegion"

### DIFF
--- a/dockedDash.js
+++ b/dockedDash.js
@@ -138,8 +138,8 @@ dockedDash.prototype = {
 
         //Add dash container actor and the container to the Chrome.
         this._box.add_actor(this.dash.actor);
-        Main.layoutManager.addChrome(this.actor, {affectsInputRegion: false, trackFullscreen: true});
-        Main.layoutManager.trackChrome(this._box, {affectsInputRegion: true});
+        Main.layoutManager.addChrome(this.actor, {trackFullscreen: true});
+        Main.layoutManager.trackChrome(this._box, {});
         Main.layoutManager.trackChrome(this.dash._box, { affectsStruts: this._settings.get_boolean('dock-fixed')});
 
         this.dash._container.connect('allocation-changed', Lang.bind(this, this._updateStaticBox));


### PR DESCRIPTION
I've removed "affectedImputRegion", because GNOME 3.9 and newer doesn't support it anymore and, even if it's not tested, I think that it will work with GNOME 3.8 too.

The reason I did this is because the Dash will hang so that it doesn't hide and you cannot interact with it. The Error gets fixed by removing "affectedImputRegion".
