### PR TITLE
Update intellihide.js for gnome shell 3.17

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -75,12 +75,7 @@ const intellihide = new Lang.Class({
             // direct maximize/unmazimize are not included in grab-operations
             [
                 global.window_manager,
-                'maximize', 
-                Lang.bind(this, this._checkOverlap )
-            ],
-            [
-                global.window_manager,
-                'unmaximize',
+                'size-change', 
                 Lang.bind(this, this._checkOverlap )
             ],
             // triggered for instance when the window list order changes,

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-"shell-version": ["3.16"],
+"shell-version": ["3.17"],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",
 "description": "A dock for the Gnome Shell. This extension moves the dash out of the overview transforming it in a dock for an easier launching of applications and a faster switching between windows and desktops. Side and bottom placement options are available.",


### PR DESCRIPTION
This should solve #202 but will likely break compatibility for 3.16 (and lower).