### PR TITLE
Added a new feature to the expand option. Its now possible to choose if ...

### DIFF
--- a/dockedDash.js
+++ b/dockedDash.js
@@ -265,6 +265,7 @@ dockedDash.prototype = {
         this._settings.connect('changed::autohide', Lang.bind(this, function(){
             this.emit('box-changed');
         }));
+        this._settings.connect('changed::shift-panel', Lang.bind(this, this._updateYPosition));
         this._settings.connect('changed::extend-height', Lang.bind(this, this._updateYPosition));
         this._settings.connect('changed::preferred-monitor', Lang.bind(this,this._resetPosition));
         this._settings.connect('changed::height-fraction', Lang.bind(this,this._updateYPosition));
@@ -512,12 +513,14 @@ dockedDash.prototype = {
         let unavailableTopSpace = 0;
         let unavailableBottomSpace = 0;
 
+        let shiftPanel = this._settings.get_boolean('shift-panel');
         let extendHeight = this._settings.get_boolean('extend-height');
         let dockFixed = this._settings.get_boolean('dock-fixed');
 
         // check if the dock is on the primary monitor
         if (this._isPrimaryMonitor()){
-            if (!extendHeight || !dockFixed) {
+            // removed dockfixed, makes no sense in my eyes
+            if(!shiftPanel && extendHeight){
                 unavailableTopSpace = Main.panel.actor.height;
             }
         }
@@ -548,19 +551,35 @@ dockedDash.prototype = {
 
     // Shift panel position to extend the dash to the full monitor height
     _updateMainPanel: function() {
+        let shiftPanel = this._settings.get_boolean('shift-panel');
         let extendHeight = this._settings.get_boolean('extend-height');
         let dockFixed = this._settings.get_boolean('dock-fixed');
+        
         let panelActor = Main.panel.actor;
+        let trayActor = Main.messageTray.actor;
 
-        if (this._isPrimaryMonitor() && extendHeight && dockFixed) {
-            panelActor.set_width(this._monitor.width - this._box.width);
+        if (this._isPrimaryMonitor() && extendHeight) {
+            if (shiftPanel) {
+                panelActor.set_width(this._monitor.width - this._box.width);
+                if (this._rtl) {
+                    panelActor.set_margin_right(this._box.width - 1);
+                } else {
+                    panelActor.set_margin_left(this._box.width - 1);
+                }
+            }else{
+                this._revertMainPanel();
+            }
+
+            // changes the width of the message tray, to prevent an overlay
+            trayActor.set_width(this._monitor.width - this._box.width);
             if (this._rtl) {
-                panelActor.set_margin_right(this._box.width - 1);
+                trayActor.set_margin_right(this._box.width - 1);
             } else {
-                panelActor.set_margin_left(this._box.width - 1);
+                trayActor.set_margin_left(this._box.width - 1);
             }
         } else {
             this._revertMainPanel();
+            this._revertMessageTray();
         }
     },
 
@@ -569,6 +588,13 @@ dockedDash.prototype = {
         panelActor.set_width(this._monitor.width);
         panelActor.set_margin_right(0);
         panelActor.set_margin_left(0);
+    },
+
+    _revertMessageTray: function() {
+        let trayActor = Main.messageTray.actor;
+        trayActor.set_width(this._monitor.width);
+        trayActor.set_margin_right(0);
+        trayActor.set_margin_left(0);
     },
 
     _updateStaticBox: function() {

--- a/prefs.js
+++ b/prefs.js
@@ -192,16 +192,27 @@ const WorkspaceSettingsWidget = new GObject.Class({
         }));
 
         dockMaxHeight.connect('format-value', function(scale, value) {return value + '%'});
-    let extendHeight =  new Gtk.CheckButton({label: _("Expand (experimental and buggy)")});
+
+    let extendHeight =  new Gtk.CheckButton({label: _("Expand\n(experimental and buggy)")});
         extendHeight.set_active(this.settings.get_boolean('extend-height'));
         extendHeight.connect('toggled', Lang.bind(this, function(check){
             this.settings.set_boolean('extend-height', check.get_active());
         }));
 
+    // setting for shifting the main panel (true means the panel is shifted)
+    let shiftPanel = new Gtk.CheckButton({label: _("Shift Panel")});
+        shiftPanel.set_active(this.settings.get_boolean('shift-panel'));
+        shiftPanel.connect('toggled', Lang.bind(this, function(check){
+            this.settings.set_boolean('shift-panel', check.get_active());
+        }));
+
     dockHeightMain.add(dockMaxHeightLabel);
     dockHeightMain.add(dockMaxHeight);
     dockHeightMain.add(extendHeight);
+    dockHeightMain.add(shiftPanel);
 
+    // extend-height must be activated
+    this.settings.bind('extend-height', shiftPanel, 'sensitive', Gio.SettingsBindFlags.DEFAULT);
     this.settings.bind('extend-height', dockMaxHeightLabel, 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN);
     this.settings.bind('extend-height', dockMaxHeight, 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN);
 

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -110,6 +110,10 @@
       <default>false</default>
       <summary>Extend the dock container to all the available height</summary>
     </key>
+    <key type="b" name="shift-panel">
+      <default>false</default>
+      <summary>Sets if the extended dock should move the main panel</summary>
+    </key>
     <key type="i" name="preferred-monitor">
       <default>-1</default>
       <summary>Monitor on which putting the dock</summary>


### PR DESCRIPTION
...the top (main) panel is shifted or not and the the message tray no longer collides with the dock.

Made this addition because I like the way the dock presents itself expended, but hated the way it shifted that top bar (margin). With this changes the user can change that behaviour. Also the dock no longer collides with the message tray at the bottom by setting the margin on the tray if it's expended.

I hope this will help you making this extension even better! 
