### PR TITLE
Hot-Key (WinKey/Super) support for application launching, switching, etc

### DIFF
--- a/dockedDash.js
+++ b/dockedDash.js
@@ -26,6 +26,7 @@ function dockedDash(settings) {
 }
 
 dockedDash.prototype = {
+    _numHotkeys: 10,
  
     _init: function(settings) {
 
@@ -178,11 +179,11 @@ dockedDash.prototype = {
 
         // Load optional features
         this._optionalScrollWorkspaceSwitch();
-
+        this._hotKeysEnabled = false;
+        this._optionalHotKeys();
     },
 
     _initialize: function(){
-
         if(this._realizeId>0){
             this.actor.disconnect(this._realizeId);
             this._realizeId=0;
@@ -219,6 +220,8 @@ dockedDash.prototype = {
         // Reshow normal dash previously hidden, restore panel position if changed.
         Main.overview._controls._dashSlider.actor.show();
         this._revertMainPanel();
+        
+        this._disableHotKeys();
     },
 
     _bindSettingsChanges: function() {
@@ -231,6 +234,10 @@ dockedDash.prototype = {
 
         this._settings.connect('changed::scroll-switch-workspace', Lang.bind(this, function(){
             this._optionalScrollWorkspaceSwitch(this._settings.get_boolean('scroll-switch-workspace'));
+        }));
+        
+        this._settings.connect('changed::hot-keys', Lang.bind(this, function() {
+            this._optionalHotKeys(this._settings.get_boolean('hot-keys'));
         }));
 
         this._settings.connect('changed::dash-max-icon-size', Lang.bind(this, function(){
@@ -279,6 +286,23 @@ dockedDash.prototype = {
             } else {
                 this._hide();
             }
+        }
+    },
+    
+    _activateApp: function(appIndex, modifier) {
+        let children = this.dash._box.get_children().filter(function(actor) {
+                return actor.child &&
+                       actor.child._delegate &&
+                       actor.child._delegate.app;
+            });
+        
+        // Apps currently in the dash
+        let apps = children.map(function(actor) {
+                return actor.child._delegate;
+            });
+        
+        if (appIndex < apps.length) {
+            apps[appIndex]._onActivate({ get_state: function() { return modifier; }, get_click_count: function() { return 1; }, simulated_hotkey_events: true });
         }
     },
 
@@ -826,6 +850,53 @@ dockedDash.prototype = {
             }
         }
 
+    },
+    
+    _optionalHotKeys: function() {
+        if(this._settings.get_boolean('hot-keys'))
+            this._enableHotKeys();
+        else
+            this._disableHotKeys();
+    },
+    
+    _enableHotKeys: function() {
+        if (this._hotKeysEnabled) {
+            return;
+        }
+        
+        // Setup keyboard bindings for dash elements
+        
+        for (let i = 0; i < this._numHotkeys; i++) {
+            let appNum = i;
+            Main.wm.addKeybinding('app-hotkey-' + (i + 1), this._settings, Meta.KeyBindingFlags.NONE, Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY, Lang.bind(this, function() {
+                this._activateApp(appNum, 0);
+            }));
+            
+            Main.wm.addKeybinding('app-shift-hotkey-' + (i + 1), this._settings, Meta.KeyBindingFlags.NONE, Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY, Lang.bind(this, function() {
+                this._activateApp(appNum, Clutter.ModifierType.SHIFT_MASK);
+            }));
+            
+            Main.wm.addKeybinding('app-ctrl-hotkey-' + (i + 1), this._settings, Meta.KeyBindingFlags.NONE, Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY, Lang.bind(this, function() {
+                this._activateApp(appNum, Clutter.ModifierType.CONTROL_MASK);
+            }));
+        }
+        
+        this._hotKeysEnabled = true;
+    },
+    
+    _disableHotKeys: function() {
+        if (!this._hotKeysEnabled) {
+            return;
+        }
+        
+        // Remove keyboard bindings for dash elements
+        for (let i = 0; i < this._numHotkeys; i++) {
+            Main.wm.removeKeybinding('app-hotkey-' + (i + 1));
+            Main.wm.removeKeybinding('app-shift-hotkey-' + (i + 1));
+            Main.wm.removeKeybinding('app-ctrl-hotkey-' + (i + 1));
+        }
+        
+        this._hotKeysEnabled = false;
     },
 
     // Disable autohide effect, thus show dash

--- a/metadata.json
+++ b/metadata.json
@@ -6,5 +6,5 @@
 "original-author": "micxgx@gmail.com",
 "url": "http://micheleg.github.io/dash-to-dock/‎",
 "gettext-domain": "dashtodock",
-"version": 40
+"version": 0
 }

--- a/metadata.json
+++ b/metadata.json
@@ -6,5 +6,5 @@
 "original-author": "micxgx@gmail.com",
 "url": "http://micheleg.github.io/dash-to-dock/‎",
 "gettext-domain": "dashtodock",
-"version": 0
+"version": 40
 }

--- a/myDash.js
+++ b/myDash.js
@@ -857,7 +857,7 @@ const myAppIcon = new Lang.Class({
 
     _onActivate: function(event) {
 
-        if ( !this._settings.get_boolean('customize-click') ){
+        if ( !this._settings.get_boolean('customize-click') && !event.simulated_hotkey_events ){
             this.parent(event);
             return;
         }

--- a/prefs.js
+++ b/prefs.js
@@ -268,9 +268,16 @@ const WorkspaceSettingsWidget = new GObject.Class({
             this.settings.set_boolean('show-apps-at-top', check.get_active());
         }));
 
+    let allowHotKeys = new Gtk.CheckButton({label: _("Use Super+(0-9) to switch applications")});
+        allowHotKeys.set_active(this.settings.get_boolean('hot-keys'));
+        allowHotKeys.connect('toggled', Lang.bind(this, function(check){
+            this.settings.set_boolean('hot-keys', check.get_active());
+        }));
+
     showIcons.add(showFavorites);
     showIcons.add(showRunning);
     showIcons.add(showAppsAtTop);
+    showIcons.add(allowHotKeys);
     
     dockSettings.add(showIcons);
 

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -120,6 +120,11 @@
       <summary>Customize click behaviour</summary>
       <description>Custmize action on various mouse events</description>
     </key>
+    <key type="b" name="hot-keys">
+      <default>true</default>
+      <summary>Super Hot-Keys</summary>
+      <description>Launch and switch between dash items using Super+(0-9)</description>
+    </key>
     <key type="b" name="minimize-shift">
       <default>true</default>
       <summary>Minimize on shift+click</summary>
@@ -132,6 +137,216 @@
       <default>'cycle-windows'</default>
       <summary>Action when clicking on a running app</summary>
       <description>Set the action that is executed when clicking on the icon of a running application</description>
+    </key>
+    <key name="app-shift-hotkey-1" type="as">
+      <default><![CDATA[['<Shift><Super>1']]]></default>
+      <summary>Keybinding to trigger 1st with shift behavior</summary>
+      <description>
+        Keybinding to trigger 1st app with shift behavior.
+      </description>
+    </key>
+   <key name="app-shift-hotkey-2" type="as">
+      <default><![CDATA[['<Shift><Super>2']]]></default>
+      <summary>Keybinding to trigger 2nd with shift behavior</summary>
+      <description>
+        Keybinding to trigger 2nd app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-3" type="as">
+      <default><![CDATA[['<Shift><Super>3']]]></default>
+      <summary>Keybinding to trigger 3rd with shift behavior</summary>
+      <description>
+        Keybinding to trigger 3rd app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-4" type="as">
+      <default><![CDATA[['<Shift><Super>4']]]></default>
+      <summary>Keybinding to trigger 4th with shift behavior</summary>
+      <description>
+        Keybinding to trigger 4th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-5" type="as">
+      <default><![CDATA[['<Shift><Super>5']]]></default>
+      <summary>Keybinding to trigger 5th with shift behavior</summary>
+      <description>
+        Keybinding to trigger 5th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-6" type="as">
+      <default><![CDATA[['<Shift><Super>6']]]></default>
+      <summary>Keybinding to trigger 6th with shift behavior</summary>
+      <description>
+        Keybinding to trigger 1st app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-7" type="as">
+      <default><![CDATA[['<Shift><Super>7']]]></default>
+      <summary>Keybinding to trigger 7th with shift behavior</summary>
+      <description>
+        Keybinding to trigger 7th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-8" type="as">
+      <default><![CDATA[['<Shift><Super>1']]]></default>
+      <summary>Keybinding to trigger 8th with shift behavior</summary>
+      <description>
+        Keybinding to trigger 8th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-9" type="as">
+      <default><![CDATA[['<Shift><Super>9']]]></default>
+      <summary>Keybinding to trigger 9th with shift behavior</summary>
+      <description>
+        Keybinding to trigger 9th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-10" type="as">
+      <default><![CDATA[['<Shift><Super>0']]]></default>
+      <summary>Keybinding to trigger 10th with shift behavior</summary>
+      <description>
+        Keybinding to trigger 10th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-1" type="as">
+      <default><![CDATA[['<Ctrl><Super>1']]]></default>
+      <summary>Keybinding to launch 1st dash app</summary>
+      <description>
+        Keybinding to launch the 1st application in the dash.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-2" type="as">
+      <default><![CDATA[['<Ctrl><Super>2']]]></default>
+      <summary>Keybinding to launch 2nd dash app</summary>
+      <description>
+        Keybinding to launch the 2nd application in the dash.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-3" type="as">
+      <default><![CDATA[['<Ctrl><Super>3']]]></default>
+      <summary>Keybinding to launch 3rd dash app</summary>
+      <description>
+        Keybinding to launch the 3rd application in the dash.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-4" type="as">
+      <default><![CDATA[['<Ctrl><Super>4']]]></default>
+      <summary>Keybinding to launch 4th dash app</summary>
+      <description>
+        Keybinding to launch the 4th application in the dash.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-5" type="as">
+      <default><![CDATA[['<Ctrl><Super>5']]]></default>
+      <summary>Keybinding to launch 5th dash app</summary>
+      <description>
+        Keybinding to launch the 5th application in the dash.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-6" type="as">
+      <default><![CDATA[['<Ctrl><Super>6']]]></default>
+      <summary>Keybinding to launch 6th dash app</summary>
+      <description>
+        Keybinding to launch the 6th application in the dash.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-7" type="as">
+      <default><![CDATA[['<Ctrl><Super>7']]]></default>
+      <summary>Keybinding to launch 7th dash app</summary>
+      <description>
+        Keybinding to launch the 7th application in the dash.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-8" type="as">
+      <default><![CDATA[['<Ctrl><Super>8']]]></default>
+      <summary>Keybinding to launch 8th dash app</summary>
+      <description>
+        Keybinding to launch the 8th application in the dash.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-9" type="as">
+      <default><![CDATA[['<Ctrl><Super>9']]]></default>
+      <summary>Keybinding to launch 9th dash app</summary>
+      <description>
+        Keybinding to launch the 9th application in the dash.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-10" type="as">
+      <default><![CDATA[['<Ctrl><Super>0']]]></default>
+      <summary>Keybinding to launch 10th dash app</summary>
+      <description>
+        Keybinding to launch the 10th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-1" type="as">
+      <default><![CDATA[['<Super>1']]]></default>
+      <summary>Keybinding to trigger 1st dash app</summary>
+      <description>
+        Keybinding to either show or launch the 1st application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-2" type="as">
+      <default><![CDATA[['<Super>2']]]></default>
+      <summary>Keybinding to trigger 2nd dash app</summary>
+      <description>
+        Keybinding to either show or launch the 2nd application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-3" type="as">
+      <default><![CDATA[['<Super>3']]]></default>
+      <summary>Keybinding to trigger 3rd dash app</summary>
+      <description>
+        Keybinding to either show or launch the 3rd application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-4" type="as">
+      <default><![CDATA[['<Super>4']]]></default>
+      <summary>Keybinding to trigger 4th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 4th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-5" type="as">
+      <default><![CDATA[['<Super>5']]]></default>
+      <summary>Keybinding to trigger 5th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 5th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-6" type="as">
+      <default><![CDATA[['<Super>6']]]></default>
+      <summary>Keybinding to trigger 6th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 6th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-7" type="as">
+      <default><![CDATA[['<Super>7']]]></default>
+      <summary>Keybinding to trigger 7th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 7th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-8" type="as">
+      <default><![CDATA[['<Super>8']]]></default>
+      <summary>Keybinding to trigger 1st dash app</summary>
+      <description>
+        Keybinding to either show or launch the 8th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-9" type="as">
+      <default><![CDATA[['<Super>9']]]></default>
+      <summary>Keybinding to trigger 1st dash app</summary>
+      <description>
+        Keybinding to either show or launch the 9th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-10" type="as">
+      <default><![CDATA[['<Super>0']]]></default>
+      <summary>Keybinding to trigger 10th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 10th application in the dash.
+      </description>
     </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
I've added support for the "Super" key.  Pressing Super+1 switches to (or launches) the first program on the dash, Shift+Super+1 performs the custom shift action when available, and Ctrl+Super+1 always launches a new copy of the program.  This works for Super+1 -> Super+0 going down the dash, much like the similar keyboard shortcuts on Win7.

This is the first time I've worked on a Gnome extension before, so let me know if there are any corrections you would like me to make.