### PR TITLE
Emit signals for when the dock is triggered to show or hide.

### DIFF
--- a/dockedDash.js
+++ b/dockedDash.js
@@ -302,6 +302,7 @@ const dockedDash = new Lang.Class({
                 delay = 0;
             }
 
+            this.emit("showing");
             this._animateIn(this._settings.get_double('animation-time'), delay);
         }
     },
@@ -333,6 +334,7 @@ const dockedDash = new Lang.Class({
                 delay = this._settings.get_double('hide-delay');
             }
 
+            this.emit("hiding");
             this._animateOut(this._settings.get_double('animation-time'), delay);
 
         }


### PR DESCRIPTION
Hi Michele,

Here's the pull request to emit signals for when the dock is triggered to show or hide.

Sorry for the delay, but I needed to do some testing to make sure things worked properly. BTW, I avoided placing the emit signals within the _animateIn & _animateOut functions because they are called directly from other functions like disableAutoHide, resetPosition, pageChanged, onAccessibilityFocus, etc).
