### PR TITLE
Fix issues related to using mouse pressure to trigger the dock.

### DIFF
--- a/dockedDash.js
+++ b/dockedDash.js
@@ -281,7 +281,7 @@ const dockedDash = new Lang.Class({
             [
                 global.screen,
                 'in-fullscreen-changed',
-                Lang.bind(this, this._updateBarrier)
+                Lang.bind(this, this._onFullscreenChanged)
             ]
         );
 
@@ -617,6 +617,11 @@ const dockedDash = new Lang.Class({
     _onMessageTrayHiding: function() {
         this._messageTrayShowing = false;
         this._updateBarrier();
+    },
+
+    _onFullscreenChanged: function() {
+        if (!this._slider.visible)
+            this._updateBarrier();
     },
 
     // Remove pressure barrier


### PR DESCRIPTION
In reference to issue #99, I went back and tested the dock in Gnome 3.4, 3.8.4, and 3.10.4. What I found is that the dock never activates with fullscreen apps. I don't know where I got the idea that the dock activated. I must be losing my mind:(

Now, in Gnome 3.12, the dock DOES activate and slide in, but is invisible (as if hidden behind the fullscreen app). The dock remains active and becomes visible after exiting fullscreen mode. The activation is due to the mouse pressure feature added in the 3.12 release. To fix this issue, I route things through the hoverChanged() function after the pressure barrier is triggered. This prevents the dock from accidentally activating and sliding in (even though it's not visible) with fullscreen apps.

A second issue raised by fullscreen apps relates to multi-monitor setups. The dock's pressure barrier prevents the mouse from accessing the 2nd monitor on the left when an app is fullscreen. To fix this issue, I call updateBarrier() when the global.screen 'in-fullscreen-changed' signal is detected. The updateBarrier() function now checks the slider's visible state to determine if we should remove the barrier or not.

A third issue to fix, although not as serious as the previous two, is to remove the pressure barrier when the messageTray is showing. There's no reason to prevent the mouse from accessing the 2nd monitor (in multi-monitor setups) when the message tray is shown.

Lastly, as a precaution, I initialize removeBarrierTimeoutId in _init() and remove it from the Mainloop (if it exists) in destroy(). Is this even necessary with Gnome Shell 3.12?

All four of these issues are addressed by this pull request.
