### PR TITLE
Change wording

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -354,7 +354,7 @@ const WorkspaceSettingsWidget = new GObject.Class({
         showRunning.connect('toggled', Lang.bind(this, function(check){
             this.settings.set_boolean('show-running', check.get_active());
         }));
-    let showAppsAtTop =  new Gtk.CheckButton({label: _("Show applications button at the top")});
+    let showAppsAtTop =  new Gtk.CheckButton({label: _("Show applications button first")});
         showAppsAtTop.set_active(this.settings.get_boolean('show-apps-at-top'));
         showAppsAtTop.connect('toggled', Lang.bind(this, function(check){
             this.settings.set_boolean('show-apps-at-top', check.get_active());


### PR DESCRIPTION
The previous message makes sense if the dock is vertical, but not
when it's horizontal. The new message is clearer no matter what
the direction of the dock is.