### PR TITLE
Fix issue with small gap between expanded dock and top panel

### DIFF
--- a/dockedDash.js
+++ b/dockedDash.js
@@ -875,8 +875,13 @@ const dockedDash = new Lang.Class({
         this.actor.move_anchor_point_from_gravity(anchor_point);
         this.actor.x = position;
 
-
-        this._updateYPosition();
+        // Normally updating position caused small gap between top panel and
+        // the dock, this small delay fixes the problem.
+        Mainloop.timeout_add(1,
+                Lang.bind(this, function(){
+                  this._updateYPosition();
+                  return false;
+                }));
     },
 
     _getMonitor: function(){


### PR DESCRIPTION
When using this extension I found a problem with expanded dock - it wasn't aligned to top panel:
![screenshot from 2014-11-11 19 36 43](https://cloud.githubusercontent.com/assets/477062/4998614/34ef16be-69da-11e4-911a-77c8861fa235.png)
Strangely, the gap was gone after resetting the expansion option. I figured out there must be some problem with timing. Unfortunately I know nothing about GTK (or any other desktop environment for that matter), but the delay in updating position seems to help with the issue. This was found through some trials and errors, there may be some cleaner way of fixing this, but I think it's beyond my current abilities.

I'll be happy to answer any questions.