### PR TITLE
an idea for embedding dash-to-dock in the top bar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Basic Makefile
 
-UUID = dash-to-dock@micxgx.gmail.com
+UUID = dash-to-topbar@nowhere.com
 BASE_MODULES = extension.js stylesheet.css metadata.json COPYING README.md
-EXTRA_MODULES = convenience.js dash.js docking.js appIcons.js windowPreview.js intellihide.js prefs.js theming.js utils.js Settings.ui
+EXTRA_MODULES = convenience.js dash.js docking.js appIcons.js windowPreview.js intellihide.js prefs.js theming.js utils.js Settings.ui moveClock.js disableHotCorner.js
 EXTRA_MEDIA = logo.svg glossy.svg
 TOLOCALIZE =  prefs.js appIcons.js
 MSGSRC = $(wildcard po/*.po)
@@ -14,7 +14,7 @@ else
 	SHARE_PREFIX = $(DESTDIR)/usr/share
 	INSTALLBASE = $(SHARE_PREFIX)/gnome-shell/extensions
 endif
-INSTALLNAME = dash-to-dock@micxgx.gmail.com
+INSTALLNAME = dash-to-topbar@nowhere.com
 
 # The command line passed variable VERSION is used to set the version string
 # in the metadata and in the generated zip-file. If no VERSION is passed, the

--- a/disableHotCorner.js
+++ b/disableHotCorner.js
@@ -1,0 +1,34 @@
+//original source: https://github.com/HROMANO/nohotcorner/blob/master/extension.js
+const Main = imports.ui.main;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Config = imports.misc.config;
+
+let _id;
+
+function _disable_hot_corners() {
+  // Disables all hot corners
+  Main.layoutManager.hotCorners.forEach(function(hot_corner) {
+    if (!hot_corner) {
+      return;
+    }
+
+    hot_corner._toggleOverview = function() {};
+    hot_corner._pressureBarrier._trigger = function() {};
+  });
+}
+
+function init() {
+}
+
+function enable() {
+  _disable_hot_corners();
+  // Hot corners may be re-created afterwards (for example, If there's a monitor change).
+  // So we catch all changes.
+  _id = Main.layoutManager.connect('hot-corners-changed', _disable_hot_corners);
+}
+
+function disable() {
+  // Disconnects the callback and re-creates the hot corners
+  Main.layoutManager.disconnect(_id);
+  Main.layoutManager._updateHotCorners();
+}

--- a/extension.js
+++ b/extension.js
@@ -2,6 +2,8 @@
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Docking = Me.imports.docking;
+const moveClock = Me.imports.moveClock;
+const disableHotCorner = Me.imports.disableHotCorner;
 const Convenience = Me.imports.convenience;
 
 let dockManager;
@@ -11,10 +13,14 @@ function init() {
 }
 
 function enable() {
+    moveClock.enable_clock_move();
+	disableHotCorner.enable();
     dockManager = new Docking.DockManager();
 }
 
 function disable() {
+	disableHotCorner.disable();
+    moveClock.disable_clock_move();
     dockManager.destroy();
 
     dockManager=null;

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,8 @@
 {
-"shell-version": ["3.18", "3.20", "3.22", "3.24", "3.26"],
-"uuid": "dash-to-dock@micxgx.gmail.com",
-"name": "Dash to Dock",
-"description": "A dock for the Gnome Shell. This extension moves the dash out of the overview transforming it in a dock for an easier launching of applications and a faster switching between windows and desktops. Side and bottom placement options are available.",
+"shell-version": ["3.18", "etc"],
+"uuid": "dash-to-topbar@nowhere.com",
+"name": "Dash to Topbar",
+"description": "A modification of dash-to-dock, to embed it in the top bar.... dash-to-dock is a dock for the Gnome Shell. This extension moves the dash out of the overview transforming it in a dock for an easier launching of applications and a faster switching between windows and desktops.",
 "original-author": "micxgx@gmail.com",
 "url": "https://micheleg.github.io/dash-to-dock/",
 "gettext-domain": "dashtodock",

--- a/moveClock.js
+++ b/moveClock.js
@@ -1,0 +1,48 @@
+/*-------------------- move clock -------------------*/
+const mSessionMode = imports.ui.sessionMode;
+const mMain = imports.ui.main;
+
+function enable_clock_move() {
+    let mode = mMain.sessionMode.currentMode;
+    let center = mSessionMode._modes[mode].panel.center;
+
+    // do nothing if the clock isn't centred in this mode
+    if ( center.indexOf('dateMenu') == -1 ) {
+        return;
+    }
+
+    let centerBox = mMain.panel._centerBox;
+    let rightBox = mMain.panel._rightBox;
+    let dateMenu = mMain.panel.statusArea['dateMenu'];
+    let children = centerBox.get_children();
+
+    // only move the clock if it's in the centre box
+    if ( children.indexOf(dateMenu.container) != -1 ) {
+        centerBox.remove_actor(dateMenu.container);
+
+        children = rightBox.get_children();
+        rightBox.insert_child_at_index(dateMenu.container, children.length-1);
+   }
+}
+
+function disable_clock_move() {
+    let mode = mMain.sessionMode.currentMode;
+    let center = mSessionMode._modes[mode].panel.center;
+
+    // do nothing if the clock isn't centred in this mode
+    if ( center.indexOf('dateMenu') == -1 ) {
+        return;
+    }
+
+    let centerBox = mMain.panel._centerBox;
+    let rightBox = mMain.panel._rightBox;
+    let dateMenu = mMain.panel.statusArea['dateMenu'];
+    let children = rightBox.get_children();
+
+    // only move the clock back if it's in the right box
+    if ( children.indexOf(dateMenu.container) != -1 ) {
+        rightBox.remove_actor(dateMenu.container);
+        centerBox.add_actor(dateMenu.container);
+    }
+}
+/*---------------------------------------*/


### PR DESCRIPTION
You may or may not have considered doing this already. I don't consider this complete. It is just something that works for me (not fully but good enough). 

I simply reoriented and re-parented the elements so that they are placed at the centre on the gnome-shell top-bar. I prefer this layout because it saves space and top-bar is closer to the regular window controls and tabs and title bar etc. So placing the dash there seems more space and movement efficient.
