### PR TITLE
Fix restore default settings in intellihide mode

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -240,7 +240,7 @@ const Settings = new Lang.Class({
                 if (id == 1) {
                     // restore default settings for the relevant keys
                     let keys = ['intellihide', 'autohide', 'intellihide-mode', 'require-pressure-to-show',
-                                'animation-time', 'show-delay', 'hide-delay'];
+                                'animation-time', 'show-delay', 'hide-delay', 'pressure-threshold'];
                     keys.forEach(function(val){
                         this._settings.set_value(val, this._settings.get_default_value(val));
                     }, this);


### PR DESCRIPTION
This is a patch to allow restoring the `pressure-threshold` back to its default value.