### PR TITLE
Added option to use mouse pressure to show the dock.

### DIFF
--- a/dockedDash.js
+++ b/dockedDash.js
@@ -16,10 +16,13 @@ const Dash = imports.ui.dash;
 const Overview = imports.ui.overview;
 const Tweener = imports.ui.tweener;
 const WorkspaceSwitcherPopup= imports.ui.workspaceSwitcherPopup;
+const Layout = imports.ui.layout;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 const MyDash = Me.imports.myDash;
+
+const PRESSURE_TIMEOUT = 1000;
 
 function dockedDash(settings) {
 
@@ -48,6 +51,12 @@ dockedDash.prototype = {
         this._defaultBackground = {red: 0, green:0, blue: 0, alpha:0};
         this._defaultBackgroundColor = {red: 0, green:0, blue: 0, alpha:0};
         this._customizedBackground = {red: 0, green:0, blue: 0, alpha:0};
+
+        // Initialize pressure barrier variables
+        this._canUsePressure = false;
+        this._pressureSensed = false;
+        this._pressureBarrier = null;
+        this._barrier = null;
 
         // Hide usual Dash
         // For some reason if I hide the actor object as I used to do before reshowing it when disabling
@@ -180,12 +189,19 @@ dockedDash.prototype = {
         // Show 
         this.actor.set_opacity(255); //this.actor.show();
 
+        // Setup pressure barrier (GS38+ only)
+        this._updatePressureBarrier();
+        this._updateBarrier();
     },
 
     destroy: function(){
 
         // Disconnect global signals
         this._signalHandler.disconnect();
+
+        // Remove existing barrier
+        this._removeBarrier();
+
         // Destroy main clutter actor: this should be sufficient
         // From clutter documentation:
         // If the actor is inside a container, the actor will be removed.
@@ -237,17 +253,55 @@ dockedDash.prototype = {
             }
 
             this._updateYPosition();
+
+            // Add or remove barrier depending on if dock-fixed
+            this._updateBarrier();
         }));
         this._settings.connect('changed::autohide', Lang.bind(this, function(){
             this.emit('box-changed');
+            this._updateBarrier();
         }));
         this._settings.connect('changed::extend-height', Lang.bind(this, this._updateYPosition));
         this._settings.connect('changed::preferred-monitor', Lang.bind(this,this._resetPosition));
         this._settings.connect('changed::height-fraction', Lang.bind(this,this._updateYPosition));
 
+        this._settings.connect('changed::require-pressure-to-show', Lang.bind(this, this._updateBarrier));
+        this._settings.connect('changed::pressure-threshold', Lang.bind(this, function() {
+            this._updatePressureBarrier();
+            this._updateBarrier();
+        }));
+
+    },
+
+    _updatePressureBarrier: function() {
+        let self = this;
+        this._canUsePressure = global.display.supports_extended_barriers();
+        let pressureThreshold = this._settings.get_double('pressure-threshold');
+
+        // Remove existing pressure barrier
+        if (this._pressureBarrier) {
+            this._pressureBarrier.destroy();
+            this._pressureBarrier = null;
+        }
+
+        // Create new pressure barrier based on pressure threshold setting
+        if (this._canUsePressure) {
+            this._pressureBarrier = new Layout.PressureBarrier(pressureThreshold, PRESSURE_TIMEOUT,
+                                Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.OVERVIEW);
+            this._pressureBarrier.connect('trigger', function(barrier){
+                self._onPressureSensed();
+            });
+        }
     },
 
     _hoverChanged: function() {
+        // Ignore hover if pressure barrier being used but pressureSensed not triggered
+        if (this._canUsePressure && this._settings.get_boolean('require-pressure-to-show') && this._barrier) {
+            if (this._pressureSensed == false) {
+                return;
+            }
+        }
+
         // Skip if dock is not in autohide mode for instance because it is shown by intellihide
         if(this._settings.get_boolean('autohide') && this._autohideStatus){
             if( this._box.hover ) {
@@ -346,7 +400,16 @@ dockedDash.prototype = {
                     this.actor.move_anchor_point_from_gravity(anchor_point);
                 }),
                 onOverwrite : Lang.bind(this, function() {this._animStatus.clear();}),
-                onComplete: Lang.bind(this, function() {this._animStatus.end();})
+                onComplete: Lang.bind(this, function() {
+                    this._animStatus.end();
+                    // Remove barrier so that mouse pointer is released and can access monitors on other side of dock
+                    // NOTE: Delay needed to keep mouse from moving past dock and re-hiding dock immediately. This
+                    // gives users an opportunity to hover over the dock
+                    if (this._removeBarrierTimeoutId > 0) {
+                        Mainloop.source_remove(this._removeBarrierTimeoutId);
+                    }
+                    this._removeBarrierTimeoutId = Mainloop.timeout_add(100, Lang.bind(this, this._removeBarrier));
+                })
             });
         }
     },
@@ -388,9 +451,66 @@ dockedDash.prototype = {
                 onOverwrite : Lang.bind(this, function() {this._animStatus.clear();}),
                 onComplete: Lang.bind(this, function() {
                     this._animStatus.end();
-                    })
+                    this._updateBarrier();
+                })
             });
         }
+    },
+
+    // handler for mouse pressure sensed (GS38+ only)
+    _onPressureSensed: function() {
+        this._pressureSensed = true;
+        // NOTE: We could have called this._hoverChanged() instead but hover processing not required.
+        if(this._settings.get_boolean('autohide') && this._autohideStatus){
+            this._show();
+        }
+    },
+
+    // Remove pressure barrier (GS38+ only)
+    _removeBarrier: function() {
+        if (this._barrier) {
+            if (this._pressureBarrier) {
+                this._pressureBarrier.removeBarrier(this._barrier);
+            }
+            this._barrier.destroy();
+            this._barrier = null;
+        }
+    },
+
+    // Update pressure barrier size (GS38+ only)
+    _updateBarrier: function() {
+        // Remove existing barrier
+        this._removeBarrier();
+
+        // Manually reset pressure barrier
+        // This is necessary because we remove the pressure barrier when it is triggered to show the dock
+        if (this._pressureBarrier) {
+            this._pressureBarrier._reset();
+            this._pressureBarrier._isTriggered = false;
+        }
+
+        // Create new barrier
+        // Note: dock in fixed position doesn't use pressure barrier
+        if (this._canUsePressure && this._settings.get_boolean('autohide') && this._settings.get_boolean('require-pressure-to-show') && !this._settings.get_boolean('dock-fixed')) {
+            let x, direction;
+            if (this._rtl) {
+                x = this._monitor.x + this._monitor.width;
+                direction = Meta.BarrierDirection.NEGATIVE_X;
+            } else {
+                x = this._monitor.x;
+                direction = Meta.BarrierDirection.POSITIVE_X;
+            }
+            this._barrier = new Meta.Barrier({display: global.display,
+                                x1: x, x2: x,
+                                y1: (this.staticBox.y1), y2: (this.staticBox.y2),
+                                directions: direction});
+            if (this._pressureBarrier) {
+                this._pressureBarrier.addBarrier(this._barrier);
+            }
+        }
+
+        // Reset pressureSensed flag
+        this._pressureSensed = false;
     },
 
     // clip the dock to the current monitor;

--- a/prefs.js
+++ b/prefs.js
@@ -125,7 +125,7 @@ const WorkspaceSettingsWidget = new GObject.Class({
 
     this.settings.bind('dock-fixed', dockSettingsMain1, 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN);
 
-    let intellihideSubSettings = new Gtk.Box({margin_left:10, margin_top:10, margin_bottom:10, margin_right:10});
+    let intellihideSubSettings = new Gtk.Box({margin_left:10, margin_top:10, margin_bottom:0, margin_right:10});
     indentWidget(intellihideSubSettings);
 
     let perappIntellihide =  new Gtk.CheckButton({label: _("Application based intellihide")});
@@ -136,9 +136,61 @@ const WorkspaceSettingsWidget = new GObject.Class({
 
     intellihideSubSettings.add(perappIntellihide);
 
+
+    /* PRESSURE SETTINGS */
+
+    let requirePressureControl = new Gtk.Box({margin_left:10, margin_top:0, margin_bottom:0, margin_right:10});
+    let requirePressureContainer = new Gtk.Box({margin_left:10, margin_top:0, margin_bottom:10, margin_right:10});
+    indentWidget(requirePressureControl);
+    indentWidget(requirePressureContainer);
+
+
+    let requirePressureButton = new Gtk.CheckButton({
+        label: _("Require pressure to show the dock (GS3.8+)"),
+        margin_left: 0,
+        margin_top: 0
+    });
+    requirePressureButton.set_active(this.settings.get_boolean('require-pressure-to-show'));
+    requirePressureButton.connect('toggled', Lang.bind(this, function(check) {
+        this.settings.set_boolean('require-pressure-to-show', check.get_active());
+    }));
+
+    let pressureThresholdLabel = new Gtk.Label({
+        label: _("Pressure threshold [px] (GS3.8+)"),
+        use_markup: true,
+        xalign: 0,
+        margin_top: 0,
+        hexpand: true
+    });
+
+    let pressureThresholdSpinner = new Gtk.SpinButton({
+        halign: Gtk.Align.END,
+        margin_top: 0
+    });
+    pressureThresholdSpinner.set_sensitive(true);
+    pressureThresholdSpinner.set_range(10, 500);
+    pressureThresholdSpinner.set_value(this.settings.get_double("pressure-threshold") * 1);
+    pressureThresholdSpinner.set_increments(10, 20);
+    pressureThresholdSpinner.connect("value-changed", Lang.bind(this, function(button) {
+        let s = button.get_value_as_int() / 1;
+        this.settings.set_double("pressure-threshold", s);
+    }));
+
+    requirePressureControl.add(requirePressureButton);
+    requirePressureContainer.add(pressureThresholdLabel);
+    requirePressureContainer.add(pressureThresholdSpinner);
+
+    this.settings.bind('require-pressure-to-show', pressureThresholdLabel, 'sensitive', Gio.SettingsBindFlags.DEFAULT);
+    this.settings.bind('require-pressure-to-show', pressureThresholdSpinner, 'sensitive', Gio.SettingsBindFlags.DEFAULT);
+
+
+
     this.settings.bind('dock-fixed', intellihideSubSettings, 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN);
     this.settings.bind('dock-fixed', perappIntellihide, 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN);
     this.settings.bind('intellihide', intellihideSubSettings, 'sensitive', Gio.SettingsBindFlags.DEFAULT);
+    this.settings.bind('autohide', requirePressureControl, 'sensitive', Gio.SettingsBindFlags.DEFAULT);
+    this.settings.bind('autohide', requirePressureContainer, 'sensitive', Gio.SettingsBindFlags.DEFAULT);
+
 
     /* POISITION AND SIZE */
 
@@ -210,6 +262,9 @@ const WorkspaceSettingsWidget = new GObject.Class({
     dockSettings.add(dockSettingsControl1);
     dockSettings.add(dockSettingsMain1);
     dockSettings.add(intellihideSubSettings);
+    dockSettings.add(requirePressureControl);
+    dockSettings.add(requirePressureContainer);
+
     dockSettings.add(dockMonitor);
     dockSettings.add(dockSettingsMain2);
 

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -52,6 +52,16 @@
       <summary>Dock shown on mouse over</summary>
       <description>Enable or disable autohide mode</description>
     </key>
+    <key type="b" name="require-pressure-to-show">
+      <default>false</default>
+      <summary>Require pressure to show dock (GS38+ only)</summary>
+      <description>Enable or disable requiring pressure to show the dock (GS38+ only)</description>
+    </key>
+    <key type="d" name="pressure-threshold">
+      <default>20</default>
+      <summary>Pressure threshold</summary>
+      <description>Sets how much pressure is needed to show the dock.</description>
+    </key>
     <key type="b" name="dock-fixed">
       <default>false</default>
       <summary>Dock always visible</summary>


### PR DESCRIPTION
FEATURE BRANCH - experimental_pressure

Hi Michele,

I've added a pressure sensitivity feature that incorporates GS 3.8 pressure barriers to sense for mouse pressure against the left edge of the screen (right edge in RTL) the dock is positioned on. This option not only helps eliminate accidentally triggering the dock, but also makes the dock more accessible in dual monitor configurations where the secondary monitor is to the left of the dock .. especially when intellihide is turned off. Of course, this feature requires Gnome Shell 3.8+ and an XServer installation that implements pressure barriers.

NOTE:
In such cases where the secondary monitor is to the left of the dock, the dock will have to be showing before the pressure barrier is removed and the mouse pointer released to access the secondary monitor. This will create a slight hesitation as the mouse must wait for the dock to show. To elliminate this issue, you may show the dock by entering Gnome Shell's overview mode prior to attempting to access the secondary monitor.

While I plan to do more thorough testing, I've sent a pull request because I thought you might be interested in looking through the code. Let me know if you think this feature would be useful.
