### PR TITLE
Code style cleanup, support for window stealing, support for right-click for settings

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -937,6 +937,48 @@
                     </child>
                   </object>
                 </child>
+                <child>
+                  <object class="GtkListBoxRow" id="listboxrow18">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkGrid" id="shrink_dash4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkSwitch" id="support_window_stealing_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="shrink_dash_label4">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="xalign">0</property>
+                            <property name="label" translatable="yes">Support window stealing</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
             <child type="label_item">

--- a/convenience.js
+++ b/convenience.js
@@ -70,7 +70,9 @@ function getSettings(schema) {
         throw new Error('Schema ' + schema + ' could not be found for extension '
                         + extension.metadata.uuid + '. Please check your installation.');
 
-    return new Gio.Settings({ settings_schema: schemaObj });
+    return new Gio.Settings({
+        settings_schema: schemaObj
+    });
 }
 
 /**
@@ -84,11 +86,10 @@ const BasicHandler = new Lang.Class({
         this._storage = new Object();
     },
 
-    add: function(/*unlimited 3-long array arguments*/) {
-
-        // convert arguments object to array, concatenate with generic
+    add: function(/* unlimited 3-long array arguments */) {
+        // Convert arguments object to array, concatenate with generic
         let args = Array.concat('generic', Array.slice(arguments));
-        // call addWithLabel with ags as if they were passed arguments
+        // Call addWithLabel with ags as if they were passed arguments
         this.addWithLabel.apply(this, args);
     },
 
@@ -97,38 +98,39 @@ const BasicHandler = new Lang.Class({
             this.removeWithLabel(label);
     },
 
-    addWithLabel: function( label /* plus unlimited 3-long array arguments*/) {
-
-        if(this._storage[label] == undefined)
+    addWithLabel: function(label /* plus unlimited 3-long array arguments*/) {
+        if (this._storage[label] == undefined)
             this._storage[label] = new Array();
 
-        // skip first element of the arguments
-        for( let i = 1; i < arguments.length; i++ ) {
-            this._storage[label].push( this._create(arguments[i]) );
+        // Skip first element of the arguments
+        for (let i = 1; i < arguments.length; i++) {
+            this._storage[label].push( this._create(arguments[i]));
         }
-
     },
 
     removeWithLabel: function(label) {
-
-        if(this._storage[label]) {
-            for( let i = 0; i < this._storage[label].length; i++ ) {
+        if (this._storage[label]) {
+            for (let i = 0; i < this._storage[label].length; i++)
                 this._remove(this._storage[label][i]);
-            }
 
             delete this._storage[label];
         }
     },
 
-    /* Virtual methods to be implemented by subclass */
-    // create single element to be stored in the storage structure
+    // Virtual methods to be implemented by subclass
+
+    /**
+     * Create single element to be stored in the storage structure
+     */
     _create: function(item) {
-      throw new Error('no implementation of _create in ' + this);
+        throw new Error('no implementation of _create in ' + this);
     },
 
-    // correctly delete single element
+    /**
+     * Correctly delete single element
+     */
     _remove: function(item) {
-      throw new Error('no implementation of _remove in ' + this);
+        throw new Error('no implementation of _remove in ' + this);
     }
 });
 
@@ -140,17 +142,16 @@ const GlobalSignalsHandler = new Lang.Class({
     Extends: BasicHandler,
 
     _create: function(item) {
+        let object = item[0];
+        let event = item[1];
+        let callback = item[2]
+        let id = object.connect(event, callback);
 
-      let object = item[0];
-      let event = item[1];
-      let callback = item[2]
-      let id = object.connect(event, callback);
-
-      return [object, id];
+        return [object, id];
     },
 
     _remove: function(item) {
-       item[0].disconnect(item[1]);
+         item[0].disconnect(item[1]);
     }
 });
 
@@ -163,14 +164,13 @@ const InjectionsHandler = new Lang.Class({
     Extends: BasicHandler,
 
     _create: function(item) {
+        let object = item[0];
+        let name = item[1];
+        let injectedFunction = item[2];
+        let original = object[name];
 
-      let object = item[0];
-      let name = item[1];
-      let injectedFunction = item[2];
-      let original = object[name];
-
-      object[name] = injectedFunction;
-      return [object, name, injectedFunction, original];
+        object[name] = injectedFunction;
+        return [object, name, injectedFunction, original];
     },
 
     _remove: function(item) {

--- a/convenience.js
+++ b/convenience.js
@@ -3,17 +3,15 @@
 /*
  * Part of this file comes from gnome-shell-extensions:
  * http://git.gnome.org/browse/gnome-shell-extensions/
- * 
  */
-
 
 const Gettext = imports.gettext;
 const Gio = imports.gi.Gio;
+const Clutter = imports.gi.Clutter;
 const Lang = imports.lang;
 
 const Config = imports.misc.config;
 const ExtensionUtils = imports.misc.extensionUtils;
-
 
 /**
  * initTranslations:
@@ -27,7 +25,7 @@ function initTranslations(domain) {
 
     domain = domain || extension.metadata['gettext-domain'];
 
-    // check if this extension was built with "make zip-file", and thus
+    // Check if this extension was built with "make zip-file", and thus
     // has the locale files in a subfolder
     // otherwise assume that extension has been installed in the
     // same prefix as gnome-shell
@@ -53,7 +51,7 @@ function getSettings(schema) {
 
     const GioSSS = Gio.SettingsSchemaSource;
 
-    // check if this extension was built with "make zip-file", and thus
+    // Check if this extension was built with "make zip-file", and thus
     // has the schema files in a subfolder
     // otherwise assume that extension has been installed in the
     // same prefix as gnome-shell (and therefore schemas are available
@@ -75,16 +73,18 @@ function getSettings(schema) {
     return new Gio.Settings({ settings_schema: schemaObj });
 }
 
-// simplify global signals and function injections handling
-// abstract class
+/**
+ * Simplify global signals and function injections handling
+ * abstract class
+ */
 const BasicHandler = new Lang.Class({
-    Name: 'dashToDock.BasicHandler',
+    Name: 'DashToDock.BasicHandler',
 
-    _init: function(){
+    _init: function() {
         this._storage = new Object();
     },
 
-    add: function(/*unlimited 3-long array arguments*/){
+    add: function(/*unlimited 3-long array arguments*/) {
 
         // convert arguments object to array, concatenate with generic
         let args = Array.concat('generic', Array.slice(arguments));
@@ -109,7 +109,7 @@ const BasicHandler = new Lang.Class({
 
     },
 
-    removeWithLabel: function(label){
+    removeWithLabel: function(label) {
 
         if(this._storage[label]) {
             for( let i = 0; i < this._storage[label].length; i++ ) {
@@ -122,17 +122,19 @@ const BasicHandler = new Lang.Class({
 
     /* Virtual methods to be implemented by subclass */
     // create single element to be stored in the storage structure
-    _create: function(item){
+    _create: function(item) {
       throw new Error('no implementation of _create in ' + this);
     },
 
     // correctly delete single element
-    _remove: function(item){
+    _remove: function(item) {
       throw new Error('no implementation of _remove in ' + this);
     }
 });
 
-// Manage global signals
+/**
+ * Manage global signals
+ */
 const GlobalSignalsHandler = new Lang.Class({
     Name: 'DashToDock.GlobalSignalHandler',
     Extends: BasicHandler,
@@ -147,13 +149,15 @@ const GlobalSignalsHandler = new Lang.Class({
       return [object, id];
     },
 
-    _remove: function(item){
+    _remove: function(item) {
        item[0].disconnect(item[1]);
     }
 });
 
-// Manage function injection: both instances and prototype can be overridden
-// and restored
+/**
+ * Manage function injection: both instances and prototype can be overridden
+ * and restored
+ */
 const InjectionsHandler = new Lang.Class({
     Name: 'DashToDock.InjectionsHandler',
     Extends: BasicHandler,
@@ -176,3 +180,17 @@ const InjectionsHandler = new Lang.Class({
         object[name] = original;
     }
 });
+
+/**
+ * Return the actual position reverseing left and right in rtl
+ */
+function getPosition(settings) {
+    let position = settings.get_enum('dock-position');
+    if (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL) {
+        if (position == St.Side.LEFT)
+            position = St.Side.RIGHT;
+        else if (position == St.Side.RIGHT)
+            position = St.Side.LEFT;
+    }
+    return position;
+}

--- a/convenience.js
+++ b/convenience.js
@@ -6,12 +6,13 @@
  */
 
 const Gettext = imports.gettext;
-const Gio = imports.gi.Gio;
-const Clutter = imports.gi.Clutter;
 const Lang = imports.lang;
 
 const Config = imports.misc.config;
 const ExtensionUtils = imports.misc.extensionUtils;
+
+const Clutter = imports.gi.Clutter;
+const Gio = imports.gi.Gio;
 
 /**
  * initTranslations:

--- a/dash.js
+++ b/dash.js
@@ -1,26 +1,25 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
+const Lang = imports.lang;
+const Mainloop = imports.mainloop;
+const Signals = imports.signals;
+
 const Clutter = imports.gi.Clutter;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
-const Signals = imports.signals;
-const Lang = imports.lang;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
-const Mainloop = imports.mainloop;
 
-const AppDisplay = imports.ui.appDisplay;
 const AppFavorites = imports.ui.appFavorites;
 const Dash = imports.ui.dash;
 const DND = imports.ui.dnd;
-const IconGrid = imports.ui.iconGrid;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
 const Tweener = imports.ui.tweener;
+
 const Util = imports.misc.util;
-const Workspace = imports.ui.workspace;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
@@ -324,6 +323,8 @@ const MyDash = new Lang.Class({
             'item-drag-cancelled',
             Lang.bind(this, this._onDragCancelled)
         ]);
+        
+        this._windowStealingChangedId = this._dtdSettings.connect('changed::window-stealing', Lang.bind(this, this._redisplay));
     },
 
     destroy: function() {
@@ -702,8 +703,7 @@ const MyDash = new Lang.Class({
             // Don't animate the icon size change when the overview
             // is transitioning, or when initially filling
             // the dash
-            if (Main.overview.animationInProgress ||
-                !this._shownInitially)
+            if (Main.overview.animationInProgress || !this._shownInitially)
                 continue;
 
             let [targetWidth, targetHeight] = icon.icon.get_size();
@@ -713,12 +713,12 @@ const MyDash = new Lang.Class({
             icon.icon.set_size(icon.icon.width * scale,
                                icon.icon.height * scale);
 
-            Tweener.addTween(icon.icon,
-                             { width: targetWidth,
-                               height: targetHeight,
-                               time: DASH_ANIMATION_TIME,
-                               transition: 'easeOutQuad',
-                             });
+            Tweener.addTween(icon.icon, {
+                width: targetWidth,
+                height: targetHeight,
+                time: DASH_ANIMATION_TIME,
+                transition: 'easeOutQuad',
+             });
         }
     },
 

--- a/dash.js
+++ b/dash.js
@@ -324,6 +324,7 @@ const MyDash = new Lang.Class({
             Lang.bind(this, this._onDragCancelled)
         ]);
         
+        this._supportWindowStealingChangedId = this._dtdSettings.connect('changed::support-window-stealing', Lang.bind(this, this._redisplay));
         this._windowStealingChangedId = this._dtdSettings.connect('changed::window-stealing', Lang.bind(this, this._redisplay));
     },
 

--- a/dash.js
+++ b/dash.js
@@ -64,7 +64,7 @@ const MyDashActor = new Lang.Class({
                                (this._position == St.Side.BOTTOM));
 
         let layout = new Clutter.BoxLayout({
-            orientation: this._isHorizontal?Clutter.Orientation.HORIZONTAL:Clutter.Orientation.VERTICAL
+            orientation: this._isHorizontal ? Clutter.Orientation.HORIZONTAL : Clutter.Orientation.VERTICAL
         });
 
         this.actor = new Shell.GenericContainer({

--- a/docking.js
+++ b/docking.js
@@ -187,7 +187,7 @@ const DockedDash = new Lang.Class({
         this._rtl = (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL);
 
         // Load settings
-        this._settings = settings;
+        this._dtdSettings = settings;
         this._bindSettingsChanges();
 
         this._position = Convenience.getPosition(settings);
@@ -203,7 +203,7 @@ const DockedDash = new Lang.Class({
         this._fixedIsEnabled = null;
 
         // Create intellihide object to monitor windows overlapping
-        this._intellihide = new Intellihide.Intellihide(this._settings);
+        this._intellihide = new Intellihide.Intellihide(this._dtdSettings);
 
         // initialize dock state
         this._dockState = State.HIDDEN;
@@ -233,7 +233,7 @@ const DockedDash = new Lang.Class({
         this._dockDwellTimeoutId = 0
 
         // Create a new dash object
-        this.dash = new MyDash.MyDash(this._settings);
+        this.dash = new MyDash.MyDash(this._dtdSettings);
 
         // set stored icon size  to the new dash
         Main.overview.dashIconSize = this.dash.iconSize;
@@ -241,7 +241,7 @@ const DockedDash = new Lang.Class({
         // connect app icon into the view selector
         this.dash.showAppsButton.connect('notify::checked', Lang.bind(this, this._onShowAppsButtonToggled));
 
-        if (!this._settings.get_boolean('show-show-apps-button'))
+        if (!this._dtdSettings.get_boolean('show-show-apps-button'))
             this.dash.hideShowAppsButton();
 
         // Create the main actor and the containers for sliding in and out and
@@ -352,7 +352,7 @@ const DockedDash = new Lang.Class({
         ]);
 
         this._injectionsHandler = new Convenience.InjectionsHandler();
-        this._themeManager = new Theming.ThemeManager(this._settings, this.actor, this.dash);
+        this._themeManager = new Theming.ThemeManager(this._dtdSettings, this.actor, this.dash);
 
         // Since the actor is not a topLevel child and its parent is now not added to the Chrome,
         // the allocation change of the parent container (slide in and slideout) doesn't trigger
@@ -421,7 +421,7 @@ const DockedDash = new Lang.Class({
         // Keep the dash below the modalDialogGroup
         Main.layoutManager.uiGroup.set_child_below_sibling(this.actor,Main.layoutManager.modalDialogGroup);
 
-        if (this._settings.get_boolean('dock-fixed'))
+        if (this._dtdSettings.get_boolean('dock-fixed'))
             Main.layoutManager._trackActor(this._box, {affectsStruts: true, trackFullscreen: true});
 
         // pretend this._slider is isToplevel child so that fullscreen is actually tracked
@@ -438,7 +438,7 @@ const DockedDash = new Lang.Class({
             this._paintId=0;
         }
 
-        this.dash.setIconSize(this._settings.get_int('dash-max-icon-size'), true);
+        this.dash.setIconSize(this._dtdSettings.get_int('dash-max-icon-size'), true);
 
         // Apply custome css class according to the settings
         this._themeManager.updateCustomTheme();
@@ -508,40 +508,40 @@ const DockedDash = new Lang.Class({
     },
 
     _bindSettingsChanges: function() {
-        this._settings.connect('changed::scroll-switch-workspace', Lang.bind(this, function() {
-            this._optionalScrollWorkspaceSwitch(this._settings.get_boolean('scroll-switch-workspace'));
+        this._dtdSettings.connect('changed::scroll-switch-workspace', Lang.bind(this, function() {
+            this._optionalScrollWorkspaceSwitch(this._dtdSettings.get_boolean('scroll-switch-workspace'));
         }));
 
-        this._settings.connect('changed::dash-max-icon-size', Lang.bind(this, function() {
-            this.dash.setIconSize(this._settings.get_int('dash-max-icon-size'));
+        this._dtdSettings.connect('changed::dash-max-icon-size', Lang.bind(this, function() {
+            this.dash.setIconSize(this._dtdSettings.get_int('dash-max-icon-size'));
         }));
 
-        this._settings.connect('changed::icon-size-fixed', Lang.bind(this, function() {
-            this.dash.setIconSize(this._settings.get_int('dash-max-icon-size'));
+        this._dtdSettings.connect('changed::icon-size-fixed', Lang.bind(this, function() {
+            this.dash.setIconSize(this._dtdSettings.get_int('dash-max-icon-size'));
         }));
 
-        this._settings.connect('changed::show-favorites', Lang.bind(this, function() {
+        this._dtdSettings.connect('changed::show-favorites', Lang.bind(this, function() {
             this.dash.resetAppIcons();
         }));
 
-        this._settings.connect('changed::show-running', Lang.bind(this, function() {
+        this._dtdSettings.connect('changed::show-running', Lang.bind(this, function() {
             this.dash.resetAppIcons();
         }));
 
-        this._settings.connect('changed::show-apps-at-top', Lang.bind(this, function() {
+        this._dtdSettings.connect('changed::show-apps-at-top', Lang.bind(this, function() {
             this.dash.resetAppIcons();
         }));
 
-        this._settings.connect('changed::show-show-apps-button', Lang.bind(this, function() {
-            if (this._settings.get_boolean('show-show-apps-button'))
+        this._dtdSettings.connect('changed::show-show-apps-button', Lang.bind(this, function() {
+            if (this._dtdSettings.get_boolean('show-show-apps-button'))
                 this.dash.showShowAppsButton();
             else
                 this.dash.hideShowAppsButton();
         }));
 
-        this._settings.connect('changed::dock-fixed', Lang.bind(this, function() {
+        this._dtdSettings.connect('changed::dock-fixed', Lang.bind(this, function() {
 
-            if (this._settings.get_boolean('dock-fixed'))
+            if (this._dtdSettings.get_boolean('dock-fixed'))
                 Main.layoutManager._trackActor(this._box, {affectsStruts: true, trackFullscreen: true});
             else
                 Main.layoutManager._untrackActor(this._box);
@@ -554,20 +554,20 @@ const DockedDash = new Lang.Class({
             this._updateVisibilityMode();
         }));
 
-        this._settings.connect('changed::intellihide', Lang.bind(this, this._updateVisibilityMode));
+        this._dtdSettings.connect('changed::intellihide', Lang.bind(this, this._updateVisibilityMode));
 
-        this._settings.connect('changed::intellihide-mode', Lang.bind(this, function() {
+        this._dtdSettings.connect('changed::intellihide-mode', Lang.bind(this, function() {
             this._intellihide.forceUpdate();
         }));
 
-        this._settings.connect('changed::autohide', Lang.bind(this, function() {
+        this._dtdSettings.connect('changed::autohide', Lang.bind(this, function() {
             this._updateVisibilityMode();
             this._updateBarrier();
         }));
-        this._settings.connect('changed::extend-height', Lang.bind(this,this._resetPosition));
-        this._settings.connect('changed::preferred-monitor', Lang.bind(this,this._resetPosition));
-        this._settings.connect('changed::height-fraction', Lang.bind(this,this._resetPosition));
-        this._settings.connect('changed::require-pressure-to-show', Lang.bind(this,function() {
+        this._dtdSettings.connect('changed::extend-height', Lang.bind(this,this._resetPosition));
+        this._dtdSettings.connect('changed::preferred-monitor', Lang.bind(this,this._resetPosition));
+        this._dtdSettings.connect('changed::height-fraction', Lang.bind(this,this._resetPosition));
+        this._dtdSettings.connect('changed::require-pressure-to-show', Lang.bind(this,function() {
             // Remove pointer watcher
             if (this._dockWatch) {
                 PointerWatcher.getPointerWatcher()._removeWatch(this._dockWatch);
@@ -576,7 +576,7 @@ const DockedDash = new Lang.Class({
             this._setupDockDwellIfNeeded();
             this._updateBarrier();
         }));
-        this._settings.connect('changed::pressure-threshold', Lang.bind(this,function() {
+        this._dtdSettings.connect('changed::pressure-threshold', Lang.bind(this,function() {
             this._updatePressureBarrier();
             this._updateBarrier();
         }));
@@ -587,15 +587,15 @@ const DockedDash = new Lang.Class({
      * This is call when visibility settings change
      */
     _updateVisibilityMode: function() {
-        if (this._settings.get_boolean('dock-fixed')) {
+        if (this._dtdSettings.get_boolean('dock-fixed')) {
             this._fixedIsEnabled = true;
             this._autohideIsEnabled = false;
             this._intellihideIsEnabled = false;
         }
         else {
             this._fixedIsEnabled = false;
-            this._autohideIsEnabled = this._settings.get_boolean('autohide')
-            this._intellihideIsEnabled = this._settings.get_boolean('intellihide')
+            this._autohideIsEnabled = this._dtdSettings.get_boolean('autohide')
+            this._intellihideIsEnabled = this._dtdSettings.get_boolean('intellihide')
         }
 
         if (this._intellihideIsEnabled)
@@ -620,19 +620,19 @@ const DockedDash = new Lang.Class({
 
         if (this._fixedIsEnabled) {
             this._removeAnimations();
-            this._animateIn(this._settings.get_double('animation-time'), 0);
+            this._animateIn(this._dtdSettings.get_double('animation-time'), 0);
         }
         else if (this._intellihideIsEnabled) {
             if (this._intellihide.getOverlapStatus()) {
                 this._ignoreHover = false;
                 // Do not hide if autohide is enabled and mouse is hover
                 if (!this._box.hover || !this._autohideIsEnabled)
-                    this._animateOut(this._settings.get_double('animation-time'), 0);
+                    this._animateOut(this._dtdSettings.get_double('animation-time'), 0);
             }
             else {
                 this._ignoreHover = true;
                 this._removeAnimations();
-                this._animateIn(this._settings.get_double('animation-time'), 0);
+                this._animateIn(this._dtdSettings.get_double('animation-time'), 0);
             }
         }
         else {
@@ -641,12 +641,12 @@ const DockedDash = new Lang.Class({
                 global.sync_pointer();
 
                 if (this._box.hover)
-                    this._animateIn(this._settings.get_double('animation-time'), 0);
+                    this._animateIn(this._dtdSettings.get_double('animation-time'), 0);
                 else
-                    this._animateOut(this._settings.get_double('animation-time'), 0);
+                    this._animateOut(this._dtdSettings.get_double('animation-time'), 0);
             }
             else
-                this._animateOut(this._settings.get_double('animation-time'), 0);
+                this._animateOut(this._dtdSettings.get_double('animation-time'), 0);
         }
     },
 
@@ -654,7 +654,7 @@ const DockedDash = new Lang.Class({
         this._ignoreHover = true;
         this._intellihide.disable();
         this._removeAnimations();
-        this._animateIn(this._settings.get_double('animation-time'), 0);
+        this._animateIn(this._dtdSettings.get_double('animation-time'), 0);
     },
 
     _onOverviewHiding: function() {
@@ -684,7 +684,7 @@ const DockedDash = new Lang.Class({
                 this._removeAnimations();
 
             this.emit('showing');
-            this._animateIn(this._settings.get_double('animation-time'), 0);
+            this._animateIn(this._dtdSettings.get_double('animation-time'), 0);
         }
     },
 
@@ -697,12 +697,12 @@ const DockedDash = new Lang.Class({
                 //if a show already started, let it finish; queue hide without removing the show.
                 // to obtain this I increase the delay to avoid the overlap and interference
                 // between the animations
-                delay = this._settings.get_double('hide-delay') + this._settings.get_double('animation-time');
+                delay = this._dtdSettings.get_double('hide-delay') + this._dtdSettings.get_double('animation-time');
             else
-                delay = this._settings.get_double('hide-delay');
+                delay = this._dtdSettings.get_double('hide-delay');
 
             this.emit('hiding');
-            this._animateOut(this._settings.get_double('animation-time'), delay);
+            this._animateOut(this._dtdSettings.get_double('animation-time'), delay);
         }
     },
 
@@ -746,7 +746,7 @@ const DockedDash = new Lang.Class({
     _setupDockDwellIfNeeded: function() {
         // If we don't have extended barrier features, then we need
         // to support the old tray dwelling mechanism.
-        if (!global.display.supports_extended_barriers() || !this._settings.get_boolean('require-pressure-to-show')) {
+        if (!global.display.supports_extended_barriers() || !this._dtdSettings.get_boolean('require-pressure-to-show')) {
             let pointerWatcher = PointerWatcher.getPointerWatcher();
             this._dockWatch = pointerWatcher.addWatch(DOCK_DWELL_CHECK_INTERVAL, Lang.bind(this, this._checkDockDwell));
             this._dockDwelling = false;
@@ -783,7 +783,7 @@ const DockedDash = new Lang.Class({
                 let focusWindow = global.display.focus_window;
                 this._dockDwellUserTime = focusWindow ? focusWindow.user_time : 0;
 
-                this._dockDwellTimeoutId = Mainloop.timeout_add(this._settings.get_double('show-delay') * 1000,
+                this._dockDwellTimeoutId = Mainloop.timeout_add(this._dtdSettings.get_double('show-delay') * 1000,
                                                                 Lang.bind(this, this._dockDwellTimeout));
                 GLib.Source.set_name_by_id(this._dockDwellTimeoutId, '[dash-to-dock] this._dockDwellTimeout');
             }
@@ -805,7 +805,7 @@ const DockedDash = new Lang.Class({
     _dockDwellTimeout: function() {
         this._dockDwellTimeoutId = 0;
 
-        if (!this._settings.get_boolean('autohide-in-fullscreen') && this._monitor.inFullscreen)
+        if (!this._dtdSettings.get_boolean('autohide-in-fullscreen') && this._monitor.inFullscreen)
             return GLib.SOURCE_REMOVE;
 
         // We don't want to open the tray when a modal dialog
@@ -828,7 +828,7 @@ const DockedDash = new Lang.Class({
 
     _updatePressureBarrier: function() {
         this._canUsePressure = global.display.supports_extended_barriers();
-        let pressureThreshold = this._settings.get_double('pressure-threshold');
+        let pressureThreshold = this._dtdSettings.get_double('pressure-threshold');
 
         // Remove existing pressure barrier
         if (this._pressureBarrier) {
@@ -843,10 +843,10 @@ const DockedDash = new Lang.Class({
 
         // Create new pressure barrier based on pressure threshold setting
         if (this._canUsePressure) {
-            this._pressureBarrier = new Layout.PressureBarrier(pressureThreshold, this._settings.get_double('show-delay')*1000,
+            this._pressureBarrier = new Layout.PressureBarrier(pressureThreshold, this._dtdSettings.get_double('show-delay')*1000,
                                 Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW);
             this._pressureBarrier.connect('trigger', Lang.bind(this, function(barrier) {
-                if (!this._settings.get_boolean('autohide-in-fullscreen') && this._monitor.inFullscreen)
+                if (!this._dtdSettings.get_boolean('autohide-in-fullscreen') && this._monitor.inFullscreen)
                     return;
                 this._onPressureSensed();
             }));
@@ -901,7 +901,7 @@ const DockedDash = new Lang.Class({
 
         // Create new barrier
         // Note: dash in fixed position doesn't use pressure barrier
-        if (this._canUsePressure && this._autohideIsEnabled && this._settings.get_boolean('require-pressure-to-show')) {
+        if (this._canUsePressure && this._autohideIsEnabled && this._dtdSettings.get_boolean('require-pressure-to-show')) {
             let x1, x2, y1, y2, direction;
 
             if (this._position == St.Side.LEFT) {
@@ -955,8 +955,8 @@ const DockedDash = new Lang.Class({
         // Ensure variables linked to settings are updated.
         this._updateVisibilityMode();
 
-        let monitorIndex = this._settings.get_int('preferred-monitor');
-        let extendHeight = this._settings.get_boolean('extend-height');
+        let monitorIndex = this._dtdSettings.get_int('preferred-monitor');
+        let extendHeight = this._dtdSettings.get_boolean('extend-height');
 
         if ((monitorIndex > 0) && (monitorIndex < Main.layoutManager.monitors.length))
             this._monitor = Main.layoutManager.monitors[monitorIndex];
@@ -978,7 +978,7 @@ const DockedDash = new Lang.Class({
             // No space is required in the overview of the dash
             this._dashSpacer.hide();
 
-        let fraction = this._settings.get_double('height-fraction');
+        let fraction = this._dtdSettings.get_double('height-fraction');
 
         if (extendHeight)
             fraction = 1;
@@ -1050,7 +1050,7 @@ const DockedDash = new Lang.Class({
     _adjustLegacyTray: function() {
         let use_work_area = true;
 
-        if (this._fixedIsEnabled && !this._settings.get_boolean('extend-height')
+        if (this._fixedIsEnabled && !this._dtdSettings.get_boolean('extend-height')
             && this._isPrimaryMonitor()
             && ((this._position == St.Side.BOTTOM) || (this._position == St.Side.LEFT)))
             use_work_area = false;
@@ -1087,7 +1087,7 @@ const DockedDash = new Lang.Class({
      * Adjust Panel corners
      */
     _adjustPanelCorners: function() {
-        let extendHeight = this._settings.get_boolean('extend-height');
+        let extendHeight = this._dtdSettings.get_boolean('extend-height');
         if (!this._isHorizontal && this._isPrimaryMonitor() && extendHeight && this._fixedIsEnabled) {
             Main.panel._rightCorner.actor.hide();
             Main.panel._leftCorner.actor.hide();
@@ -1111,7 +1111,7 @@ const DockedDash = new Lang.Class({
         Main.layoutManager.uiGroup.set_child_above_sibling(this.actor, global.top_window_group);
         this._oldignoreHover = this._ignoreHover;
         this._ignoreHover = true;
-        this._animateIn(this._settings.get_double('animation-time'), 0);
+        this._animateIn(this._dtdSettings.get_double('animation-time'), 0);
     },
 
     _onDragEnd: function() {
@@ -1131,9 +1131,9 @@ const DockedDash = new Lang.Class({
                            activePage == ViewSelector.ViewPage.APPS);
 
         if (dashVisible)
-            this._animateIn(this._settings.get_double('animation-time'), 0);
+            this._animateIn(this._dtdSettings.get_double('animation-time'), 0);
         else
-            this._animateOut(this._settings.get_double('animation-time'), 0);
+            this._animateOut(this._dtdSettings.get_double('animation-time'), 0);
     },
 
     _onPageEmpty: function() {
@@ -1162,7 +1162,7 @@ const DockedDash = new Lang.Class({
      */
     _onAccessibilityFocus: function() {
         this._box.navigate_focus(null, Gtk.DirectionType.TAB_FORWARD, false);
-        this._animateIn(this._settings.get_double('animation-time'), 0);
+        this._animateIn(this._dtdSettings.get_double('animation-time'), 0);
     },
 
     _onShowAppsButtonToggled: function() {
@@ -1172,7 +1172,7 @@ const DockedDash = new Lang.Class({
         // status (due to the _syncShowAppsButtonToggled function below) and it
         // has already performed the desired action.
 
-        let animate = this._settings.get_boolean('animate-show-apps');
+        let animate = this._dtdSettings.get_boolean('animate-show-apps');
         let selector = Main.overview.viewSelector;
 
         if (selector._showAppsButton.checked !== this.dash.showAppsButton.checked) {
@@ -1277,14 +1277,14 @@ const DockedDash = new Lang.Class({
     _optionalScrollWorkspaceSwitch: function() {
         let label = 'optionalScrollWorkspaceSwitch';
 
-        this._settings.connect('changed::scroll-switch-workspace', Lang.bind(this, function() {
-            if (this._settings.get_boolean('scroll-switch-workspace'))
+        this._dtdSettings.connect('changed::scroll-switch-workspace', Lang.bind(this, function() {
+            if (this._dtdSettings.get_boolean('scroll-switch-workspace'))
                 Lang.bind(this, enable)();
             else
                 Lang.bind(this, disable)();
         }));
 
-        if (this._settings.get_boolean('scroll-switch-workspace'))
+        if (this._dtdSettings.get_boolean('scroll-switch-workspace'))
             Lang.bind(this, enable)();
 
         function enable() {

--- a/docking.js
+++ b/docking.js
@@ -1,27 +1,26 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
+const Lang = imports.lang;
+const Mainloop = imports.mainloop;
+const Signals = imports.signals;
+
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
-const Lang = imports.lang;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
-const Mainloop = imports.mainloop;
-const Params = imports.misc.params;
 
 const Main = imports.ui.main;
-const Dash = imports.ui.dash;
 const IconGrid = imports.ui.iconGrid;
-const Overview = imports.ui.overview;
 const OverviewControls = imports.ui.overviewControls;
 const PointerWatcher = imports.ui.pointerWatcher;
 const Tweener = imports.ui.tweener;
-const Signals = imports.signals;
 const ViewSelector = imports.ui.viewSelector;
-const WorkspaceSwitcherPopup= imports.ui.workspaceSwitcherPopup;
+const WorkspaceSwitcherPopup = imports.ui.workspaceSwitcherPopup;
 const Layout = imports.ui.layout;
-const LayoutManager = imports.ui.main.layoutManager;
+
+const Params = imports.misc.params;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;

--- a/docking.js
+++ b/docking.js
@@ -29,7 +29,7 @@ const Intellihide = Me.imports.intellihide;
 const Theming = Me.imports.theming;
 const MyDash = Me.imports.dash;
 
-const DOCK_DWELL_CHECK_INTERVAL = 100;  //TODO
+const DOCK_DWELL_CHECK_INTERVAL = 100; // TODO
 
 const State = {
     HIDDEN:  0,
@@ -38,7 +38,7 @@ const State = {
     HIDING:  3
 };
 
-/*
+/**
  * A simple St.Widget with one child whose allocation takes into account the
  * slide out of its child via the _slidex parameter ([0:1]).
  *
@@ -54,13 +54,11 @@ const State = {
  * It can't be an extended object because of this: https://bugzilla.gnome.org/show_bug.cgi?id=688973.
  * thus use the Shell.GenericContainer pattern.
 */
-
 const DashSlideContainer = new Lang.Class({
     Name: 'DashToDock.DashSlideContainer',
 
     _init: function(params) {
-
-        /* Default local params */
+        // Default local params
         let localDefaults = {
             side: St.Side.LEFT,
             initialSlideValue: 1
@@ -69,8 +67,8 @@ const DashSlideContainer = new Lang.Class({
         let localParams = Params.parse(params, localDefaults, true);
 
         if (params) {
-            /* Remove local params before passing the params to the parent
-               constructor to avoid errors. */
+            // Remove local params before passing the params to the parent
+            // constructor to avoid errors.
             let prop;
             for (prop in localDefaults) {
                 if ((prop in params))
@@ -94,7 +92,6 @@ const DashSlideContainer = new Lang.Class({
     },
 
     _allocate: function(actor, box, flags) {
-
         if (this._child == null)
             return;
 
@@ -111,62 +108,64 @@ const DashSlideContainer = new Lang.Class({
         let slideoutSize = this._slideoutSize;
 
         if (this._side == St.Side.LEFT) {
-            childBox.x1 = (this._slidex -1)*(childWidth - slideoutSize);
+            childBox.x1 = (this._slidex -1) * (childWidth - slideoutSize);
             childBox.x2 = slideoutSize + this._slidex*(childWidth - slideoutSize);
             childBox.y1 = 0;
             childBox.y2 = childBox.y1 + childHeight;
-        } else if (this._side ==  St.Side.RIGHT
-                 || this._side ==  St.Side.BOTTOM) {
+        }
+        else if ((this._side == St.Side.RIGHT) || (this._side == St.Side.BOTTOM)) {
             childBox.x1 = 0;
             childBox.x2 = childWidth;
             childBox.y1 = 0;
             childBox.y2 = childBox.y1 + childHeight;
-        } else if (this._side ==  St.Side.TOP) {
+        }
+        else if (this._side == St.Side.TOP) {
             childBox.x1 = 0;
             childBox.x2 = childWidth;
-            childBox.y1 = (this._slidex -1)*(childHeight - slideoutSize);
-            childBox.y2 = slideoutSize + this._slidex*(childHeight - slideoutSize);
+            childBox.y1 = (this._slidex -1) * (childHeight - slideoutSize);
+            childBox.y2 = slideoutSize + this._slidex * (childHeight - slideoutSize);
         }
 
         this._child.allocate(childBox, flags);
         this._child.set_clip(-childBox.x1, -childBox.y1,
-                             -childBox.x1+availWidth,-childBox.y1 + availHeight);
+                             -childBox.x1+availWidth, -childBox.y1 + availHeight);
     },
 
-    /* Just the child width but taking into account the slided out part */
+    /**
+     * Just the child width but taking into account the slided out part
+     */
     _getPreferredWidth: function(actor, forHeight, alloc) {
-        let [minWidth, natWidth ] = this._child.get_preferred_width(forHeight);
-        if (this._side ==  St.Side.LEFT
-          || this._side == St.Side.RIGHT) {
-            minWidth = (minWidth - this._slideoutSize)*this._slidex + this._slideoutSize;
-            natWidth = (natWidth - this._slideoutSize)*this._slidex + this._slideoutSize;
+        let [minWidth, natWidth] = this._child.get_preferred_width(forHeight);
+        if ((this._side ==  St.Side.LEFT) || (this._side == St.Side.RIGHT)) {
+            minWidth = (minWidth - this._slideoutSize) * this._slidex + this._slideoutSize;
+            natWidth = (natWidth - this._slideoutSize) * this._slidex + this._slideoutSize;
         }
 
         alloc.min_size = minWidth;
         alloc.natural_size = natWidth;
     },
 
-    /* Just the child height but taking into account the slided out part */
+    /**
+     * Just the child height but taking into account the slided out part
+     */
     _getPreferredHeight: function(actor, forWidth,  alloc) {
         let [minHeight, natHeight] = this._child.get_preferred_height(forWidth);
-        if (this._side ==  St.Side.TOP
-          || this._side ==  St.Side.BOTTOM) {
-            minHeight = (minHeight - this._slideoutSize)*this._slidex + this._slideoutSize;
-            natHeight = (natHeight - this._slideoutSize)*this._slidex + this._slideoutSize;
+        if ((this._side ==  St.Side.TOP) || (this._side ==  St.Side.BOTTOM)) {
+            minHeight = (minHeight - this._slideoutSize) * this._slidex + this._slideoutSize;
+            natHeight = (natHeight - this._slideoutSize) * this._slidex + this._slideoutSize;
         }
         alloc.min_size = minHeight;
         alloc.natural_size = natHeight;
     },
 
-    /* I was expecting it to be a virtual function... stil I don't understand
-       how things work.
-    */
+    /**
+     * I was expecting it to be a virtual function... stil I don't understand
+     * how things work.
+     */
     add_child: function(actor) {
-
-        /* I'm supposed to have only on child */
-        if(this._child !== null) {
+        // I'm supposed to have only on child
+        if (this._child !== null)
             this.actor.remove_child(actor);
-        }
 
         this._child = actor;
         this.actor.add_child(actor);
@@ -184,18 +183,16 @@ const DashSlideContainer = new Lang.Class({
 
 const DockedDash = new Lang.Class({
     Name: 'DashToDock.DockedDash',
- 
-    _init: function(settings) {
 
-        this._rtl = Clutter.get_default_text_direction() == Clutter.TextDirection.RTL;
+    _init: function(settings) {
+        this._rtl = (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL);
 
         // Load settings
         this._settings = settings;
         this._bindSettingsChanges();
 
         this._position = Convenience.getPosition(settings);
-        this._isHorizontal = ( this._position == St.Side.TOP ||
-                               this._position == St.Side.BOTTOM );
+        this._isHorizontal = ((this._position == St.Side.TOP) || (this._position == St.Side.BOTTOM));
 
         // Temporary ignore hover events linked to autohide for whatever reason
         this._ignoreHover = false;
@@ -253,109 +250,107 @@ const DockedDash = new Lang.Class({
 
         let positionStyleClass = ['top', 'right', 'bottom', 'left'];
         // This is the centering actor
-        this.actor = new St.Bin({ name: 'dashtodockContainer',reactive: false,
-            style_class:positionStyleClass[this._position],
+        this.actor = new St.Bin({
+            name: 'dashtodockContainer',
+            reactive: false,
+            style_class: positionStyleClass[this._position],
             x_align: this._isHorizontal?St.Align.MIDDLE:St.Align.START,
-            y_align: this._isHorizontal?St.Align.START:St.Align.MIDDLE});
+            y_align: this._isHorizontal?St.Align.START:St.Align.MIDDLE
+        });
         this.actor._delegate = this;
 
         // This is the sliding actor whose allocation is to be tracked for input regions
-        this._slider = new DashSlideContainer({side: this._position, initialSlideValue: 0});
+        this._slider = new DashSlideContainer({
+            side: this._position,
+            initialSlideValue: 0
+        });
 
         // This is the actor whose hover status us tracked for autohide
-        this._box = new St.BoxLayout({ name: 'dashtodockBox', reactive: true, track_hover:true } );
-        this._box.connect("notify::hover", Lang.bind(this, this._hoverChanged));
+        this._box = new St.BoxLayout({
+            name: 'dashtodockBox',
+            reactive: true,
+            track_hover: true
+        });
+        this._box.connect('notify::hover', Lang.bind(this, this._hoverChanged));
 
         // Create and apply height constraint to the dash. It's controlled by this.actor height
-        this.constrainSize = new Clutter.BindConstraint({ source: this.actor,
-          coordinate: this._isHorizontal?Clutter.BindCoordinate.WIDTH:Clutter.BindCoordinate.HEIGHT });
+        this.constrainSize = new Clutter.BindConstraint({
+            source: this.actor,
+            coordinate: this._isHorizontal?Clutter.BindCoordinate.WIDTH:Clutter.BindCoordinate.HEIGHT
+        });
         this.dash.actor.add_constraint(this.constrainSize);
 
         // Connect global signals
         this._signalsHandler = new Convenience.GlobalSignalsHandler();
-        this._signalsHandler.add(
-            [
-                Main.overview,
-                'item-drag-begin',
-                Lang.bind(this, this._onDragStart)
-            ],
-            [
-                Main.overview,
-                'item-drag-end',
-                Lang.bind(this, this._onDragEnd)
-            ],
-            [
-                Main.overview,
-                'item-drag-cancelled',
-                Lang.bind(this, this._onDragEnd)
-            ],
+        this._signalsHandler.add([
+            Main.overview,
+            'item-drag-begin',
+            Lang.bind(this, this._onDragStart)
+        ], [
+            Main.overview,
+            'item-drag-end',
+            Lang.bind(this, this._onDragEnd)
+        ], [
+            Main.overview,
+            'item-drag-cancelled',
+            Lang.bind(this, this._onDragEnd)
+        ], [
             // update when monitor changes, for instance in multimonitor when monitor are attached
-            [
-                global.screen,
-                'monitors-changed',
-                Lang.bind(this, this._resetPosition )
-            ],
+            global.screen,
+            'monitors-changed',
+            Lang.bind(this, this._resetPosition )
+        ], [
             // update when workarea changes, for instance if  other extensions modify the struts
             //(like moving th panel at the bottom)
-            [
-                global.screen,
-                'workareas-changed',
-                Lang.bind(this, this._resetPosition)
-            ],
-            [
-                Main.overview,
-                'showing',
-                Lang.bind(this, this._onOverviewShowing)
-            ],
-            [
-                Main.overview,
-                'hiding',
-                Lang.bind(this, this._onOverviewHiding)
-            ],
+            global.screen,
+            'workareas-changed',
+            Lang.bind(this, this._resetPosition)
+        ], [
+            Main.overview,
+            'showing',
+            Lang.bind(this, this._onOverviewShowing)
+        ], [
+            Main.overview,
+            'hiding',
+            Lang.bind(this, this._onOverviewHiding)
+        ], [
             // Hide on appview
-            [
-                Main.overview.viewSelector,
-                'page-changed',
-                Lang.bind(this, this._pageChanged)
-            ],
-            [
-                Main.overview.viewSelector,
-                'page-empty',
-                Lang.bind(this, this._onPageEmpty)
-            ],
+            Main.overview.viewSelector,
+            'page-changed',
+            Lang.bind(this, this._pageChanged)
+        ], [
+            Main.overview.viewSelector,
+            'page-empty',
+            Lang.bind(this, this._onPageEmpty)
+        ], [
             // Ensure the ShowAppsButton status is kept in sync
-            [
-                Main.overview.viewSelector._showAppsButton,
-                'notify::checked',
-                Lang.bind(this, this._syncShowAppsButtonToggled)
-            ],
+            Main.overview.viewSelector._showAppsButton,
+            'notify::checked',
+            Lang.bind(this, this._syncShowAppsButtonToggled)
+        ], [
             // Monitor windows overlapping
-            [
-                this._intellihide,
-                'status-changed',
-                Lang.bind(this, this._updateDashVisibility)
-            ],
+            this._intellihide,
+            'status-changed',
+            Lang.bind(this, this._updateDashVisibility)
+        ], [
             // Keep dragged icon consistent in size with this dash
-            [
-                this.dash,
-                'icon-size-changed',
-                Lang.bind(this, function() {
-                    Main.overview.dashIconSize = this.dash.iconSize;
-                })
-            ],
+            this.dash,
+            'icon-size-changed',
+            Lang.bind(this, function() {
+                Main.overview.dashIconSize = this.dash.iconSize;
+            })
+        ], [
             // This duplicate the similar signal which is in owerview.js.
             // Being connected and thus executed later this effectively
             // overwrite any attempt to use the size of the default dash
             //which given the customization is usually much smaller.
             // I can't easily disconnect the original signal
-            [
-                Main.overview._controls.dash,
-                'icon-size-changed',
-                Lang.bind(this, function() {
-                    Main.overview.dashIconSize = this.dash.iconSize;
-                })
-            ]
-        );
+            Main.overview._controls.dash,
+            'icon-size-changed',
+            Lang.bind(this, function() {
+                Main.overview.dashIconSize = this.dash.iconSize;
+            })
+        ]);
 
         this._injectionsHandler = new Convenience.InjectionsHandler();
         this._themeManager = new Theming.ThemeManager(this._settings, this.actor, this.dash);
@@ -367,14 +362,16 @@ const DockedDash = new Lang.Class({
                                               Lang.bind(Main.layoutManager, Main.layoutManager._queueUpdateRegions));
 
         this.dash._container.connect('allocation-changed', Lang.bind(this, this._updateStaticBox));
-        this._slider.actor.connect(this._isHorizontal?'notify::x':'notify::y', Lang.bind(this, this._updateStaticBox));
+        this._slider.actor.connect(this._isHorizontal ? 'notify::x' : 'notify::y', Lang.bind(this, this._updateStaticBox));
 
         // sync hover after a popupmenu is closed
-        this.dash.connect('menu-closed', Lang.bind(this, function() {this._box.sync_hover();}));
+        this.dash.connect('menu-closed', Lang.bind(this, function() {
+            this._box.sync_hover();
+        }));
 
         // Restore dash accessibility
         Main.ctrlAltTabManager.addGroup(
-            this.dash.actor, _("Dash"),'user-bookmarks-symbolic',
+            this.dash.actor, _('Dash'), 'user-bookmarks-symbolic',
                 {focusCallback: Lang.bind(this, this._onAccessibilityFocus)});
 
         // Load optional features
@@ -383,7 +380,7 @@ const DockedDash = new Lang.Class({
          // Delay operations that require the shell to be fully loaded and with
          // user theme applied.
 
-        this._paintId = this.actor.connect("paint", Lang.bind(this, this._initialize));
+        this._paintId = this.actor.connect('paint', Lang.bind(this, this._initialize));
 
         // Hide usual Dash
         Main.overview._controls.dash.actor.hide();
@@ -402,14 +399,14 @@ const DockedDash = new Lang.Class({
         this._dashSpacer = new OverviewControls.DashSpacer();
         this._dashSpacer.setDashActor(this._box);
 
-        if (this._position ==  St.Side.LEFT)
-          Main.overview._controls._group.insert_child_at_index(this._dashSpacer, this._rtl?-1:0); // insert on first
+        if (this._position == St.Side.LEFT)
+            Main.overview._controls._group.insert_child_at_index(this._dashSpacer, this._rtl ? -1 : 0); // insert on first
         else if (this._position ==  St.Side.RIGHT)
-            Main.overview._controls._group.insert_child_at_index(this._dashSpacer, this._rtl?0:-1); // insert on last
-        else if (this._position ==  St.Side.TOP)
+            Main.overview._controls._group.insert_child_at_index(this._dashSpacer, this._rtl ? 0 : -1); // insert on last
+        else if (this._position == St.Side.TOP)
             Main.overview._overview.insert_child_at_index(this._dashSpacer, 0);
-        else if (this._position ==  St.Side.BOTTOM)
-          Main.overview._overview.insert_child_at_index(this._dashSpacer, -1);
+        else if (this._position == St.Side.BOTTOM)
+            Main.overview._overview.insert_child_at_index(this._dashSpacer, -1);
 
         // Add dash container actor and the container to the Chrome.
         this.actor.set_child(this._slider.actor);
@@ -425,21 +422,19 @@ const DockedDash = new Lang.Class({
         // Keep the dash below the modalDialogGroup
         Main.layoutManager.uiGroup.set_child_below_sibling(this.actor,Main.layoutManager.modalDialogGroup);
 
-        if ( this._settings.get_boolean('dock-fixed') )
-          Main.layoutManager._trackActor(this._box, {affectsStruts: true, trackFullscreen: true});
+        if (this._settings.get_boolean('dock-fixed'))
+            Main.layoutManager._trackActor(this._box, {affectsStruts: true, trackFullscreen: true});
 
         // pretend this._slider is isToplevel child so that fullscreen is actually tracked
         let index = Main.layoutManager._findActor(this._slider.actor);
-        Main.layoutManager._trackedActors[index].isToplevel = true ;
+        Main.layoutManager._trackedActors[index].isToplevel = true;
 
         // Set initial position
         this._resetPosition();
-
     },
 
     _initialize: function() {
-
-        if(this._paintId>0) {
+        if (this._paintId > 0) {
             this.actor.disconnect(this._paintId);
             this._paintId=0;
         }
@@ -451,8 +446,8 @@ const DockedDash = new Lang.Class({
 
         // Since Gnome 3.8 dragging an app without having opened the overview before cause the attemp to
         //animate a null target since some variables are not initialized when the viewSelector is created
-        if(Main.overview.viewSelector._activePage == null)
-                Main.overview.viewSelector._activePage = Main.overview.viewSelector._workspacesPage;
+        if (Main.overview.viewSelector._activePage == null)
+            Main.overview.viewSelector._activePage = Main.overview.viewSelector._workspacesPage;
 
         this._updateVisibilityMode();
 
@@ -469,11 +464,9 @@ const DockedDash = new Lang.Class({
 
         // setup dwelling system if pressure barriers are not available
         this._setupDockDwellIfNeeded();
-
     },
 
     destroy: function() {
-
         // Disconnect global signals
         this._signalsHandler.destroy();
         // The dash and intellihide have global signals as well internally
@@ -494,7 +487,7 @@ const DockedDash = new Lang.Class({
         this._removeBarrier();
 
         // Remove pointer watcher
-        if(this._dockWatch) {
+        if (this._dockWatch) {
             PointerWatcher.getPointerWatcher()._removeWatch(this._dockWatch);
             this._dockWatch = null;
         }
@@ -516,7 +509,6 @@ const DockedDash = new Lang.Class({
     },
 
     _bindSettingsChanges: function() {
-
         this._settings.connect('changed::scroll-switch-workspace', Lang.bind(this, function() {
             this._optionalScrollWorkspaceSwitch(this._settings.get_boolean('scroll-switch-workspace'));
         }));
@@ -550,11 +542,10 @@ const DockedDash = new Lang.Class({
 
         this._settings.connect('changed::dock-fixed', Lang.bind(this, function() {
 
-            if(this._settings.get_boolean('dock-fixed')) {
+            if (this._settings.get_boolean('dock-fixed'))
                 Main.layoutManager._trackActor(this._box, {affectsStruts: true, trackFullscreen: true});
-            } else {
+            else
                 Main.layoutManager._untrackActor(this._box);
-            }
 
             this._resetPosition();
 
@@ -579,7 +570,7 @@ const DockedDash = new Lang.Class({
         this._settings.connect('changed::height-fraction', Lang.bind(this,this._resetPosition));
         this._settings.connect('changed::require-pressure-to-show', Lang.bind(this,function() {
             // Remove pointer watcher
-            if(this._dockWatch) {
+            if (this._dockWatch) {
                 PointerWatcher.getPointerWatcher()._removeWatch(this._dockWatch);
                 this._dockWatch = null;
             }
@@ -593,14 +584,16 @@ const DockedDash = new Lang.Class({
 
     },
 
-    // This is call when visibility settings change
+    /**
+     * This is call when visibility settings change
+     */
     _updateVisibilityMode: function() {
-
         if (this._settings.get_boolean('dock-fixed')) {
             this._fixedIsEnabled = true;
             this._autohideIsEnabled = false;
             this._intellihideIsEnabled = false;
-        } else {
+        }
+        else {
             this._fixedIsEnabled = false;
             this._autohideIsEnabled = this._settings.get_boolean('autohide')
             this._intellihideIsEnabled = this._settings.get_boolean('intellihide')
@@ -614,7 +607,8 @@ const DockedDash = new Lang.Class({
         this._updateDashVisibility();
     },
 
-    /* Show/hide dash based on, in order of priority:
+    /**
+     * Show/hide dash based on, in order of priority:
      * overview visibility
      * fixed mode
      * intellihide
@@ -622,39 +616,38 @@ const DockedDash = new Lang.Class({
      * overview visibility
      */
     _updateDashVisibility: function() {
-
         if (Main.overview.visibleTarget)
             return;
 
-        if ( this._fixedIsEnabled ) {
+        if (this._fixedIsEnabled) {
             this._removeAnimations();
             this._animateIn(this._settings.get_double('animation-time'), 0);
-        } else if (this._intellihideIsEnabled) {
-            if ( this._intellihide.getOverlapStatus() ) {
+        }
+        else if (this._intellihideIsEnabled) {
+            if (this._intellihide.getOverlapStatus()) {
                 this._ignoreHover = false;
                 // Do not hide if autohide is enabled and mouse is hover
-                if (!this._box.hover || !this._autohideIsEnabled) {
+                if (!this._box.hover || !this._autohideIsEnabled)
                     this._animateOut(this._settings.get_double('animation-time'), 0);
-                }
-            } else {
+            }
+            else {
                 this._ignoreHover = true;
                 this._removeAnimations();
                 this._animateIn(this._settings.get_double('animation-time'), 0);
             }
-        } else {
+        }
+        else {
             if (this._autohideIsEnabled) {
                 this._ignoreHover = false;
                 global.sync_pointer();
 
-                if( this._box.hover ) {
+                if (this._box.hover)
                     this._animateIn(this._settings.get_double('animation-time'), 0);
-                } else {
+                else
                     this._animateOut(this._settings.get_double('animation-time'), 0);
-                }
-
-            } else {
-                this._animateOut(this._settings.get_double('animation-time'), 0);
             }
+            else
+                this._animateOut(this._settings.get_double('animation-time'), 0);
         }
     },
 
@@ -672,96 +665,85 @@ const DockedDash = new Lang.Class({
     },
 
     _hoverChanged: function() {
-
         if (!this._ignoreHover) {
-
             // Skip if dock is not in autohide mode for instance because it is shown
             // by intellihide.
-            if(this._autohideIsEnabled) {
-                if( this._box.hover ) {
+            if (this._autohideIsEnabled) {
+                if (this._box.hover)
                     this._show();
-                } else {
+                else
                     this._hide();
-                }
             }
         }
     },
 
     _show: function() {
-
-        if ( this._dockState == State.HIDDEN || this._dockState == State.HIDING ) {
-
-            if(this._dockState == State.HIDING) {
+        if ((this._dockState == State.HIDDEN) || (this._dockState == State.HIDING)) {
+            if (this._dockState == State.HIDING)
                 // suppress all potential queued hiding animations - i.e. added to Tweener but not started,
                 // always give priority to show
                 this._removeAnimations();
-            }
 
-            this.emit("showing");
+            this.emit('showing');
             this._animateIn(this._settings.get_double('animation-time'), 0);
         }
     },
 
     _hide: function() {
-
         // If no hiding animation is running or queued
-        if ( this._dockState == State.SHOWN || this._dockState == State.SHOWING ) {
-
+        if ((this._dockState == State.SHOWN) || (this._dockState == State.SHOWING)) {
             let delay;
 
-            if (this._dockState == State.SHOWING) {
+            if (this._dockState == State.SHOWING)
                 //if a show already started, let it finish; queue hide without removing the show.
-                // to obtain this I increase the delay to avoid the overlap and interference 
+                // to obtain this I increase the delay to avoid the overlap and interference
                 // between the animations
                 delay = this._settings.get_double('hide-delay') + this._settings.get_double('animation-time');
-            } else {
+            else
                 delay = this._settings.get_double('hide-delay');
-            }
 
-            this.emit("hiding");
+            this.emit('hiding');
             this._animateOut(this._settings.get_double('animation-time'), delay);
-
         }
     },
 
     _animateIn: function(time, delay) {
-
         this._dockState = State.SHOWING;
 
-        Tweener.addTween(this._slider,{
+        Tweener.addTween(this._slider, {
             slidex: 1,
             time: time,
             delay: delay,
             transition: 'easeOutQuad',
             onComplete: Lang.bind(this, function() {
-                  this._dockState = State.SHOWN;
-                  // Remove barrier so that mouse pointer is released and can access monitors on other side of dock
-                  // NOTE: Delay needed to keep mouse from moving past dock and re-hiding dock immediately. This
-                  // gives users an opportunity to hover over the dock
-                  if (this._removeBarrierTimeoutId > 0) {
-                      Mainloop.source_remove(this._removeBarrierTimeoutId);
-                  }
-                  this._removeBarrierTimeoutId = Mainloop.timeout_add(100, Lang.bind(this, this._removeBarrier));
-              })
+                this._dockState = State.SHOWN;
+                // Remove barrier so that mouse pointer is released and can access monitors on other side of dock
+                // NOTE: Delay needed to keep mouse from moving past dock and re-hiding dock immediately. This
+                // gives users an opportunity to hover over the dock
+                if (this._removeBarrierTimeoutId > 0)
+                    Mainloop.source_remove(this._removeBarrierTimeoutId);
+                this._removeBarrierTimeoutId = Mainloop.timeout_add(100, Lang.bind(this, this._removeBarrier));
+            })
         });
     },
 
     _animateOut: function(time, delay) {
-
         this._dockState = State.HIDING;
-        Tweener.addTween(this._slider,{
+        Tweener.addTween(this._slider, {
             slidex: 0,
             time: time,
             delay: delay ,
             transition: 'easeOutQuad',
             onComplete: Lang.bind(this, function() {
-                    this._dockState = State.HIDDEN;
-                    this._updateBarrier();
+                this._dockState = State.HIDDEN;
+                this._updateBarrier();
             })
         });
     },
 
-    // Dwelling system based on the GNOME Shell 3.14 messageTray code.
+    /**
+     * Dwelling system based on the GNOME Shell 3.14 messageTray code.
+     */
     _setupDockDwellIfNeeded: function() {
         // If we don't have extended barrier features, then we need
         // to support the old tray dwelling mechanism.
@@ -782,15 +764,14 @@ const DockedDash = new Lang.Class({
 
         // Check for the correct screen edge
         // Position is approximated to the lower integer
-        if(this._position==St.Side.LEFT) {
-            shouldDwell = shouldDwell &&  x == this._monitor.x;
-        } else if(this._position==St.Side.RIGHT) {
-            shouldDwell = shouldDwell &&  x == this._monitor.x + this._monitor.width - 1;
-        } else if(this._position==St.Side.TOP) {
-            shouldDwell = shouldDwell &&  y == this._monitor.y;
-        } else if (this._position==St.Side.BOTTOM) {
-            shouldDwell = shouldDwell &&  y == this._monitor.y + this._monitor.height - 1;
-        }
+        if (this._position == St.Side.LEFT)
+            shouldDwell = shouldDwell && (x == this._monitor.x);
+        else if (this._position == St.Side.RIGHT)
+            shouldDwell = shouldDwell && (x == this._monitor.x + this._monitor.width - 1);
+        else if (this._position == St.Side.TOP)
+            shouldDwell = shouldDwell && (y == this._monitor.y);
+        else if (this._position == St.Side.BOTTOM)
+            shouldDwell = shouldDwell && (y == this._monitor.y + this._monitor.height - 1);
 
         if (shouldDwell) {
             // We only set up dwell timeout when the user is not hovering over the dock
@@ -798,17 +779,18 @@ const DockedDash = new Lang.Class({
             // The _dockDwelling variable is used so that we only try to
             // fire off one dock dwell - if it fails (because, say, the user has the mouse down),
             // we don't try again until the user moves the mouse up and down again.
-            if (!this._dockDwelling && !this._box.hover && this._dockDwellTimeoutId == 0) {
+            if (!this._dockDwelling && !this._box.hover && (this._dockDwellTimeoutId == 0)) {
                 // Save the interaction timestamp so we can detect user input
                 let focusWindow = global.display.focus_window;
                 this._dockDwellUserTime = focusWindow ? focusWindow.user_time : 0;
 
-                this._dockDwellTimeoutId = Mainloop.timeout_add(this._settings.get_double('show-delay')*1000,
+                this._dockDwellTimeoutId = Mainloop.timeout_add(this._settings.get_double('show-delay') * 1000,
                                                                 Lang.bind(this, this._dockDwellTimeout));
                 GLib.Source.set_name_by_id(this._dockDwellTimeoutId, '[dash-to-dock] this._dockDwellTimeout');
             }
             this._dockDwelling = true;
-        } else {
+        }
+        else {
             this._cancelDockDwell();
             this._dockDwelling = false;
         }
@@ -872,30 +854,31 @@ const DockedDash = new Lang.Class({
         }
     },
 
-    // handler for mouse pressure sensed
+    /**
+     * handler for mouse pressure sensed
+     */
     _onPressureSensed: function() {
-
         if (Main.overview.visibleTarget)
             return;
 
         // In case the mouse move away from the dock area before hovering it, in such case the leave event
         // would never be triggered and the dock would stay visible forever.
-        let triggerTimeoutId =  Mainloop.timeout_add(250,
-                                                 Lang.bind(this, function() {
-                                                                      triggerTimeoutId = 0;
-                                                                      this._hoverChanged();
-                                                                      return GLib.SOURCE_REMOVE;
-                                                                  }));
+        let triggerTimeoutId =  Mainloop.timeout_add(250, Lang.bind(this, function() {
+            triggerTimeoutId = 0;
+            this._hoverChanged();
+            return GLib.SOURCE_REMOVE;
+        }));
 
         this._show();
     },
 
-    // Remove pressure barrier
+    /**
+     * Remove pressure barrier
+     */
     _removeBarrier: function() {
         if (this._barrier) {
-            if (this._pressureBarrier) {
+            if (this._pressureBarrier)
                 this._pressureBarrier.removeBarrier(this._barrier);
-            }
             this._barrier.destroy();
             this._barrier = null;
         }
@@ -903,7 +886,9 @@ const DockedDash = new Lang.Class({
         return false;
     },
 
-    // Update pressure barrier size
+    /**
+     * Update pressure barrier size
+     */
     _updateBarrier: function() {
         // Remove existing barrier
         this._removeBarrier();
@@ -920,25 +905,28 @@ const DockedDash = new Lang.Class({
         if (this._canUsePressure && this._autohideIsEnabled && this._settings.get_boolean('require-pressure-to-show')) {
             let x1, x2, y1, y2, direction;
 
-            if(this._position==St.Side.LEFT) {
+            if (this._position == St.Side.LEFT) {
                 x1 = this.staticBox.x1;
                 x2 = this.staticBox.x1;
                 y1 = this.staticBox.y1;
                 y2 = this.staticBox.y2;
                 direction = Meta.BarrierDirection.POSITIVE_X;
-            } else if(this._position==St.Side.RIGHT) {
+            }
+            else if (this._position == St.Side.RIGHT) {
                 x1 = this.staticBox.x2;
                 x2 = this.staticBox.x2;
                 y1 = this.staticBox.y1;
                 y2 = this.staticBox.y2;
                 direction = Meta.BarrierDirection.NEGATIVE_X;
-            } else if(this._position==St.Side.TOP) {
+            }
+            else if (this._position == St.Side.TOP) {
                 x1 = this.staticBox.x1;
                 x2 = this.staticBox.x2;
                 y1 = this.staticBox.y1;
                 y2 = this.staticBox.y1;
                 direction = Meta.BarrierDirection.POSITIVE_Y;
-            } else if (this._position==St.Side.BOTTOM) {
+            }
+            else if (this._position == St.Side.BOTTOM) {
                 x1 = this.staticBox.x1;
                 x2 = this.staticBox.x2;
                 y1 = this.staticBox.y2;
@@ -946,31 +934,32 @@ const DockedDash = new Lang.Class({
                 direction = Meta.BarrierDirection.NEGATIVE_Y;
             }
 
-            this._barrier = new Meta.Barrier({display: global.display,
-                                x1: x1, x2: x2,
-                                y1: y1, y2: y2,
-                                directions: direction});
-            if (this._pressureBarrier) {
+            this._barrier = new Meta.Barrier({
+                display: global.display,
+                x1: x1,
+                x2: x2,
+                y1: y1,
+                y2: y2,
+                directions: direction
+            });
+            if (this._pressureBarrier)
                 this._pressureBarrier.addBarrier(this._barrier);
-            }
         }
-
     },
 
     _isPrimaryMonitor: function() {
-        return (this._monitor.x == Main.layoutManager.primaryMonitor.x &&
-             this._monitor.y == Main.layoutManager.primaryMonitor.y);
+        return ((this._monitor.x == Main.layoutManager.primaryMonitor.x) &&
+             (this._monitor.y == Main.layoutManager.primaryMonitor.y));
     },
 
     _resetPosition: function() {
-
         // Ensure variables linked to settings are updated.
         this._updateVisibilityMode();
 
         let monitorIndex = this._settings.get_int('preferred-monitor');
         let extendHeight = this._settings.get_boolean('extend-height');
 
-        if (monitorIndex >0 && monitorIndex< Main.layoutManager.monitors.length)
+        if ((monitorIndex > 0) && (monitorIndex < Main.layoutManager.monitors.length))
             this._monitor = Main.layoutManager.monitors[monitorIndex];
         else {
             monitorIndex = Main.layoutManager.primaryIndex
@@ -984,68 +973,69 @@ const DockedDash = new Lang.Class({
 
         // Reserve space for the dash on the overview
         // if the dock is on the primary monitor
-        if (this._isPrimaryMonitor()) {
+        if (this._isPrimaryMonitor())
             this._dashSpacer.show();
-        } else {
+        else
             // No space is required in the overview of the dash
             this._dashSpacer.hide();
-        }
 
         let fraction = this._settings.get_double('height-fraction');
 
-        if(extendHeight)
+        if (extendHeight)
             fraction = 1;
-        else if(fraction<0 || fraction >1)
+        else if ((fraction < 0) || (fraction > 1))
             fraction = 0.95;
 
         let anchor_point;
 
-        if(this._isHorizontal) {
-
+        if (this._isHorizontal) {
             this.actor.width = Math.round( fraction * workArea.width);
 
             let pos_y;
-            if( this._position == St.Side.BOTTOM) {
+            if (this._position == St.Side.BOTTOM) {
                 pos_y =  this._monitor.y + this._monitor.height;
                 anchor_point = Clutter.Gravity.SOUTH_WEST;
-            } else {
+            }
+            else {
                 pos_y = this._monitor.y;
                 anchor_point = Clutter.Gravity.NORTH_WEST;
             }
 
             this.actor.move_anchor_point_from_gravity(anchor_point);
-            this.actor.x = workArea.x + Math.round( (1-fraction)/2 * workArea.width);
+            this.actor.x = workArea.x + Math.round((1 - fraction) / 2 * workArea.width);
             this.actor.y = pos_y;
 
-            if(extendHeight) {
+            if (extendHeight) {
                 this.dash._container.set_width(this.actor.width);
                 this.actor.add_style_class_name('extended');
-            } else {
+            }
+            else {
                 this.dash._container.set_width(-1);
                 this.actor.remove_style_class_name('extended');
             }
-
-        } else {
-
-            this.actor.height = Math.round( fraction * workArea.height);
+        }
+        else {
+            this.actor.height = Math.round(fraction * workArea.height);
 
             let pos_x;
-            if( this._position == St.Side.RIGHT) {
+            if (this._position == St.Side.RIGHT) {
                 pos_x =  this._monitor.x + this._monitor.width;
                 anchor_point = Clutter.Gravity.NORTH_EAST;
-            } else {
+            }
+            else {
                 pos_x =  this._monitor.x;
                 anchor_point = Clutter.Gravity.NORTH_WEST;
             }
 
             this.actor.move_anchor_point_from_gravity(anchor_point);
             this.actor.x = pos_x;
-            this.actor.y = workArea.y + Math.round( (1-fraction)/2 * workArea.height);
+            this.actor.y = workArea.y + Math.round((1 - fraction) / 2 * workArea.height);
 
-            if(extendHeight) {
+            if (extendHeight) {
                 this.dash._container.set_height(this.actor.height);
                 this.actor.add_style_class_name('extended');
-            } else {
+            }
+            else {
                 this.dash._container.set_height(-1);
                 this.actor.remove_style_class_name('extended');
             }
@@ -1059,35 +1049,34 @@ const DockedDash = new Lang.Class({
     },
 
     _adjustLegacyTray: function() {
-
         let use_work_area = true;
 
-        if ( this._fixedIsEnabled && !this._settings.get_boolean('extend-height')
-             && this._isPrimaryMonitor()
-             && (this._position == St.Side.BOTTOM ||this._position == St.Side.LEFT )
-             )
-        {
+        if (this._fixedIsEnabled && !this._settings.get_boolean('extend-height')
+            && this._isPrimaryMonitor()
+            && ((this._position == St.Side.BOTTOM) || (this._position == St.Side.LEFT)))
             use_work_area = false;
-        }
 
         Main.legacyTray.actor.clear_constraints();
-        let constraint = new Layout.MonitorConstraint({ primary: true,
-                                                        work_area: use_work_area});
+        let constraint = new Layout.MonitorConstraint({
+            primary: true,
+            work_area: use_work_area
+        });
         Main.legacyTray.actor.add_constraint(constraint);
     },
 
     _resetLegacyTray: function() {
         Main.legacyTray.actor.clear_constraints();
-        let constraint = new Layout.MonitorConstraint({ primary: true,
-                                                        work_area: true });
+        let constraint = new Layout.MonitorConstraint({
+            primary: true,
+            work_area: true
+        });
         Main.legacyTray.actor.add_constraint(constraint);
     },
 
     _updateStaticBox: function() {
-
         this.staticBox.init_rect(
-            this.actor.x + this._slider.actor.x - (this._position==St.Side.RIGHT?this._box.width:0),
-            this.actor.y + this._slider.actor.y - (this._position==St.Side.BOTTOM?this._box.height:0),
+            this.actor.x + this._slider.actor.x - (this._position == St.Side.RIGHT ? this._box.width : 0),
+            this.actor.y + this._slider.actor.y - (this._position == St.Side.BOTTOM ? this._box.height : 0),
             this._box.width,
             this._box.height
         );
@@ -1095,15 +1084,17 @@ const DockedDash = new Lang.Class({
         this._intellihide.updateTargetBox(this.staticBox);
     },
 
-    // Adjust Panel corners
+    /**
+     * Adjust Panel corners
+     */
     _adjustPanelCorners: function() {
         let extendHeight = this._settings.get_boolean('extend-height');
         if (!this._isHorizontal && this._isPrimaryMonitor() && extendHeight && this._fixedIsEnabled) {
             Main.panel._rightCorner.actor.hide();
             Main.panel._leftCorner.actor.hide();
-        } else {
-            this._revertPanelCorners();
         }
+        else
+            this._revertPanelCorners();
     },
 
     _revertPanelCorners: function() {
@@ -1131,21 +1122,19 @@ const DockedDash = new Lang.Class({
             this._ignoreHover  = this._oldignoreHover;
         this._oldignoreHover = null;
         this._box.sync_hover();
-        if(Main.overview._shown)
+        if (Main.overview._shown)
             this._pageChanged();
     },
 
     _pageChanged: function() {
-
         let activePage = Main.overview.viewSelector.getActivePage();
         let dashVisible = (activePage == ViewSelector.ViewPage.WINDOWS ||
                            activePage == ViewSelector.ViewPage.APPS);
 
-        if(dashVisible) {
+        if (dashVisible)
             this._animateIn(this._settings.get_double('animation-time'), 0);
-        } else {
+        else
             this._animateOut(this._settings.get_double('animation-time'), 0);
-        }
     },
 
     _onPageEmpty: function() {
@@ -1169,14 +1158,15 @@ const DockedDash = new Lang.Class({
         this._dashSpacer.visible = (this._isHorizontal || activePage == ViewSelector.ViewPage.WINDOWS);
     },
 
-    // Show dock and give key focus to it
+    /**
+     * Show dock and give key focus to it
+     */
     _onAccessibilityFocus: function() {
         this._box.navigate_focus(null, Gtk.DirectionType.TAB_FORWARD, false);
         this._animateIn(this._settings.get_double('animation-time'), 0);
     },
 
     _onShowAppsButtonToggled: function() {
-
         // Sync the status of the default appButtons. Only if the two statuses are
         // different, that means the user interacted with the extension provided
         // application button, cutomize the behaviour. Otherwise the shell has changed the
@@ -1186,21 +1176,19 @@ const DockedDash = new Lang.Class({
         let animate = this._settings.get_boolean('animate-show-apps');
         let selector = Main.overview.viewSelector;
 
-        if(selector._showAppsButton.checked !== this.dash.showAppsButton.checked) {
-
+        if (selector._showAppsButton.checked !== this.dash.showAppsButton.checked) {
             // find visible view
             let visibleView;
             Main.overview.viewSelector.appDisplay._views.every(function(v, index) {
                 if (v.view.actor.visible) {
                     visibleView = index;
                     return false;
-                } else {
-                  return true;
                 }
+                else
+                    return true;
             });
 
-            if(this.dash.showAppsButton.checked) {
-
+            if (this.dash.showAppsButton.checked) {
                 // force spring animation triggering.By default the animation only
                 // runs if we are already inside the overview.
                 if (!Main.overview._shown) {
@@ -1219,7 +1207,6 @@ const DockedDash = new Lang.Class({
                         Main.overview.viewSelector._activePage.show();
                         grid.actor.opacity = 0;
 
-
                         // The animation has to be trigered manually because the AppDisplay.animate
                         // method is waiting for an allocation not happening, as we skip the workspace view
                         // and the appgrid could already be allocated from previous shown.
@@ -1231,15 +1218,15 @@ const DockedDash = new Lang.Class({
                                 grid.actor.opacity = 255;
                                 grid.animateSpring(IconGrid.AnimationDirection.IN, this.dash.showAppsButton);
                             }));
-                          }));
+                        }));
                     }
                 }
 
                 // Finally show the overview
                 selector._showAppsButton.checked = true;
                 Main.overview.show();
-
-            } else {
+            }
+            else {
                 if (this.forcedOverview) {
                     // force exiting overview if needed
 
@@ -1255,75 +1242,75 @@ const DockedDash = new Lang.Class({
                             selector._showAppsButton.checked = false;
                             this.forcedOverview = false;
                         }));
-                    } else {
+                    }
+                    else {
                         Main.overview.hide();
                         this.forcedOverview = false;
                     }
-                } else {
+                }
+                else {
                     selector._showAppsButton.checked = false;
                     this.forcedOverview = false;
                 }
-
             }
         }
 
         // whenever the button is unactivated even if not by the user still reset the
         // forcedOverview flag
-        if( this.dash.showAppsButton.checked==false)
+        if (this.dash.showAppsButton.checked == false)
             this.forcedOverview = false;
     },
 
-    // Keep ShowAppsButton status in sync with the overview status
+    /**
+     * Keep ShowAppsButton status in sync with the overview status
+     */
     _syncShowAppsButtonToggled: function() {
         let status = Main.overview.viewSelector._showAppsButton.checked;
-        if(this.dash.showAppsButton.checked !== status)
+        if (this.dash.showAppsButton.checked !== status)
             this.dash.showAppsButton.checked = status;
     },
 
     // Optional features enable/disable
 
-    // Switch workspace by scrolling over the dock
+    /**
+     * Switch workspace by scrolling over the dock
+     */
     _optionalScrollWorkspaceSwitch: function() {
-
         let label = 'optionalScrollWorkspaceSwitch';
 
-        this._settings.connect('changed::scroll-switch-workspace',Lang.bind(this, function() {
-            if(this._settings.get_boolean('scroll-switch-workspace'))
+        this._settings.connect('changed::scroll-switch-workspace', Lang.bind(this, function() {
+            if (this._settings.get_boolean('scroll-switch-workspace'))
                 Lang.bind(this, enable)();
             else
                 Lang.bind(this, disable)();
         }));
 
-        if(this._settings.get_boolean('scroll-switch-workspace'))
+        if (this._settings.get_boolean('scroll-switch-workspace'))
             Lang.bind(this, enable)();
 
         function enable() {
-
             this._signalsHandler.removeWithLabel(label);
 
-            this._signalsHandler.addWithLabel(label,
-                [
-                    this._box,
-                    'scroll-event',
-                    Lang.bind(this, onScrollEvent)
-                ]
-            );
+            this._signalsHandler.addWithLabel(label, [
+                this._box,
+                'scroll-event',
+                Lang.bind(this, onScrollEvent)
+            ]);
 
-            this._optionalScrollWorkspaceSwitchDeadTimeId=0;
+            this._optionalScrollWorkspaceSwitchDeadTimeId = 0;
         }
 
         function disable() {
             this._signalsHandler.removeWithLabel(label);
 
-            if(this._optionalScrollWorkspaceSwitchDeadTimeId>0) {
+            if (this._optionalScrollWorkspaceSwitchDeadTimeId > 0) {
                 Mainloop.source_remove(this._optionalScrollWorkspaceSwitchDeadTimeId);
-                this._optionalScrollWorkspaceSwitchDeadTimeId=0;
+                this._optionalScrollWorkspaceSwitchDeadTimeId = 0;
             }
         }
 
         // This was inspired to desktop-scroller@obsidien.github.com
         function onScrollEvent(actor, event) {
-
             // When in overview change workscape only in windows view
             if (Main.overview.visible && Main.overview.viewSelector.getActivePage() !== ViewSelector.ViewPage.WINDOWS)
                 return false;
@@ -1331,7 +1318,7 @@ const DockedDash = new Lang.Class({
             let activeWs = global.screen.get_active_workspace();
             let direction = null;
 
-            switch ( event.get_scroll_direction() ) {
+            switch (event.get_scroll_direction()) {
             case Clutter.ScrollDirection.UP:
                 direction = Meta.MotionDirection.UP;
                 break;
@@ -1340,32 +1327,25 @@ const DockedDash = new Lang.Class({
                 break;
             case Clutter.ScrollDirection.SMOOTH:
                 let [dx, dy] = event.get_scroll_delta();
-                if(dy < 0) {
+                if (dy < 0)
                     direction = Meta.MotionDirection.UP;
-                } else if(dy > 0) {
+                else if (dy > 0)
                     direction = Meta.MotionDirection.DOWN;
-                }
                 break;
             }
 
-            if(direction !==null ) {
-
+            if (direction !== null) {
                 // Prevent scroll events from triggering too many workspace switches
                 // by adding a 250ms deadtime between each scroll event.
                 // Usefull on laptops when using a touchpad.
 
                 // During the deadtime do nothing
-                if(this._optionalScrollWorkspaceSwitchDeadTimeId>0)
+                if (this._optionalScrollWorkspaceSwitchDeadTimeId > 0)
                     return false;
-                else {
-                    this._optionalScrollWorkspaceSwitchDeadTimeId =
-                            Mainloop.timeout_add(250,
-                                Lang.bind(this, function() {
-                                    this._optionalScrollWorkspaceSwitchDeadTimeId=0;
-                                }
-                    ));
-                }
-
+                else
+                    this._optionalScrollWorkspaceSwitchDeadTimeId = Mainloop.timeout_add(250, Lang.bind(this, function() {
+                        this._optionalScrollWorkspaceSwitchDeadTimeId = 0;
+                    }));
 
                 let ws;
 
@@ -1382,17 +1362,15 @@ const DockedDash = new Lang.Class({
                     });
 
                 // Do not show wokspaceSwithcer in overview
-                if(!Main.overview.visible)
-                  Main.wm._workspaceSwitcherPopup.display(direction, ws.index());
+                if (!Main.overview.visible)
+                    Main.wm._workspaceSwitcherPopup.display(direction, ws.index());
                 Main.wm.actionMoveWorkspace(ws);
 
                 return true;
-
-            } else {
-                return false;
             }
+            else
+                return false;
         }
-
     }
 });
 

--- a/extension.js
+++ b/extension.js
@@ -8,20 +8,17 @@ const Main = imports.ui.main;
 
 let settings;
 let dock;
-
 let oldDash;
 
 function init() {
 }
 
 function enable() {
-
     settings = Convenience.getSettings('org.gnome.shell.extensions.dash-to-dock');
     dock = new Docking.DockedDash(settings);
 
-    /* Pretend I'm the dash: meant to make appgrd swarm animation come from the
-     * right position of the appShowButton.
-     */
+    // Pretend I'm the dash: meant to make appgrd swarm animation come from the
+    // right position of the appShowButton.
     oldDash  = Main.overview._dash;
     Main.overview._dash = dock.dash;
     bindSettingsChanges();
@@ -41,9 +38,8 @@ function disable() {
 function bindSettingsChanges() {
     // This settings change require a full reload.
 
-    /* It's easier to just reload the extension when the dock position changes
-     * rather than working out all changes to the differen containers.
-     */
+    // It's easier to just reload the extension when the dock position changes
+    // rather than working out all changes to the differen containers.
     settings.connect('changed::dock-position', function() {
         disable();
         enable();

--- a/extension.js
+++ b/extension.js
@@ -1,10 +1,10 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
+const Main = imports.ui.main;
+
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 const Docking = Me.imports.docking;
-
-const Main = imports.ui.main;
 
 let settings;
 let dock;

--- a/extension.js
+++ b/extension.js
@@ -2,7 +2,7 @@
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
-const DockedDash = Me.imports.dockedDash;
+const Docking = Me.imports.docking;
 
 const Main = imports.ui.main;
 
@@ -12,13 +12,12 @@ let dock;
 let oldDash;
 
 function init() {
-
 }
 
 function enable() {
 
     settings = Convenience.getSettings('org.gnome.shell.extensions.dash-to-dock');
-    dock = new DockedDash.dockedDash(settings);
+    dock = new Docking.DockedDash(settings);
 
     /* Pretend I'm the dash: meant to make appgrd swarm animation come from the
      * right position of the appShowButton.
@@ -45,7 +44,7 @@ function bindSettingsChanges() {
     /* It's easier to just reload the extension when the dock position changes
      * rather than working out all changes to the differen containers.
      */
-    settings.connect('changed::dock-position', function(){
+    settings.connect('changed::dock-position', function() {
         disable();
         enable();
     });

--- a/icons.js
+++ b/icons.js
@@ -1,0 +1,547 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Clutter = imports.gi.Clutter;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const Gtk = imports.gi.Gtk;
+const Signals = imports.signals;
+const Lang = imports.lang;
+const Meta = imports.gi.Meta;
+const Shell = imports.gi.Shell;
+const St = imports.gi.St;
+const Mainloop = imports.mainloop;
+
+const AppDisplay = imports.ui.appDisplay;
+const AppFavorites = imports.ui.appFavorites;
+const Dash = imports.ui.dash;
+const DND = imports.ui.dnd;
+const IconGrid = imports.ui.iconGrid;
+const Main = imports.ui.main;
+const PopupMenu = imports.ui.popupMenu;
+const Tweener = imports.ui.tweener;
+const Util = imports.misc.util;
+const Workspace = imports.ui.workspace;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Convenience = Me.imports.convenience;
+const Windows = Me.imports.windows;
+
+/**
+ * Extend AppIcon
+ *
+ * - Pass settings to the constructor and bind settings changes
+ * - Apply a css class based on the number of windows of each application (#N);
+ * - Draw a dot for each window of the application based on the default "dot" style which is hidden (#N);
+ *   a class of the form "running#N" is applied to the AppWellIcon actor.
+ *   like the original .running one.
+ * - add a .focused style to the focused app
+ * - Customize click actions.
+ * - Update minimization animation target
+ *
+ */
+
+let tracker = Shell.WindowTracker.get_default();
+
+const clickAction = {
+    SKIP: 0,
+    MINIMIZE: 1,
+    LAUNCH: 2,
+    CYCLE_WINDOWS: 3
+};
+
+let recentlyClickedAppLoopId = 0;
+let recentlyClickedApp = null;
+let recentlyClickedAppWindows = null;
+let recentlyClickedAppIndex = 0;
+
+const MyAppIcon = new Lang.Class({
+    Name: 'DashToDock.AppIcon',
+    Extends: AppDisplay.AppIcon,
+
+    // settings are required inside.
+    _init: function(settings, app, iconParams, onActivateOverride) {
+
+        this._dtdSettings = settings;
+        this._nWindows = 0;
+
+        this.parent(app, iconParams, onActivateOverride);
+
+        // Monitor windows-changes instead of app state.
+        // Keep using the same Id and function callback (that is extended)
+        if(this._stateChangedId>0) {
+            this.app.disconnect(this._stateChangedId);
+            this._stateChangedId=0;
+        }
+
+        this._stateChangedId = this.app.connect('windows-changed',
+                                                Lang.bind(this,
+                                                          this.onWindowsChanged));
+        this._focuseAppChangeId = tracker.connect('notify::focus-app',
+                                                Lang.bind(this,
+                                                          this._onFocusAppChanged));
+
+        this._dots = null;
+
+        let keys = ['apply-custom-theme',
+                    'custom-theme-running-dots',
+                   'custom-theme-customize-running-dots',
+                   'custom-theme-running-dots-color',
+                   'custom-theme-running-dots-border-color',
+                   'custom-theme-running-dots-border-width'];
+
+        keys.forEach(function(key) {
+          this._dtdSettings.connect('changed::'+key,
+                                 Lang.bind(this, this._toggleDots)
+          );
+        }, this );
+
+        this._toggleDots();
+    },
+
+    _onDestroy: function() {
+        this.parent();
+
+        // Disconect global signals
+        // stateChangedId is already handled by parent)
+        if(this._focusAppId>0)
+            tracker.disconnect(this._focusAppId);
+    },
+
+    onWindowsChanged: function() {
+      this._updateRunningStyle();
+      this.updateIconGeometry();
+
+    },
+
+    // Update taraget for minimization animation
+    updateIconGeometry: function() {
+
+        // If (for unknown reason) the actor is not on the stage the reported size
+        // and position are random values, which might exceeds the integer range
+        // resulting in an error when assigned to the a rect. This is a more like
+        // a workaround to prevent flooding the system with errors.
+        if (this.actor.get_stage() == null)
+            return
+
+        let rect = new Meta.Rectangle();
+
+		if (Windows.isStolen(this.app)) {
+			if (this.actor.child) {
+				this.actor.child.destroy();
+				this.actor.child = null;
+			}
+		}
+
+		[rect.x, rect.y] = this.actor.get_transformed_position();
+		[rect.width, rect.height] = this.actor.get_transformed_size();
+
+        let windows = Windows.getAllWindows(this.app);
+        windows.forEach(function(w) {
+            w.set_icon_geometry(rect);
+        });
+
+    },
+
+    _toggleDots: function() {
+
+        if ( this._dtdSettings.get_boolean('custom-theme-running-dots')
+             || this._dtdSettings.get_boolean('apply-custom-theme') )
+            this._showDots();
+        else
+            this._hideDots();
+    },
+
+    _showDots: function() {
+        // I use opacity to hide the default dot because the show/hide function
+        // are used by the parent class.
+        this._dot.opacity = 0;
+
+        // Just update style if dots already exist
+        if (this._dots) {
+            this._updateCounterClass();
+            return;
+        }
+
+        this._dots = new St.DrawingArea({x_expand: true, y_expand: true});
+        this._dots.connect('repaint', Lang.bind(this,
+            function() {
+                    this._drawCircles(this._dots, Convenience.getPosition(this._dtdSettings));
+            }));
+        this._iconContainer.add_child(this._dots);
+        this._updateCounterClass();
+
+    },
+
+    _hideDots: function() {
+        this._dot.opacity=255;
+        if (this._dots)
+            this._dots.destroy()
+        this._dots = null;
+    },
+
+    _updateRunningStyle: function() {
+        this.parent();
+        this._updateCounterClass();
+    },
+
+    popupMenu: function() {
+        this._removeMenuTimeout();
+        this.actor.fake_release();
+        this._draggable.fakeRelease();
+
+        if (!this._menu) {
+            this._menu = new MyAppIconMenu(this, this._dtdSettings);
+            this._menu.connect('activate-window', Lang.bind(this, function (menu, window) {
+                this.activateWindow(window);
+            }));
+            this._menu.connect('open-state-changed', Lang.bind(this, function (menu, isPoppedUp) {
+                if (!isPoppedUp)
+                    this._onMenuPoppedDown();
+            }));
+            let id = Main.overview.connect('hiding', Lang.bind(this, function () { this._menu.close(); }));
+            this._menu.actor.connect('destroy', function() {
+                Main.overview.disconnect(id);
+            });
+
+            this._menuManager.addMenu(this._menu);
+        }
+
+        this.emit('menu-state-changed', true);
+
+        this.actor.set_hover(true);
+        this._menu.popup();
+        this._menuManager.ignoreRelease();
+        this.emit('sync-tooltip');
+
+        return false;
+    },
+
+    _onFocusAppChanged: function() {
+        if(tracker.focus_app == this.app)
+            this.actor.add_style_class_name('focused');
+        else
+            this.actor.remove_style_class_name('focused');
+    },
+
+    activate: function(button) {
+
+        if ( !this._dtdSettings.get_boolean('customize-click') ) {
+            this.parent(button);
+            return;
+        }
+        
+        let isRunning = Windows.isWindowStealer(this.app) ?
+			Windows.getAllWindows(this.app).length > 0 :
+			this.app.state == Shell.AppState.RUNNING;
+
+        let event = Clutter.get_current_event();
+        let modifiers = event ? event.get_state() : 0;
+        let openNewWindow = modifiers & Clutter.ModifierType.CONTROL_MASK &&
+                            isRunning ||
+                            button && button == 2;
+
+		let focusedApp = tracker.focus_app;
+        let isFocused = Windows.isWindowStealer(this.app) ?
+			Windows.isStealingFrom(this.app, focusedApp) :
+			this.app == focusedApp;
+
+        if (!isRunning || openNewWindow)
+            this.animateLaunch();
+
+        if(button && button == 1 && isRunning) {
+
+            if(modifiers & Clutter.ModifierType.CONTROL_MASK) {
+                // Keep default behaviour: launch new window
+                // By calling the parent method I make it compatible
+                // with other extensions tweaking ctrl + click
+                this.parent(button);
+                return;
+
+            } else if (this._dtdSettings.get_boolean('minimize-shift') && modifiers & Clutter.ModifierType.SHIFT_MASK) {
+                // On double click, minimize all windows in the current workspace
+                minimizeWindow(this.app, event.get_click_count() > 1);
+
+            } else if(isFocused && !Main.overview._shown) {
+
+                if(this._dtdSettings.get_enum('click-action') == clickAction.CYCLE_WINDOWS)
+                    cycleThroughWindows(this.app);
+                else if(this._dtdSettings.get_enum('click-action') == clickAction.MINIMIZE)
+                    minimizeWindow(this.app, true);
+                else if(this._dtdSettings.get_enum('click-action') == clickAction.LAUNCH)
+                    this.app.open_new_window(-1);
+
+            } else {
+                // Activate all window of the app or only le last used
+                if (this._dtdSettings.get_enum('click-action') == clickAction.CYCLE_WINDOWS && !Main.overview._shown) {
+                    // If click cycles through windows I can activate one windows at a time
+                    let windows = Windows.getInterestingWindows(this.app);
+                    let w = windows[0];
+                    Main.activateWindow(w);
+                } else if(this._dtdSettings.get_enum('click-action') == clickAction.LAUNCH)
+                    this.app.open_new_window(-1);
+                else if(this._dtdSettings.get_enum('click-action') == clickAction.MINIMIZE) {
+                    // If click minimizes all, then one expects all windows to be reshown
+                    activateAllWindows(this.app);
+                } else
+                    this.app.activate();
+            }
+        } else {
+         // Default behaviour
+         if (openNewWindow)
+            this.app.open_new_window(-1);
+         else
+            this.app.activate();
+        }
+
+        Main.overview.hide();
+    },
+
+    _updateCounterClass: function() {
+
+        let maxN = 4;
+        this._nWindows = Math.min(Windows.getInterestingWindows(this.app).length, maxN);
+
+        for(let i = 1; i<=maxN; i++) {
+            let className = 'running'+i;
+            if(i!=this._nWindows)
+                this.actor.remove_style_class_name(className);
+            else
+                this.actor.add_style_class_name(className);
+        }
+
+        if (this._dots)
+            this._dots.queue_repaint();
+    },
+
+    _drawCircles: function(area, side) {
+
+        let borderColor, borderWidth, bodyColor;
+
+        if (!this._dtdSettings.get_boolean('apply-custom-theme')
+            && this._dtdSettings.get_boolean('custom-theme-running-dots')
+            && this._dtdSettings.get_boolean('custom-theme-customize-running-dots')) {
+            borderColor = Clutter.color_from_string(this._dtdSettings.get_string('custom-theme-running-dots-border-color'))[1];
+            borderWidth = this._dtdSettings.get_int('custom-theme-running-dots-border-width');
+            bodyColor =  Clutter.color_from_string(this._dtdSettings.get_string('custom-theme-running-dots-color'))[1];
+        } else {
+            // Re-use the style - background color, and border width and color -
+            // of the default dot
+            let themeNode = this._dot.get_theme_node();
+            borderColor = themeNode.get_border_color(side);
+            borderWidth = themeNode.get_border_width(side);
+            bodyColor = themeNode.get_background_color();
+        }
+
+        let [width, height] = area.get_surface_size();
+        let cr = area.get_context();
+
+        // Draw the required numbers of dots
+        let radius = width/22 - borderWidth/2;
+        radius = Math.max(radius, borderWidth/4+1);
+        let padding = 0; // distance from the margin
+        let spacing = radius + borderWidth; // separation between the dots
+        let n = this._nWindows;
+
+        cr.setLineWidth(borderWidth);
+        Clutter.cairo_set_source_color(cr, borderColor);
+
+        switch (side) {
+        case St.Side.TOP:
+            cr.translate((width - (2*n)*radius - (n-1)*spacing)/2, padding);
+            for (let i=0; i<n;i++) {
+                cr.newSubPath();
+                cr.arc((2*i+1)*radius + i*spacing, radius + borderWidth/2, radius, 0, 2*Math.PI);
+            }
+            break;
+
+        case St.Side.BOTTOM:
+            cr.translate((width - (2*n)*radius - (n-1)*spacing)/2, height- padding- 2*radius);
+            for (let i=0; i<n;i++) {
+                cr.newSubPath();
+                cr.arc((2*i+1)*radius + i*spacing, radius + borderWidth/2, radius, 0, 2*Math.PI);
+            }
+            break;
+
+        case St.Side.LEFT:
+            cr.translate(padding, (height - (2*n)*radius - (n-1)*spacing)/2);
+            for (let i=0; i<n;i++) {
+                cr.newSubPath();
+                cr.arc(radius + borderWidth/2, (2*i+1)*radius + i*spacing, radius, 0, 2*Math.PI);
+            }
+            break;
+
+        case St.Side.RIGHT:
+            cr.translate(width - padding- 2*radius, (height - (2*n)*radius - (n-1)*spacing)/2);
+            for (let i=0; i<n;i++) {
+                cr.newSubPath();
+                cr.arc(radius + borderWidth/2, (2*i+1)*radius + i*spacing, radius, 0, 2*Math.PI);
+            }
+            break;
+        }
+
+        cr.strokePreserve();
+
+        Clutter.cairo_set_source_color(cr, bodyColor);
+        cr.fill();
+        cr.$dispose();
+    }
+
+});
+
+function minimizeWindow(app, param) {
+    // Param true make all app windows minimize
+    let windows = Windows.getInterestingWindows(app);
+    let current_workspace = global.screen.get_active_workspace();
+    for (let i = 0; i < windows.length; i++) {
+        let w = windows[i];
+        if (w.get_workspace() == current_workspace && w.showing_on_its_workspace()) {
+            w.minimize();
+            // Just minimize one window. By specification it should be the
+            // focused window on the current workspace.
+            if(!param)
+                break;
+        }
+    }
+}
+
+/*
+ * By default only non minimized windows are activated.
+ * This activates all windows in the current workspace.
+ */
+function activateAllWindows(app) {
+
+    // First activate first window so workspace is switched if needed.
+    if (!Windows.isWindowStealer(app))
+		app.activate();
+
+    // then activate all other app windows in the current workspace
+    let windows = Windows.getInterestingWindows(app);
+    let activeWorkspace = global.screen.get_active_workspace_index();
+
+    if( windows.length<=0)
+        return;
+
+    let activatedWindows = 0;
+
+    for (let i=windows.length-1; i>=0; i--) {
+        if(windows[i].get_workspace().index() == activeWorkspace) {
+            Main.activateWindow(windows[i]);
+            activatedWindows++;
+        }
+    }
+}
+
+function cycleThroughWindows(app) {
+
+    // Store for a little amount of time last clicked app and its windows
+    // since the order changes upon window interaction
+    let MEMORY_TIME=3000;
+
+    let app_windows = Windows.getInterestingWindows(app);
+
+    if(recentlyClickedAppLoopId>0)
+        Mainloop.source_remove(recentlyClickedAppLoopId);
+    recentlyClickedAppLoopId = Mainloop.timeout_add(MEMORY_TIME, resetRecentlyClickedApp);
+
+    // If there isn't already a list of windows for the current app,
+    // or the stored list is outdated, use the current windows list.
+    if( !recentlyClickedApp ||
+        recentlyClickedApp.get_id() != app.get_id() ||
+        recentlyClickedAppWindows.length != app_windows.length
+      ) {
+
+        recentlyClickedApp = app;
+        recentlyClickedAppWindows = app_windows;
+        recentlyClickedAppIndex = 0;
+    }
+
+    recentlyClickedAppIndex++;
+    let index = recentlyClickedAppIndex % recentlyClickedAppWindows.length;
+    let window = recentlyClickedAppWindows[index];
+
+    Main.activateWindow(window);
+}
+
+function resetRecentlyClickedApp() {
+
+    if(recentlyClickedAppLoopId>0)
+        Mainloop.source_remove(recentlyClickedAppLoopId);
+    recentlyClickedAppLoopId=0;
+    recentlyClickedApp =null;
+    recentlyClickedAppWindows = null;
+    recentlyClickedAppIndex = 0;
+
+    return false;
+}
+
+/**
+ * Extend AppIconMenu
+ *
+ * - Pass settings to the constructor
+ * - set popup arrow side based on dash orientation
+ * - Add close windows option based on quitfromdash extension
+ *   (https://github.com/deuill/shell-extension-quitfromdash)
+ */
+
+const MyAppIconMenu = new Lang.Class({
+    Name: 'DashToDock.MyAppIconMenu',
+    Extends: AppDisplay.AppIconMenu,
+
+    _init: function(source, settings) {
+
+        let side = Convenience.getPosition(settings);
+
+        // Damm it, there has to be a proper way of doing this...
+        // As I can't call the parent parent constructor (?) passing the side
+        // parameter, I overwite what I need later
+        this.parent(source);
+
+        // Change the initialized side where required.
+        this._arrowSide = side;
+        this._boxPointer._arrowSide = side;
+        this._boxPointer._userArrowSide = side;
+        
+        this._settings = settings;
+    },
+
+    // helper function for the quit windows abilities
+    _closeWindowInstance: function(metaWindow) {
+        metaWindow.delete(global.get_current_time());
+    },
+
+    _redisplay: function() {
+
+        this.parent();
+
+		// steal windows menu
+		this._appendSeparator();
+		this._stealWindowsMenuItem = this._appendMenuItem(_('Steal Windows'));
+		this._stealWindowsMenuItem.connect('activate', Lang.bind(this, function() {
+			
+			//let r = Util.spawn(['gnome-shell-extension-prefs', 'dash-to-dock@micxgx.gmail.com']);
+			//global.log('>>>>>>>>>>>> ' + r);
+			
+		}));
+
+        // quit menu
+        let app = this._source.app;
+        let count = Windows.getInterestingWindows(app).length;
+        if ( count > 0) {
+            this._appendSeparator();
+            let quitFromDashMenuText = "";
+            if (count == 1)
+                quitFromDashMenuText = _("Quit");
+            else
+                quitFromDashMenuText = _("Quit") + ' ' + count + ' ' + _("Windows");
+
+            this._quitfromDashMenuItem = this._appendMenuItem(quitFromDashMenuText);
+            this._quitfromDashMenuItem.connect('activate', Lang.bind(this, function() {
+                let app = this._source.app;
+                let windows = Windows.getAllWindows(app);
+                for (let i = 0; i < windows.length; i++) {
+                    this._closeWindowInstance(windows[i])
+                }
+            }));
+        }
+    }
+});

--- a/icons.js
+++ b/icons.js
@@ -501,12 +501,14 @@ const MyAppIconMenu = new Lang.Class({
         this.parent();
 
         // steal windows menu
-        this._appendSeparator();
-        this._stealWindowsMenuItem = this._appendMenuItem(_('Steal Windows'));
-        this._stealWindowsMenuItem.connect('activate', Lang.bind(this, function() {
-            let dialog = new Windows.WindowStealingSettings(this._source.app, this._dtdSettings);
-            dialog.open();
-        }));
+        if (this._dtdSettings.get_boolean('support-window-stealing')) {
+            this._appendSeparator();
+            this._stealWindowsMenuItem = this._appendMenuItem(_('Steal Windows'));
+            this._stealWindowsMenuItem.connect('activate', Lang.bind(this, function() {
+                let dialog = new Windows.WindowStealingSettings(this._source.app, this._dtdSettings);
+                dialog.open();
+            }));
+        }
 
         // quit menu
         let app = this._source.app;

--- a/intellihide.js
+++ b/intellihide.js
@@ -1,13 +1,14 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-const GLib = imports.gi.GLib;
 const Lang = imports.lang;
 const Mainloop = imports.mainloop;
+const Signals = imports.signals;
+
+const GLib = imports.gi.GLib;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
 
 const Main = imports.ui.main;
-const Signals = imports.signals;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;

--- a/intellihide.js
+++ b/intellihide.js
@@ -30,25 +30,24 @@ const IntellihideMode = {
 // List of windows type taken into account. Order is important (keep the original
 // enum order).
 const handledWindowTypes = [
-  Meta.WindowType.NORMAL,
-  Meta.WindowType.DOCK,
-  Meta.WindowType.DIALOG,
-  Meta.WindowType.MODAL_DIALOG,
-  Meta.WindowType.TOOLBAR,
-  Meta.WindowType.MENU,
-  Meta.WindowType.UTILITY,
-  Meta.WindowType.SPLASHSCREEN
+	Meta.WindowType.NORMAL,
+	Meta.WindowType.DOCK,
+	Meta.WindowType.DIALOG,
+	Meta.WindowType.MODAL_DIALOG,
+	Meta.WindowType.TOOLBAR,
+	Meta.WindowType.MENU,
+	Meta.WindowType.UTILITY,
+	Meta.WindowType.SPLASHSCREEN
 ];
 
-/*
+/**
  * A rough and ugly implementation of the intellihide behaviour.
  * Intallihide object: emit 'status-changed' signal when the overlap of windows
  * with the provided targetBoxClutter.ActorBox changes;
  * 
 */
-
-const intellihide = new Lang.Class({
-    Name: 'Intellihide',
+const Intellihide = new Lang.Class({
+    Name: 'DashToDock.Intellihide',
 
     _init: function(settings) {
 
@@ -110,7 +109,7 @@ const intellihide = new Lang.Class({
     enable: function() {
       this._isEnabled = true;
       this._status = OverlapStatus.UNDEFINED;
-      global.get_window_actors().forEach(function(win){
+      global.get_window_actors().forEach(function(win) {
                 this._addWindowSignals(win.get_meta_window())
             }, this);
       this._doCheckOverlap();
@@ -118,7 +117,7 @@ const intellihide = new Lang.Class({
 
     disable: function() {
         this._isEnabled = false;
-        global.get_window_actors().forEach(function(win){
+        global.get_window_actors().forEach(function(win) {
                 this._removeWindowSignals(win.get_meta_window())
             }, this);
 
@@ -167,7 +166,7 @@ const intellihide = new Lang.Class({
         this._doCheckOverlap();
     },
 
-    getOverlapStatus: function(){
+    getOverlapStatus: function() {
         if(this._status == OverlapStatus.TRUE)
             return true;
         else
@@ -180,7 +179,7 @@ const intellihide = new Lang.Class({
             return;
 
         /* Limit the number of calls to the doCheckOverlap function */
-        if(this._checkOverlapTimeoutId){
+        if(this._checkOverlapTimeoutId) {
             this._checkOverlapTimeoutContinue = true;
             return
         }
@@ -191,7 +190,7 @@ const intellihide = new Lang.Class({
                     Mainloop.timeout_add(INTELLIHIDE_CHECK_INTERVAL,
                         Lang.bind(this, function() {
                             this._doCheckOverlap();
-                            if (this._checkOverlapTimeoutContinue){
+                            if (this._checkOverlapTimeoutContinue) {
                                 this._checkOverlapTimeoutContinue = false;
                                 return GLib.SOURCE_CONTINUE;
                             } else {
@@ -210,7 +209,7 @@ const intellihide = new Lang.Class({
         let overlaps = OverlapStatus.FALSE;
         let windows = global.get_window_actors();
 
-        if (windows.length>0){
+        if (windows.length>0) {
 
 
             /*
@@ -243,10 +242,10 @@ const intellihide = new Lang.Class({
 
                 windows = windows.filter(this._intellihideFilterInteresting, this);
 
-                for(let i=0; i< windows.length; i++){
+                for(let i=0; i< windows.length; i++) {
 
                     let win = windows[i].get_meta_window();
-                    if(win){
+                    if(win) {
                         let rect = win.get_frame_rect();
 
                         let test = ( rect.x < this._targetBox.x2) &&
@@ -254,7 +253,7 @@ const intellihide = new Lang.Class({
                                    ( rect.y < this._targetBox.y2 ) &&
                                    ( rect.y +rect.height > this._targetBox.y1 );
 
-                        if(test){
+                        if(test) {
                             overlaps = OverlapStatus.TRUE;
                             break;
                         }
@@ -273,7 +272,7 @@ const intellihide = new Lang.Class({
     // Filter interesting windows to be considered for intellihide.
     // Consider all windows visible on the current workspace.
     // Optionally skip windows of other applications
-    _intellihideFilterInteresting: function(wa){
+    _intellihideFilterInteresting: function(wa) {
 
         let meta_win = wa.get_meta_window();
         if (!meta_win || !this._handledWindow(meta_win)) {
@@ -365,4 +364,4 @@ const intellihide = new Lang.Class({
 
 });
 
-Signals.addSignalMethods(intellihide.prototype);
+Signals.addSignalMethods(Intellihide.prototype);

--- a/intellihide.js
+++ b/intellihide.js
@@ -51,7 +51,7 @@ const Intellihide = new Lang.Class({
 
     _init: function(settings) {
         // Load settings
-        this._settings = settings;
+        this._dtdSettings = settings;
 
         this._signalsHandler = new Convenience.GlobalSignalsHandler();
         this._tracker = Shell.WindowTracker.get_default();
@@ -199,7 +199,7 @@ const Intellihide = new Lang.Class({
              * select a window in the secondary monitor.
              */
 
-            let monitorIndex = this._settings.get_int('preferred-monitor');
+            let monitorIndex = this._dtdSettings.get_int('preferred-monitor');
 
             if ((monitorIndex < 0) || (monitorIndex > Main.layoutManager.monitors.length))
                 monitorIndex = Main.layoutManager.primaryIndex;
@@ -259,7 +259,7 @@ const Intellihide = new Lang.Class({
         let wksp_index = wksp.index();
 
         // Depending on the intellihide mode, exclude non-relevent windows
-        switch (this._settings.get_enum('intellihide-mode')) {
+        switch (this._dtdSettings.get_enum('intellihide-mode')) {
             case IntellihideMode.ALL_WINDOWS:
                 // Do nothing
                 break;

--- a/intellihide.js
+++ b/intellihide.js
@@ -30,34 +30,32 @@ const IntellihideMode = {
 // List of windows type taken into account. Order is important (keep the original
 // enum order).
 const handledWindowTypes = [
-	Meta.WindowType.NORMAL,
-	Meta.WindowType.DOCK,
-	Meta.WindowType.DIALOG,
-	Meta.WindowType.MODAL_DIALOG,
-	Meta.WindowType.TOOLBAR,
-	Meta.WindowType.MENU,
-	Meta.WindowType.UTILITY,
-	Meta.WindowType.SPLASHSCREEN
+    Meta.WindowType.NORMAL,
+    Meta.WindowType.DOCK,
+    Meta.WindowType.DIALOG,
+    Meta.WindowType.MODAL_DIALOG,
+    Meta.WindowType.TOOLBAR,
+    Meta.WindowType.MENU,
+    Meta.WindowType.UTILITY,
+    Meta.WindowType.SPLASHSCREEN
 ];
 
 /**
  * A rough and ugly implementation of the intellihide behaviour.
  * Intallihide object: emit 'status-changed' signal when the overlap of windows
  * with the provided targetBoxClutter.ActorBox changes;
- * 
-*/
+ */
 const Intellihide = new Lang.Class({
     Name: 'DashToDock.Intellihide',
 
     _init: function(settings) {
-
         // Load settings
         this._settings = settings;
 
         this._signalsHandler = new Convenience.GlobalSignalsHandler();
         this._tracker = Shell.WindowTracker.get_default();
         this._focusApp = null; // The application whose window is focused.
-        this._topApp = null; //The application whose window is on top on the monitor with the dock.
+        this._topApp = null; // The application whose window is on top on the monitor with the dock.
 
         this._isEnabled = false;
         this.status = OverlapStatus.UNDEFINED;
@@ -67,35 +65,29 @@ const Intellihide = new Lang.Class({
         this._checkOverlapTimeoutId = 0;
 
         // Connect global signals
-        this._signalsHandler.add (
+        this._signalsHandler.add([
             // Add signals on windows created from now on
-            [
-                global.display,
-                'window-created',
-                Lang.bind(this, this._windowCreated)
-            ],
+            global.display,
+            'window-created',
+            Lang.bind(this, this._windowCreated)
+        ], [
             // triggered for instance when the window list order changes,
             // included when the workspace is switched
-            [
-                global.screen,
-                'restacked',
-                Lang.bind(this, this._checkOverlap)
-            ],
-            // when windows are alwasy on top, the focus window can change 
+            global.screen,
+            'restacked',
+            Lang.bind(this, this._checkOverlap)
+        ], [
+            // when windows are alwasy on top, the focus window can change
             // without the windows being restacked. Thus monitor window focus change.
-            [
-                this._tracker,
-                'notify::focus-app',
-                Lang.bind(this, this._checkOverlap)
-            ],
+            this._tracker,
+            'notify::focus-app',
+            Lang.bind(this, this._checkOverlap)
+        ], [
             // update wne monitor changes, for instance in multimonitor when monitor are attached
-            [
-                global.screen,
-                'monitors-changed',
-                Lang.bind(this, this._checkOverlap )
-            ]
-        );
-
+            global.screen,
+            'monitors-changed',
+            Lang.bind(this, this._checkOverlap )
+        ]);
     },
 
     destroy: function() {
@@ -107,21 +99,21 @@ const Intellihide = new Lang.Class({
     },
 
     enable: function() {
-      this._isEnabled = true;
-      this._status = OverlapStatus.UNDEFINED;
-      global.get_window_actors().forEach(function(win) {
-                this._addWindowSignals(win.get_meta_window())
-            }, this);
-      this._doCheckOverlap();
+        this._isEnabled = true;
+        this._status = OverlapStatus.UNDEFINED;
+        global.get_window_actors().forEach(function(win) {
+            this._addWindowSignals(win.get_meta_window());
+        }, this);
+        this._doCheckOverlap();
     },
 
     disable: function() {
         this._isEnabled = false;
         global.get_window_actors().forEach(function(win) {
-                this._removeWindowSignals(win.get_meta_window())
-            }, this);
+            this._removeWindowSignals(win.get_meta_window());
+        }, this);
 
-        if(this._checkOverlapTimeoutId>0) {
+        if (this._checkOverlapTimeoutId > 0) {
             Mainloop.source_remove(this._checkOverlapTimeoutId);
             this._checkOverlapTimeoutId = 0;
         }
@@ -132,27 +124,23 @@ const Intellihide = new Lang.Class({
     },
 
     _addWindowSignals: function(meta_win) {
-            if(!meta_win || !this._handledWindow(meta_win))
-                return;
+        if (!meta_win || !this._handledWindow(meta_win))
+            return;
 
-            meta_win.dtd_onPositionChanged = meta_win.connect(
-                'position-changed', Lang.bind(this, this._checkOverlap, meta_win)
-            );
+        meta_win.dtd_onPositionChanged = meta_win.connect('position-changed', Lang.bind(this, this._checkOverlap, meta_win));
 
-            meta_win.dtd_onSizeChanged = meta_win.connect(
-                'size-changed', Lang.bind(this, this._checkOverlap, meta_win)
-            );
+        meta_win.dtd_onSizeChanged = meta_win.connect('size-changed', Lang.bind(this, this._checkOverlap, meta_win));
     },
 
     _removeWindowSignals: function(meta_win) {
-        if( meta_win && meta_win.dtd_onSizeChanged ) {
-               meta_win.disconnect(meta_win.dtd_onSizeChanged);
-               delete meta_win.dtd_onSizeChanged;
+        if (meta_win && meta_win.dtd_onSizeChanged) {
+           meta_win.disconnect(meta_win.dtd_onSizeChanged);
+           delete meta_win.dtd_onSizeChanged;
         }
 
-        if( meta_win && meta_win.dtd_onPositionChanged ) {
-               meta_win.disconnect(meta_win.dtd_onPositionChanged);
-               delete meta_win.dtd_onPositionChanged;
+        if (meta_win && meta_win.dtd_onPositionChanged) {
+           meta_win.disconnect(meta_win.dtd_onPositionChanged);
+           delete meta_win.dtd_onPositionChanged;
         }
     },
 
@@ -167,51 +155,42 @@ const Intellihide = new Lang.Class({
     },
 
     getOverlapStatus: function() {
-        if(this._status == OverlapStatus.TRUE)
-            return true;
-        else
-            return false;
+        return (this._status == OverlapStatus.TRUE);
     },
 
     _checkOverlap: function() {
-
-        if( !this._isEnabled || this._targetBox == null)
+        if (!this._isEnabled || (this._targetBox == null))
             return;
 
         /* Limit the number of calls to the doCheckOverlap function */
-        if(this._checkOverlapTimeoutId) {
+        if (this._checkOverlapTimeoutId) {
             this._checkOverlapTimeoutContinue = true;
             return
         }
 
         this._doCheckOverlap();
 
-        this._checkOverlapTimeoutId =
-                    Mainloop.timeout_add(INTELLIHIDE_CHECK_INTERVAL,
-                        Lang.bind(this, function() {
-                            this._doCheckOverlap();
-                            if (this._checkOverlapTimeoutContinue) {
-                                this._checkOverlapTimeoutContinue = false;
-                                return GLib.SOURCE_CONTINUE;
-                            } else {
-                                this._checkOverlapTimeoutId = 0;
-                                return GLib.SOURCE_REMOVE;
-                            }
-                        }
-            ));
+        this._checkOverlapTimeoutId = Mainloop.timeout_add(INTELLIHIDE_CHECK_INTERVAL, Lang.bind(this, function() {
+            this._doCheckOverlap();
+            if (this._checkOverlapTimeoutContinue) {
+                this._checkOverlapTimeoutContinue = false;
+                return GLib.SOURCE_CONTINUE;
+            } else {
+                this._checkOverlapTimeoutId = 0;
+                return GLib.SOURCE_REMOVE;
+            }
+        }));
     },
 
     _doCheckOverlap: function() {
 
-        if( !this._isEnabled || this._targetBox == null)
+        if (!this._isEnabled || (this._targetBox == null))
             return;
 
         let overlaps = OverlapStatus.FALSE;
         let windows = global.get_window_actors();
 
-        if (windows.length>0) {
-
-
+        if (windows.length > 0) {
             /*
              * Get the top window on the monitor where the dock is placed.
              * The idea is that we dont want to overlap with the windows of the topmost application,
@@ -221,39 +200,36 @@ const Intellihide = new Lang.Class({
 
             let monitorIndex = this._settings.get_int('preferred-monitor');
 
-            if (monitorIndex < 0 || monitorIndex > Main.layoutManager.monitors.length)
+            if ((monitorIndex < 0) || (monitorIndex > Main.layoutManager.monitors.length))
                 monitorIndex = Main.layoutManager.primaryIndex;
 
             let topWindow = null;
-            for (let i = windows.length-1; i>=0; i--) {
+            for (let i = windows.length - 1; i >= 0; i--) {
                 let meta_win = windows[i].get_meta_window();
-                if (this._handledWindow(meta_win)
-                    && meta_win.get_monitor() == monitorIndex) {
+                if (this._handledWindow(meta_win) && (meta_win.get_monitor() == monitorIndex)) {
                     topWindow = meta_win;
                     break;
                 }
             }
 
             if (topWindow !== null) {
-
                 this._topApp = this._tracker.get_window_app(topWindow);
                 // If there isn't a focused app, use that of the window on top
                 this._focusApp = this._tracker.focus_app || this._topApp
 
                 windows = windows.filter(this._intellihideFilterInteresting, this);
 
-                for(let i=0; i< windows.length; i++) {
-
+                for (let i in windows.length) {
                     let win = windows[i].get_meta_window();
-                    if(win) {
+                    if (win) {
                         let rect = win.get_frame_rect();
 
-                        let test = ( rect.x < this._targetBox.x2) &&
-                                   ( rect.x +rect.width > this._targetBox.x1 ) &&
-                                   ( rect.y < this._targetBox.y2 ) &&
-                                   ( rect.y +rect.height > this._targetBox.y1 );
+                        let test = (rect.x < this._targetBox.x2) &&
+                                   (rect.x + rect.width > this._targetBox.x1) &&
+                                   (rect.y < this._targetBox.y2) &&
+                                   (rect.y + rect.height > this._targetBox.y1);
 
-                        if(test) {
+                        if (test) {
                             overlaps = OverlapStatus.TRUE;
                             break;
                         }
@@ -262,7 +238,7 @@ const Intellihide = new Lang.Class({
             }
         }
 
-        if ( this._status !== overlaps ) {
+        if (this._status !== overlaps) {
             this._status = overlaps;
             this.emit('status-changed', this._status);
         }
@@ -273,11 +249,9 @@ const Intellihide = new Lang.Class({
     // Consider all windows visible on the current workspace.
     // Optionally skip windows of other applications
     _intellihideFilterInteresting: function(wa) {
-
         let meta_win = wa.get_meta_window();
-        if (!meta_win || !this._handledWindow(meta_win)) {
+        if (!meta_win || !this._handledWindow(meta_win))
             return false;
-        }
 
         let currentWorkspace = global.screen.get_active_workspace_index();
         let wksp = meta_win.get_workspace();
@@ -291,7 +265,7 @@ const Intellihide = new Lang.Class({
 
             case IntellihideMode.FOCUS_APPLICATION_WINDOWS:
                 // Skip windows of other apps
-                if (this._focusApp ) {
+                if (this._focusApp) {
                     // The DropDownTerminal extension is not an application per se
                     // so we match its window by wm class instead
                     if (meta_win.get_wm_class() == 'DropDownTerminalWindow')
@@ -302,21 +276,18 @@ const Intellihide = new Lang.Class({
 
                     // Consider half maximized windows side by side
                     // and windows which are alwayson top
-                    if( currentApp != this._focusApp && currentApp != this._topApp
-                        && !( (focusWindow && focusWindow.maximized_vertically && !focusWindow.maximized_horizontally)
+                    if((currentApp != this._focusApp) && (currentApp != this._topApp)
+                        && !((focusWindow && focusWindow.maximized_vertically && !focusWindow.maximized_horizontally)
                               && (meta_win.maximized_vertically && !meta_win.maximized_horizontally)
-                              && meta_win.get_monitor() == focusWindow.get_monitor()
-                            )
-                        && !meta_win.is_above()
-                      ) {
+                              && meta_win.get_monitor() == focusWindow.get_monitor())
+                        && !meta_win.is_above())
                         return false;
-                    }
                 }
                 break;
 
             case IntellihideMode.MAXIMIZED_WINDOWS:
                 // Skip unmaximized windows
-                if (!meta_win.maximized_vertically  &&  !meta_win.maximized_horizontally)
+                if (!meta_win.maximized_vertically && !meta_win.maximized_horizontally)
                     return false;
                 break;
         }
@@ -332,12 +303,11 @@ const Intellihide = new Lang.Class({
            start hiding the dock, which is readily reshown as soon as the window
            position is updated.
         */
-        if ( wksp_index == currentWorkspace && meta_win.showing_on_its_workspace()
-            && (Main.overview.visible || wa.mapped)) {
+        if (wksp_index == currentWorkspace && meta_win.showing_on_its_workspace()
+            && (Main.overview.visible || wa.mapped))
             return true;
-        } else {
+        else
             return false;
-        }
 
     },
 
@@ -349,19 +319,16 @@ const Intellihide = new Lang.Class({
         if (metaWindow.get_wm_class() == 'DropDownTerminalWindow')
             return true;
 
-        var wtype = metaWindow.get_window_type();
-        for (var i = 0; i < handledWindowTypes.length; i++) {
+        let wtype = metaWindow.get_window_type();
+        for (let i in handledWindowTypes) {
             var hwtype = handledWindowTypes[i];
-            if (hwtype == wtype) {
+            if (hwtype == wtype)
                 return true;
-            } else if (hwtype > wtype) {
+            else if (hwtype > wtype)
                 return false;
-            }
         }
         return false;
-
     }
-
 });
 
 Signals.addSignalMethods(Intellihide.prototype);

--- a/prefs.js
+++ b/prefs.js
@@ -1,4 +1,4 @@
-// -*- mode: js2; indent-tabs-mode: nil; js2-basic-offset: 4 -*-
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
@@ -7,7 +7,6 @@ const Gtk = imports.gi.Gtk;
 const Gdk = imports.gi.Gdk;
 const Lang = imports.lang;
 const Mainloop = imports.mainloop;
-
 
 const Gettext = imports.gettext.domain('dashtodock');
 const _ = Gettext.gettext;
@@ -20,11 +19,11 @@ const Convenience = Me.imports.convenience;
 const SCALE_UPDATE_TIMEOUT = 500;
 const DEFAULT_ICONS_SIZES = [ 128, 96, 64, 48, 32, 24, 16 ];
 
-/*
-This function was copied from the activities-config extension
-https://github.com/nls1729/acme-code/tree/master/activities-config
-by Norman L. Smith.
-*/
+/**
+ * This function was copied from the activities-config extension
+ * https://github.com/nls1729/acme-code/tree/master/activities-config
+ * by Norman L. Smith.
+ */
 function cssHexString(css) {
     let rrggbb = '#';
     let start;
@@ -52,10 +51,8 @@ function cssHexString(css) {
     return rrggbb;
 }
 
-
 const Settings = new Lang.Class({
-    Name: 'DashToDockSettings',
-
+    Name: 'DashToDock.Settings',
 
     _init: function() {
 
@@ -105,7 +102,7 @@ const Settings = new Lang.Class({
         // Add connected monitors
         let ctr = 0;
         for (let i = 0; i < n_monitors; i++) {
-            if (i !== primary_monitor){
+            if (i !== primary_monitor) {
                 ctr++;
                 this._monitors.push(ctr);
                 this._builder.get_object('dock_monitor_combo').append_text(_("Secondary monitor ") + ctr);
@@ -250,7 +247,7 @@ const Settings = new Lang.Class({
                     // restore default settings for the relevant keys
                     let keys = ['intellihide', 'autohide', 'intellihide-mode', 'autohide-in-fullscreen', 'require-pressure-to-show',
                                 'animation-time', 'show-delay', 'hide-delay', 'pressure-threshold'];
-                    keys.forEach(function(val){
+                    keys.forEach(function(val) {
                         this._settings.set_value(val, this._settings.get_default_value(val));
                     }, this);
                     intellihideModeRadioButtons[this._settings.get_enum('intellihide-mode')].set_active(true);
@@ -272,7 +269,7 @@ const Settings = new Lang.Class({
         let icon_size_scale = this._builder.get_object('icon_size_scale');
         icon_size_scale.set_range(DEFAULT_ICONS_SIZES[DEFAULT_ICONS_SIZES.length -1], DEFAULT_ICONS_SIZES[0]);
         icon_size_scale.set_value(this._settings.get_int('dash-max-icon-size'));
-        DEFAULT_ICONS_SIZES.forEach(function(val){
+        DEFAULT_ICONS_SIZES.forEach(function(val) {
                 icon_size_scale.add_mark(val, Gtk.PositionType.TOP, val.toString());
         });
 
@@ -420,7 +417,6 @@ const Settings = new Lang.Class({
 
     },
 
-
     // Object containing all signals defined in the glade file
     _SignalHandler: {
 
@@ -428,7 +424,7 @@ const Settings = new Lang.Class({
                 this._settings.set_int('preferred-monitor', this._monitors[combo.get_active()]);
             },
 
-            position_top_button_toggled_cb: function (button){
+            position_top_button_toggled_cb: function (button) {
                 if (button.get_active()) 
                     this._settings.set_enum('dock-position', 0);
             },
@@ -456,12 +452,12 @@ const Settings = new Lang.Class({
                 return Math.round(value*100)+ ' %';
             },
 
-            dock_size_scale_value_changed_cb: function(scale){
+            dock_size_scale_value_changed_cb: function(scale) {
                 // Avoid settings the size consinuosly
                 if (this._dock_size_timeout >0)
                     Mainloop.source_remove(this._dock_size_timeout);
 
-                this._dock_size_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function(){
+                this._dock_size_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function() {
                     this._settings.set_double('height-fraction', scale.get_value());
                     this._dock_size_timeout = 0;
                     return GLib.SOURCE_REMOVE;
@@ -472,24 +468,24 @@ const Settings = new Lang.Class({
                 return value+ ' px';
             },
 
-            icon_size_scale_value_changed_cb: function(scale){
+            icon_size_scale_value_changed_cb: function(scale) {
                 // Avoid settings the size consinuosly
                 if (this._icon_size_timeout >0)
                     Mainloop.source_remove(this._icon_size_timeout);
 
-                this._icon_size_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function(){
+                this._icon_size_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function() {
                     this._settings.set_int('dash-max-icon-size', scale.get_value());
                     this._icon_size_timeout = 0;
                     return GLib.SOURCE_REMOVE;
                 }));       
             },
 
-            custom_opacity_scale_value_changed_cb: function(scale){
+            custom_opacity_scale_value_changed_cb: function(scale) {
                 // Avoid settings the opacity consinuosly as it's change is animated
                 if (this._opacity_timeout >0)
                     Mainloop.source_remove(this._opacity_timeout);
 
-                this._opacity_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function(){
+                this._opacity_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function() {
                     this._settings.set_double('background-opacity', scale.get_value());
                     this._opacity_timeout = 0;
                     return GLib.SOURCE_REMOVE;
@@ -500,17 +496,17 @@ const Settings = new Lang.Class({
                 return Math.round(value*100) + ' %';
             },
 
-            all_windows_radio_button_toggled_cb: function (button){
+            all_windows_radio_button_toggled_cb: function (button) {
                 if (button.get_active())
                     this._settings.set_enum('intellihide-mode', 0);
             },
 
-            focus_application_windows_radio_button_toggled_cb: function (button){
+            focus_application_windows_radio_button_toggled_cb: function (button) {
                 if (button.get_active())
                     this._settings.set_enum('intellihide-mode', 1);
             },
 
-            maximized_windows_radio_button_toggled_cb: function (button){
+            maximized_windows_radio_button_toggled_cb: function (button) {
                 if (button.get_active())
                     this._settings.set_enum('intellihide-mode', 2);
             }

--- a/prefs.js
+++ b/prefs.js
@@ -1,12 +1,13 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
+const Lang = imports.lang;
+const Mainloop = imports.mainloop;
+
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Gdk = imports.gi.Gdk;
-const Lang = imports.lang;
-const Mainloop = imports.mainloop;
 
 const Gettext = imports.gettext.domain('dashtodock');
 const _ = Gettext.gettext;
@@ -17,7 +18,7 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 
 const SCALE_UPDATE_TIMEOUT = 500;
-const DEFAULT_ICONS_SIZES = [ 128, 96, 64, 48, 32, 24, 16 ];
+const DEFAULT_ICONS_SIZES = [128, 96, 64, 48, 32, 24, 16];
 
 /**
  * This function was copied from the activities-config extension

--- a/prefs.js
+++ b/prefs.js
@@ -27,25 +27,25 @@ const DEFAULT_ICONS_SIZES = [ 128, 96, 64, 48, 32, 24, 16 ];
 function cssHexString(css) {
     let rrggbb = '#';
     let start;
-    for(let loop = 0; loop < 3; loop++) {
+    for (let loop = 0; loop < 3; loop++) {
         let end = 0;
         let xx = '';
-        for(let loop = 0; loop < 2; loop++) {
-            while(true) {
+        for (let loop = 0; loop < 2; loop++) {
+            while (true) {
                 let x = css.slice(end, end + 1);
-                if(x == '(' || x == ',' || x == ')')
+                if ((x == '(') || (x == ',') || (x == ')'))
                     break;
-                end = end + 1;
+                end++;
             }
-            if(loop == 0) {
-                end = end + 1;
+            if (loop == 0) {
+                end++;
                 start = end;
             }
         }
         xx = parseInt(css.slice(start, end)).toString(16);
-        if(xx.length == 1)
+        if (xx.length == 1)
             xx = '0' + xx;
-        rrggbb = rrggbb + xx;
+        rrggbb += xx;
         css = css.slice(end);
     }
     return rrggbb;
@@ -55,10 +55,9 @@ const Settings = new Lang.Class({
     Name: 'DashToDock.Settings',
 
     _init: function() {
-
         this._settings = Convenience.getSettings('org.gnome.shell.extensions.dash-to-dock');
 
-        this._rtl = Gtk.Widget.get_default_direction()==Gtk.TextDirection.RTL;
+        this._rtl = (Gtk.Widget.get_default_direction() == Gtk.TextDirection.RTL);
 
         this._builder = new Gtk.Builder();
         this._builder.set_translation_domain(Me.metadata['gettext-domain']);
@@ -74,17 +73,17 @@ const Settings = new Lang.Class({
         this._bindSettings();
 
         this._builder.connect_signals_full(Lang.bind(this, this._connector));
-
     },
 
-    // Connect signals
+    /**
+     * Connect signals
+     */
     _connector: function(builder, object, signal, handler) {
         object.connect(signal, Lang.bind(this, this._SignalHandler[handler]));
     },
 
     _bindSettings: function() {
-
-        /* Position and size panel */
+        // Position and size panel
 
         // Monitor options
 
@@ -96,7 +95,7 @@ const Settings = new Lang.Class({
         let monitor = this._settings.get_int('preferred-monitor');
 
         // Add primary monitor with index 0, because in GNOME Shell the primary monitor is always 0
-        this._builder.get_object('dock_monitor_combo').append_text(_("Primary monitor"));
+        this._builder.get_object('dock_monitor_combo').append_text(_('Primary monitor'));
         this._monitors.push(0);
 
         // Add connected monitors
@@ -105,14 +104,14 @@ const Settings = new Lang.Class({
             if (i !== primary_monitor) {
                 ctr++;
                 this._monitors.push(ctr);
-                this._builder.get_object('dock_monitor_combo').append_text(_("Secondary monitor ") + ctr);
+                this._builder.get_object('dock_monitor_combo').append_text(_('Secondary monitor ') + ctr);
             }
         }
 
         // If one of the external monitor is set as preferred, show it even if not attached
-        if ( monitor >= n_monitors && monitor !== primary_monitor) {
+        if ((monitor >= n_monitors) && (monitor !== primary_monitor)) {
             this._monitors.push(monitor)
-            this._builder.get_object('dock_monitor_combo').append_text(_("Secondary monitor ") + ++ctr);
+            this._builder.get_object('dock_monitor_combo').append_text(_('Secondary monitor ') + ++ctr);
         }
 
         this._builder.get_object('dock_monitor_combo').set_active(this._monitors.indexOf(monitor));
@@ -137,8 +136,8 @@ const Settings = new Lang.Class({
 
         if (this._rtl) {
             /* Left is Right in rtl as a setting */
-            this._builder.get_object('position_left_button').set_label(_("Right"));
-            this._builder.get_object('position_right_button').set_label(_("Left"));
+            this._builder.get_object('position_left_button').set_label(_('Right'));
+            this._builder.get_object('position_right_button').set_label(_('Left'));
         }
 
         // Intelligent autohide options
@@ -188,14 +187,14 @@ const Settings = new Lang.Class({
         // Create dialog for intelligent autohide advanced settings
         this._builder.get_object('intelligent_autohide_button').connect('clicked', Lang.bind(this, function() {
 
-            let dialog = new Gtk.Dialog({ title: _("Intelligent autohide customization"),
+            let dialog = new Gtk.Dialog({ title: _('Intelligent autohide customization'),
                                           transient_for: this.widget.get_toplevel(),
                                           use_header_bar: true,
                                           modal: true });
 
             // GTK+ leaves positive values for application-defined response ids.
-            // Use +1 for the reset action 
-            dialog.add_button(_("Reset to defaults"), 1);
+            // Use +1 for the reset action
+            dialog.add_button(_('Reset to defaults'), 1);
 
             let box = this._builder.get_object('intelligent_autohide_advanced_settings_box');
             dialog.get_content_area().add(box);
@@ -270,7 +269,7 @@ const Settings = new Lang.Class({
         icon_size_scale.set_range(DEFAULT_ICONS_SIZES[DEFAULT_ICONS_SIZES.length -1], DEFAULT_ICONS_SIZES[0]);
         icon_size_scale.set_value(this._settings.get_int('dash-max-icon-size'));
         DEFAULT_ICONS_SIZES.forEach(function(val) {
-                icon_size_scale.add_mark(val, Gtk.PositionType.TOP, val.toString());
+             icon_size_scale.add_mark(val, Gtk.PositionType.TOP, val.toString());
         });
 
         // Corrent for rtl languages
@@ -278,10 +277,9 @@ const Settings = new Lang.Class({
             // Flip value position: this is not done automatically
             this._builder.get_object('dock_size_scale').set_value_pos(Gtk.PositionType.LEFT);
             icon_size_scale.set_value_pos(Gtk.PositionType.LEFT);
-            /* I suppose due to a bug, having a more than one mark and one above a value of 100
-             * makes the rendering of the marks wrong in rtl. This doesn't happen setting the scale as not flippable
-             * and then manually inverting it
-             */
+            // I suppose due to a bug, having a more than one mark and one above a value of 100
+            // makes the rendering of the marks wrong in rtl. This doesn't happen setting the scale as not flippable
+            // and then manually inverting it
             icon_size_scale.set_flippable(false);
             icon_size_scale.set_inverted(true);
         }
@@ -291,7 +289,7 @@ const Settings = new Lang.Class({
         this._settings.bind('extend-height', this._builder.get_object('dock_size_scale'), 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN);
 
 
-        /* Behavior panel */
+        // Behavior panel
 
         this._settings.bind('show-running',
                             this._builder.get_object('show_running_switch'),
@@ -324,18 +322,18 @@ const Settings = new Lang.Class({
 
         this._builder.get_object('click_action_combo').set_active(this._settings.get_enum('click-action'));
         this._builder.get_object('click_action_combo').connect('changed', Lang.bind (this, function(widget) {
-                this._settings.set_enum('click-action', widget.get_active());
+            this._settings.set_enum('click-action', widget.get_active());
         }));
 
         this._builder.get_object('shift_click_action_combo').set_active(this._settings.get_boolean('minimize-shift')?1:0);
 
         this._builder.get_object('shift_click_action_combo').connect('changed', Lang.bind (this, function(widget) {
-                this._settings.set_boolean('minimize-shift', widget.get_active()==1);
+            this._settings.set_boolean('minimize-shift', widget.get_active()==1);
         }));
 
         this._settings.bind('scroll-switch-workspace', this._builder.get_object('switch_workspace_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
 
-        /* Appearance Panel */
+        // Appearance Panel
 
         this._settings.bind('apply-custom-theme', this._builder.get_object('customize_theme'), 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN | Gio.SettingsBindFlags.GET);
         this._settings.bind('apply-custom-theme', this._builder.get_object('builtin_theme_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
@@ -353,7 +351,7 @@ const Settings = new Lang.Class({
         // Create dialog for running dots advanced settings
         this._builder.get_object('running_dots_advance_settings_button').connect('clicked', Lang.bind(this, function() {
 
-            let dialog = new Gtk.Dialog({ title: _("Customize running indicators"),
+            let dialog = new Gtk.Dialog({ title: _('Customize running indicators'),
                                           transient_for: this.widget.get_toplevel(),
                                           use_header_bar: true,
                                           modal: true });
@@ -411,105 +409,105 @@ const Settings = new Lang.Class({
         this._builder.get_object('custom_opacity_scale').set_value(this._settings.get_double('background-opacity'));
         this._settings.bind('opaque-background', this._builder.get_object('custom_opacity'), 'sensitive', Gio.SettingsBindFlags.DEFAULT);
 
-        /* About Panel */
+        // About Panel
 
         this._builder.get_object('extension_version').set_label(Me.metadata.version.toString());
-
     },
 
-    // Object containing all signals defined in the glade file
+    /**
+     * Object containing all signals defined in the glade file
+     */
     _SignalHandler: {
+        dock_display_combo_changed_cb: function(combo) {
+            this._settings.set_int('preferred-monitor', this._monitors[combo.get_active()]);
+        },
 
-            dock_display_combo_changed_cb: function (combo) {
-                this._settings.set_int('preferred-monitor', this._monitors[combo.get_active()]);
-            },
+        position_top_button_toggled_cb: function(button) {
+            if (button.get_active())
+                this._settings.set_enum('dock-position', 0);
+        },
 
-            position_top_button_toggled_cb: function (button) {
-                if (button.get_active()) 
-                    this._settings.set_enum('dock-position', 0);
-            },
+        position_right_button_toggled_cb: function(button) {
+            if (button.get_active())
+                this._settings.set_enum('dock-position', 1);
+        },
 
-            position_right_button_toggled_cb: function (button) {
-                if (button.get_active()) 
-                    this._settings.set_enum('dock-position', 1);
-            },
+        position_bottom_button_toggled_cb: function(button) {
+            if (button.get_active())
+                this._settings.set_enum('dock-position', 2);
+        },
 
-            position_bottom_button_toggled_cb: function (button) {
-                if (button.get_active()) 
-                    this._settings.set_enum('dock-position', 2);
-            },
+        position_left_button_toggled_cb: function(button) {
+            if (button.get_active())
+                this._settings.set_enum('dock-position', 3);
+        },
 
-            position_left_button_toggled_cb: function (button) {
-                if (button.get_active()) 
-                    this._settings.set_enum('dock-position', 3);
-            },
+        icon_size_combo_changed_cb: function(combo) {
+            this._settings.set_int('dash-max-icon-size', this._allIconSizes[combo.get_active()]);
+        },
 
-            icon_size_combo_changed_cb: function(combo) {
-                this._settings.set_int('dash-max-icon-size', this._allIconSizes[combo.get_active()]);
-            },
+        dock_size_scale_format_value_cb: function(scale, value) {
+            return Math.round(value*100)+ ' %';
+        },
 
-            dock_size_scale_format_value_cb: function(scale, value) {
-                return Math.round(value*100)+ ' %';
-            },
+        dock_size_scale_value_changed_cb: function(scale) {
+            // Avoid settings the size consinuosly
+            if (this._dock_size_timeout > 0)
+                Mainloop.source_remove(this._dock_size_timeout);
 
-            dock_size_scale_value_changed_cb: function(scale) {
-                // Avoid settings the size consinuosly
-                if (this._dock_size_timeout >0)
-                    Mainloop.source_remove(this._dock_size_timeout);
+            this._dock_size_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function() {
+                this._settings.set_double('height-fraction', scale.get_value());
+                this._dock_size_timeout = 0;
+                return GLib.SOURCE_REMOVE;
+            }));
+        },
 
-                this._dock_size_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function() {
-                    this._settings.set_double('height-fraction', scale.get_value());
-                    this._dock_size_timeout = 0;
-                    return GLib.SOURCE_REMOVE;
-                }));       
-            },
+        icon_size_scale_format_value_cb: function(scale, value) {
+            return value+ ' px';
+        },
 
-            icon_size_scale_format_value_cb: function(scale, value) {
-                return value+ ' px';
-            },
+        icon_size_scale_value_changed_cb: function(scale) {
+            // Avoid settings the size consinuosly
+            if (this._icon_size_timeout > 0)
+                Mainloop.source_remove(this._icon_size_timeout);
 
-            icon_size_scale_value_changed_cb: function(scale) {
-                // Avoid settings the size consinuosly
-                if (this._icon_size_timeout >0)
-                    Mainloop.source_remove(this._icon_size_timeout);
+            this._icon_size_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function() {
+                this._settings.set_int('dash-max-icon-size', scale.get_value());
+                this._icon_size_timeout = 0;
+                return GLib.SOURCE_REMOVE;
+            }));
+        },
 
-                this._icon_size_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function() {
-                    this._settings.set_int('dash-max-icon-size', scale.get_value());
-                    this._icon_size_timeout = 0;
-                    return GLib.SOURCE_REMOVE;
-                }));       
-            },
+        custom_opacity_scale_value_changed_cb: function(scale) {
+            // Avoid settings the opacity consinuosly as it's change is animated
+            if (this._opacity_timeout > 0)
+                Mainloop.source_remove(this._opacity_timeout);
 
-            custom_opacity_scale_value_changed_cb: function(scale) {
-                // Avoid settings the opacity consinuosly as it's change is animated
-                if (this._opacity_timeout >0)
-                    Mainloop.source_remove(this._opacity_timeout);
+            this._opacity_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function() {
+                this._settings.set_double('background-opacity', scale.get_value());
+                this._opacity_timeout = 0;
+                return GLib.SOURCE_REMOVE;
+            }));
+        },
 
-                this._opacity_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function() {
-                    this._settings.set_double('background-opacity', scale.get_value());
-                    this._opacity_timeout = 0;
-                    return GLib.SOURCE_REMOVE;
-                }));
-            },
+        custom_opacity_scale_format_value_cb: function(scale, value) {
+            return Math.round(value*100) + ' %';
+        },
 
-            custom_opacity_scale_format_value_cb: function(scale, value) {
-                return Math.round(value*100) + ' %';
-            },
+        all_windows_radio_button_toggled_cb: function(button) {
+            if (button.get_active())
+                this._settings.set_enum('intellihide-mode', 0);
+        },
 
-            all_windows_radio_button_toggled_cb: function (button) {
-                if (button.get_active())
-                    this._settings.set_enum('intellihide-mode', 0);
-            },
+        focus_application_windows_radio_button_toggled_cb: function(button) {
+            if (button.get_active())
+                this._settings.set_enum('intellihide-mode', 1);
+        },
 
-            focus_application_windows_radio_button_toggled_cb: function (button) {
-                if (button.get_active())
-                    this._settings.set_enum('intellihide-mode', 1);
-            },
-
-            maximized_windows_radio_button_toggled_cb: function (button) {
-                if (button.get_active())
-                    this._settings.set_enum('intellihide-mode', 2);
-            }
+        maximized_windows_radio_button_toggled_cb: function(button) {
+            if (button.get_active())
+                this._settings.set_enum('intellihide-mode', 2);
+        }
     }
 });
 
@@ -523,4 +521,3 @@ function buildPrefsWidget() {
     widget.show_all();
     return widget;
 }
-

--- a/prefs.js
+++ b/prefs.js
@@ -320,13 +320,17 @@ const Settings = new Lang.Class({
                             this._builder.get_object('application_button_animation_button'),
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('support-window-stealing',
+                            this._builder.get_object('support_window_stealing_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
 
         this._builder.get_object('click_action_combo').set_active(this._settings.get_enum('click-action'));
         this._builder.get_object('click_action_combo').connect('changed', Lang.bind (this, function(widget) {
             this._settings.set_enum('click-action', widget.get_active());
         }));
 
-        this._builder.get_object('shift_click_action_combo').set_active(this._settings.get_boolean('minimize-shift')?1:0);
+        this._builder.get_object('shift_click_action_combo').set_active(this._settings.get_boolean('minimize-shift') ? 1 : 0);
 
         this._builder.get_object('shift_click_action_combo').connect('changed', Lang.bind (this, function(widget) {
             this._settings.set_boolean('minimize-shift', widget.get_active()==1);

--- a/prefs.js
+++ b/prefs.js
@@ -56,7 +56,7 @@ const Settings = new Lang.Class({
     Name: 'DashToDock.Settings',
 
     _init: function() {
-        this._settings = Convenience.getSettings('org.gnome.shell.extensions.dash-to-dock');
+        this._dtdSettings = Convenience.getSettings('org.gnome.shell.extensions.dash-to-dock');
 
         this._rtl = (Gtk.Widget.get_default_direction() == Gtk.TextDirection.RTL);
 
@@ -93,7 +93,7 @@ const Settings = new Lang.Class({
         let n_monitors = Gdk.Screen.get_default().get_n_monitors();
         let primary_monitor = Gdk.Screen.get_default().get_primary_monitor();
 
-        let monitor = this._settings.get_int('preferred-monitor');
+        let monitor = this._dtdSettings.get_int('preferred-monitor');
 
         // Add primary monitor with index 0, because in GNOME Shell the primary monitor is always 0
         this._builder.get_object('dock_monitor_combo').append_text(_('Primary monitor'));
@@ -118,7 +118,7 @@ const Settings = new Lang.Class({
         this._builder.get_object('dock_monitor_combo').set_active(this._monitors.indexOf(monitor));
 
         // Position option
-        let position = this._settings.get_enum('dock-position');
+        let position = this._dtdSettings.get_enum('dock-position');
 
         switch (position) {
             case 0:
@@ -142,56 +142,58 @@ const Settings = new Lang.Class({
         }
 
         // Intelligent autohide options
-        this._settings.bind('dock-fixed',
+        this._dtdSettings.bind('dock-fixed',
                             this._builder.get_object('intelligent_autohide_switch'),
                             'active',
                             Gio.SettingsBindFlags.INVERT_BOOLEAN);
-        this._settings.bind('dock-fixed',
+        this._dtdSettings.bind('dock-fixed',
                             this._builder.get_object('intelligent_autohide_button'),
                             'sensitive',
                             Gio.SettingsBindFlags.INVERT_BOOLEAN);
-        this._settings.bind('autohide',
+        this._dtdSettings.bind('autohide',
                             this._builder.get_object('autohide_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('autohide-in-fullscreen',
+        this._dtdSettings.bind('autohide-in-fullscreen',
                             this._builder.get_object('autohide_enable_in_fullscreen_checkbutton'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('require-pressure-to-show',
+        this._dtdSettings.bind('require-pressure-to-show',
                             this._builder.get_object('require_pressure_checkbutton'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('intellihide',
+        this._dtdSettings.bind('intellihide',
                             this._builder.get_object('intellihide_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('animation-time',
+        this._dtdSettings.bind('animation-time',
                             this._builder.get_object('animation_duration_spinbutton'),
                             'value',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('hide-delay',
+        this._dtdSettings.bind('hide-delay',
                             this._builder.get_object('hide_timeout_spinbutton'),
                             'value',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('show-delay',
+        this._dtdSettings.bind('show-delay',
                             this._builder.get_object('show_timeout_spinbutton'),
                             'value',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('pressure-threshold',
+        this._dtdSettings.bind('pressure-threshold',
                             this._builder.get_object('pressure_threshold_spinbutton'),
                             'value',
                             Gio.SettingsBindFlags.DEFAULT);
 
-        //this._builder.get_object('animation_duration_spinbutton').set_value(this._settings.get_double('animation-time'));
+        //this._builder.get_object('animation_duration_spinbutton').set_value(this._dtdSettings.get_double('animation-time'));
 
         // Create dialog for intelligent autohide advanced settings
         this._builder.get_object('intelligent_autohide_button').connect('clicked', Lang.bind(this, function() {
 
-            let dialog = new Gtk.Dialog({ title: _('Intelligent autohide customization'),
-                                          transient_for: this.widget.get_toplevel(),
-                                          use_header_bar: true,
-                                          modal: true });
+            let dialog = new Gtk.Dialog({
+                title: _('Intelligent autohide customization'),
+                transient_for: this.widget.get_toplevel(),
+                use_header_bar: true,
+                modal: true
+            });
 
             // GTK+ leaves positive values for application-defined response ids.
             // Use +1 for the reset action
@@ -200,7 +202,7 @@ const Settings = new Lang.Class({
             let box = this._builder.get_object('intelligent_autohide_advanced_settings_box');
             dialog.get_content_area().add(box);
 
-            this._settings.bind('intellihide',
+            this._dtdSettings.bind('intellihide',
                             this._builder.get_object('intellihide_mode_box'),
                             'sensitive',
                             Gio.SettingsBindFlags.GET);
@@ -213,31 +215,31 @@ const Settings = new Lang.Class({
                 this._builder.get_object('maximized_windows_radio_button')
             ];
 
-            intellihideModeRadioButtons[this._settings.get_enum('intellihide-mode')].set_active(true);
+            intellihideModeRadioButtons[this._dtdSettings.get_enum('intellihide-mode')].set_active(true);
 
-            this._settings.bind('autohide',
+            this._dtdSettings.bind('autohide',
                             this._builder.get_object('require_pressure_checkbutton'),
                             'sensitive',
                             Gio.SettingsBindFlags.GET);
 
-            this._settings.bind('autohide',
+            this._dtdSettings.bind('autohide',
                             this._builder.get_object('autohide_enable_in_fullscreen_checkbutton'),
                             'sensitive',
                             Gio.SettingsBindFlags.GET);
 
-            this._settings.bind('require-pressure-to-show',
+            this._dtdSettings.bind('require-pressure-to-show',
                                 this._builder.get_object('show_timeout_spinbutton'),
                                 'sensitive',
                                 Gio.SettingsBindFlags.INVERT_BOOLEAN);
-            this._settings.bind('require-pressure-to-show',
+            this._dtdSettings.bind('require-pressure-to-show',
                                 this._builder.get_object('show_timeout_label'),
                                 'sensitive',
                                 Gio.SettingsBindFlags.INVERT_BOOLEAN);
-            this._settings.bind('require-pressure-to-show',
+            this._dtdSettings.bind('require-pressure-to-show',
                                 this._builder.get_object('pressure_threshold_spinbutton'),
                                 'sensitive',
                                 Gio.SettingsBindFlags.DEFAULT);
-            this._settings.bind('require-pressure-to-show',
+            this._dtdSettings.bind('require-pressure-to-show',
                                 this._builder.get_object('pressure_threshold_label'),
                                 'sensitive',
                                 Gio.SettingsBindFlags.DEFAULT);
@@ -248,10 +250,11 @@ const Settings = new Lang.Class({
                     let keys = ['intellihide', 'autohide', 'intellihide-mode', 'autohide-in-fullscreen', 'require-pressure-to-show',
                                 'animation-time', 'show-delay', 'hide-delay', 'pressure-threshold'];
                     keys.forEach(function(val) {
-                        this._settings.set_value(val, this._settings.get_default_value(val));
+                        this._dtdSettings.set_value(val, this._dtdSettings.get_default_value(val));
                     }, this);
-                    intellihideModeRadioButtons[this._settings.get_enum('intellihide-mode')].set_active(true);
-                } else {
+                    intellihideModeRadioButtons[this._dtdSettings.get_enum('intellihide-mode')].set_active(true);
+                }
+                else {
                     // remove the settings box so it doesn't get destroyed;
                     dialog.get_content_area().remove(box);
                     dialog.destroy();
@@ -264,11 +267,11 @@ const Settings = new Lang.Class({
         }));
 
         // size options
-        this._builder.get_object('dock_size_scale').set_value(this._settings.get_double('height-fraction'));
+        this._builder.get_object('dock_size_scale').set_value(this._dtdSettings.get_double('height-fraction'));
         this._builder.get_object('dock_size_scale').add_mark(0.9, Gtk.PositionType.TOP, null);
         let icon_size_scale = this._builder.get_object('icon_size_scale');
-        icon_size_scale.set_range(DEFAULT_ICONS_SIZES[DEFAULT_ICONS_SIZES.length -1], DEFAULT_ICONS_SIZES[0]);
-        icon_size_scale.set_value(this._settings.get_int('dash-max-icon-size'));
+        icon_size_scale.set_range(DEFAULT_ICONS_SIZES[DEFAULT_ICONS_SIZES.length - 1], DEFAULT_ICONS_SIZES[0]);
+        icon_size_scale.set_value(this._dtdSettings.get_int('dash-max-icon-size'));
         DEFAULT_ICONS_SIZES.forEach(function(val) {
              icon_size_scale.add_mark(val, Gtk.PositionType.TOP, val.toString());
         });
@@ -285,70 +288,70 @@ const Settings = new Lang.Class({
             icon_size_scale.set_inverted(true);
         }
 
-        this._settings.bind('icon-size-fixed', this._builder.get_object('icon_size_fixed_checkbutton'), 'active', Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('extend-height', this._builder.get_object('dock_size_extend_checkbutton'), 'active', Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('extend-height', this._builder.get_object('dock_size_scale'), 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN);
+        this._dtdSettings.bind('icon-size-fixed', this._builder.get_object('icon_size_fixed_checkbutton'), 'active', Gio.SettingsBindFlags.DEFAULT);
+        this._dtdSettings.bind('extend-height', this._builder.get_object('dock_size_extend_checkbutton'), 'active', Gio.SettingsBindFlags.DEFAULT);
+        this._dtdSettings.bind('extend-height', this._builder.get_object('dock_size_scale'), 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN);
 
 
         // Behavior panel
 
-        this._settings.bind('show-running',
+        this._dtdSettings.bind('show-running',
                             this._builder.get_object('show_running_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('show-favorites',
+        this._dtdSettings.bind('show-favorites',
                             this._builder.get_object('show_favorite_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('show-show-apps-button',
+        this._dtdSettings.bind('show-show-apps-button',
                             this._builder.get_object('show_applications_button_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('show-apps-at-top',
+        this._dtdSettings.bind('show-apps-at-top',
                             this._builder.get_object('application_button_first_button'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('show-show-apps-button',
+        this._dtdSettings.bind('show-show-apps-button',
                             this._builder.get_object('application_button_first_button'),
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('animate-show-apps',
+        this._dtdSettings.bind('animate-show-apps',
                             this._builder.get_object('application_button_animation_button'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('show-show-apps-button',
+        this._dtdSettings.bind('show-show-apps-button',
                             this._builder.get_object('application_button_animation_button'),
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('support-window-stealing',
+        this._dtdSettings.bind('support-window-stealing',
                             this._builder.get_object('support_window_stealing_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
 
-        this._builder.get_object('click_action_combo').set_active(this._settings.get_enum('click-action'));
+        this._builder.get_object('click_action_combo').set_active(this._dtdSettings.get_enum('click-action'));
         this._builder.get_object('click_action_combo').connect('changed', Lang.bind (this, function(widget) {
-            this._settings.set_enum('click-action', widget.get_active());
+            this._dtdSettings.set_enum('click-action', widget.get_active());
         }));
 
-        this._builder.get_object('shift_click_action_combo').set_active(this._settings.get_boolean('minimize-shift') ? 1 : 0);
+        this._builder.get_object('shift_click_action_combo').set_active(this._dtdSettings.get_boolean('minimize-shift') ? 1 : 0);
 
         this._builder.get_object('shift_click_action_combo').connect('changed', Lang.bind (this, function(widget) {
-            this._settings.set_boolean('minimize-shift', widget.get_active()==1);
+            this._dtdSettings.set_boolean('minimize-shift', widget.get_active() == 1);
         }));
 
-        this._settings.bind('scroll-switch-workspace', this._builder.get_object('switch_workspace_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
+        this._dtdSettings.bind('scroll-switch-workspace', this._builder.get_object('switch_workspace_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
 
         // Appearance Panel
 
-        this._settings.bind('apply-custom-theme', this._builder.get_object('customize_theme'), 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN | Gio.SettingsBindFlags.GET);
-        this._settings.bind('apply-custom-theme', this._builder.get_object('builtin_theme_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('custom-theme-shrink', this._builder.get_object('shrink_dash_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
+        this._dtdSettings.bind('apply-custom-theme', this._builder.get_object('customize_theme'), 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN | Gio.SettingsBindFlags.GET);
+        this._dtdSettings.bind('apply-custom-theme', this._builder.get_object('builtin_theme_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
+        this._dtdSettings.bind('custom-theme-shrink', this._builder.get_object('shrink_dash_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
 
-        this._settings.bind('custom-theme-running-dots',
+        this._dtdSettings.bind('custom-theme-running-dots',
                              this._builder.get_object('running_dots_switch'),
                              'active',
                              Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('custom-theme-running-dots',
+        this._dtdSettings.bind('custom-theme-running-dots',
                             this._builder.get_object('running_dots_advance_settings_button'),
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
@@ -364,36 +367,36 @@ const Settings = new Lang.Class({
             let box = this._builder.get_object('running_dots_advance_settings_box');
             dialog.get_content_area().add(box);
 
-            this._settings.bind('custom-theme-customize-running-dots',
+            this._dtdSettings.bind('custom-theme-customize-running-dots',
                                 this._builder.get_object('dot_style_switch'),
                                 'active',
                                 Gio.SettingsBindFlags.DEFAULT);
-            this._settings.bind('custom-theme-customize-running-dots',
+            this._dtdSettings.bind('custom-theme-customize-running-dots',
                                 this._builder.get_object('dot_style_settings_box'),
                                 'sensitive', Gio.SettingsBindFlags.DEFAULT);
 
             let rgba = new Gdk.RGBA();
-            rgba.parse(this._settings.get_string('custom-theme-running-dots-color'));
+            rgba.parse(this._dtdSettings.get_string('custom-theme-running-dots-color'));
             this._builder.get_object('dot_color_colorbutton').set_rgba(rgba);
 
             this._builder.get_object('dot_color_colorbutton').connect('notify::color', Lang.bind(this, function(button) {
                 let rgba = button.get_rgba();
                 let css = rgba.to_string();
                 let hexString = cssHexString(css);
-                this._settings.set_string('custom-theme-running-dots-color', hexString);
+                this._dtdSettings.set_string('custom-theme-running-dots-color', hexString);
             }));
 
-            rgba.parse(this._settings.get_string('custom-theme-running-dots-border-color'));
+            rgba.parse(this._dtdSettings.get_string('custom-theme-running-dots-border-color'));
             this._builder.get_object('dot_border_color_colorbutton').set_rgba(rgba);
 
             this._builder.get_object('dot_border_color_colorbutton').connect('notify::color', Lang.bind(this, function(button) {
                 let rgba = button.get_rgba();
                 let css = rgba.to_string();
                 let hexString = cssHexString(css);
-                this._settings.set_string('custom-theme-running-dots-border-color', hexString);
+                this._dtdSettings.set_string('custom-theme-running-dots-border-color', hexString);
             }));
 
-            this._settings.bind('custom-theme-running-dots-border-width',
+            this._dtdSettings.bind('custom-theme-running-dots-border-width',
                                 this._builder.get_object('dot_border_width_spin_button'),
                                 'value',
                                 Gio.SettingsBindFlags.DEFAULT);
@@ -410,9 +413,9 @@ const Settings = new Lang.Class({
 
         }));
 
-        this._settings.bind('opaque-background', this._builder.get_object('customize_opacity_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
-        this._builder.get_object('custom_opacity_scale').set_value(this._settings.get_double('background-opacity'));
-        this._settings.bind('opaque-background', this._builder.get_object('custom_opacity'), 'sensitive', Gio.SettingsBindFlags.DEFAULT);
+        this._dtdSettings.bind('opaque-background', this._builder.get_object('customize_opacity_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
+        this._builder.get_object('custom_opacity_scale').set_value(this._dtdSettings.get_double('background-opacity'));
+        this._dtdSettings.bind('opaque-background', this._builder.get_object('custom_opacity'), 'sensitive', Gio.SettingsBindFlags.DEFAULT);
 
         // About Panel
 
@@ -424,31 +427,31 @@ const Settings = new Lang.Class({
      */
     _SignalHandler: {
         dock_display_combo_changed_cb: function(combo) {
-            this._settings.set_int('preferred-monitor', this._monitors[combo.get_active()]);
+            this._dtdSettings.set_int('preferred-monitor', this._monitors[combo.get_active()]);
         },
 
         position_top_button_toggled_cb: function(button) {
             if (button.get_active())
-                this._settings.set_enum('dock-position', 0);
+                this._dtdSettings.set_enum('dock-position', 0);
         },
 
         position_right_button_toggled_cb: function(button) {
             if (button.get_active())
-                this._settings.set_enum('dock-position', 1);
+                this._dtdSettings.set_enum('dock-position', 1);
         },
 
         position_bottom_button_toggled_cb: function(button) {
             if (button.get_active())
-                this._settings.set_enum('dock-position', 2);
+                this._dtdSettings.set_enum('dock-position', 2);
         },
 
         position_left_button_toggled_cb: function(button) {
             if (button.get_active())
-                this._settings.set_enum('dock-position', 3);
+                this._dtdSettings.set_enum('dock-position', 3);
         },
 
         icon_size_combo_changed_cb: function(combo) {
-            this._settings.set_int('dash-max-icon-size', this._allIconSizes[combo.get_active()]);
+            this._dtdSettings.set_int('dash-max-icon-size', this._allIconSizes[combo.get_active()]);
         },
 
         dock_size_scale_format_value_cb: function(scale, value) {
@@ -461,7 +464,7 @@ const Settings = new Lang.Class({
                 Mainloop.source_remove(this._dock_size_timeout);
 
             this._dock_size_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function() {
-                this._settings.set_double('height-fraction', scale.get_value());
+                this._dtdSettings.set_double('height-fraction', scale.get_value());
                 this._dock_size_timeout = 0;
                 return GLib.SOURCE_REMOVE;
             }));
@@ -477,7 +480,7 @@ const Settings = new Lang.Class({
                 Mainloop.source_remove(this._icon_size_timeout);
 
             this._icon_size_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function() {
-                this._settings.set_int('dash-max-icon-size', scale.get_value());
+                this._dtdSettings.set_int('dash-max-icon-size', scale.get_value());
                 this._icon_size_timeout = 0;
                 return GLib.SOURCE_REMOVE;
             }));
@@ -489,7 +492,7 @@ const Settings = new Lang.Class({
                 Mainloop.source_remove(this._opacity_timeout);
 
             this._opacity_timeout = Mainloop.timeout_add(SCALE_UPDATE_TIMEOUT, Lang.bind(this, function() {
-                this._settings.set_double('background-opacity', scale.get_value());
+                this._dtdSettings.set_double('background-opacity', scale.get_value());
                 this._opacity_timeout = 0;
                 return GLib.SOURCE_REMOVE;
             }));
@@ -501,17 +504,17 @@ const Settings = new Lang.Class({
 
         all_windows_radio_button_toggled_cb: function(button) {
             if (button.get_active())
-                this._settings.set_enum('intellihide-mode', 0);
+                this._dtdSettings.set_enum('intellihide-mode', 0);
         },
 
         focus_application_windows_radio_button_toggled_cb: function(button) {
             if (button.get_active())
-                this._settings.set_enum('intellihide-mode', 1);
+                this._dtdSettings.set_enum('intellihide-mode', 1);
         },
 
         maximized_windows_radio_button_toggled_cb: function(button) {
             if (button.get_active())
-                this._settings.set_enum('intellihide-mode', 2);
+                this._dtdSettings.set_enum('intellihide-mode', 2);
         }
     }
 });

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -191,6 +191,11 @@
       <default>true</default>
       <summary>Activate only one window</summary>
     </key>
+    <key type="as" name="window-stealing">
+	  <default>[]</default>
+      <summary>Window stealing</summary>
+      <description>Each string is a space-separated list, where the first item in the list is the app ID and the subsequent items are WM_CLASS names</description>
+    </key>
     <key name="click-action" enum="org.gnome.shell.extensions.dash-to-dock.clickAction">
       <default>'cycle-windows'</default>
       <summary>Action when clicking on a running app</summary>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -191,6 +191,10 @@
       <default>true</default>
       <summary>Activate only one window</summary>
     </key>
+    <key type="b" name="support-window-stealing">
+      <default>false</default>
+      <summary>Support window stealing</summary>
+    </key>
     <key type="as" name="window-stealing">
 	  <default>[]</default>
       <summary>Window stealing</summary>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -87,3 +87,29 @@
 #dashtodockContainer.dashtodock #dash {
     background: #2e3436;
 }
+
+/*
+#dashtodockContainer2 .stolen {
+	border: 0px solid red;
+	margin: 0px;
+	padding: 0px;
+	width: 0px;
+	height: 0px;
+}
+
+#dashtodockContainer2 .stolen StBin {
+	border: 0px solid red;
+	margin: 0px;
+	padding: 0px;
+	width: 0px;
+	height: 0px;
+}
+
+#dashtodockContainer2 .stolen StWidget {
+	border: 0px solid red;
+	margin: 0px;
+	padding: 0px;
+	width: 0px;
+	height: 0px;
+}
+*/

--- a/theming.js
+++ b/theming.js
@@ -1,31 +1,13 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-const Clutter = imports.gi.Clutter;
-const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
-const Gtk = imports.gi.Gtk;
-const Signals = imports.signals;
 const Lang = imports.lang;
-const Meta = imports.gi.Meta;
-const Shell = imports.gi.Shell;
-const St = imports.gi.St;
-const Mainloop = imports.mainloop;
 
-const AppDisplay = imports.ui.appDisplay;
-const AppFavorites = imports.ui.appFavorites;
-const Dash = imports.ui.dash;
-const DND = imports.ui.dnd;
-const IconGrid = imports.ui.iconGrid;
+const St = imports.gi.St;
+
 const Main = imports.ui.main;
-const PopupMenu = imports.ui.popupMenu;
-const Tweener = imports.ui.tweener;
-const Util = imports.misc.util;
-const Workspace = imports.ui.workspace;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
-const Icons = Me.imports.icons;
-const Windows = Me.imports.windows;
 
 /**
  * Manage theme customization and custom theme support

--- a/theming.js
+++ b/theming.js
@@ -1,0 +1,236 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Clutter = imports.gi.Clutter;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const Gtk = imports.gi.Gtk;
+const Signals = imports.signals;
+const Lang = imports.lang;
+const Meta = imports.gi.Meta;
+const Shell = imports.gi.Shell;
+const St = imports.gi.St;
+const Mainloop = imports.mainloop;
+
+const AppDisplay = imports.ui.appDisplay;
+const AppFavorites = imports.ui.appFavorites;
+const Dash = imports.ui.dash;
+const DND = imports.ui.dnd;
+const IconGrid = imports.ui.iconGrid;
+const Main = imports.ui.main;
+const PopupMenu = imports.ui.popupMenu;
+const Tweener = imports.ui.tweener;
+const Util = imports.misc.util;
+const Workspace = imports.ui.workspace;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Convenience = Me.imports.convenience;
+const Icons = Me.imports.icons;
+const Windows = Me.imports.windows;
+
+/* 
+ * Manage theme customization and custom theme support
+*/
+const ThemeManager = new Lang.Class({
+    Name: 'DashToDock.ThemeManager',
+
+    _init: function(settings, actor, dash) {
+
+        this._settings = settings;
+        this._bindSettingsChanges();
+        this._actor = actor;
+        this._dash = dash;
+
+        // initialize colors with generic values
+        this._defaultBackground = {red: 0, green:0, blue: 0, alpha:0};
+        this._defaultBackgroundColor = {red: 0, green:0, blue: 0, alpha:0};
+        this._customizedBackground = {red: 0, green:0, blue: 0, alpha:0};
+
+        this._signalsHandler = new Convenience.GlobalSignalsHandler();
+        this._signalsHandler.add(
+            // When theme changes re-obtain default background color
+            [
+              St.ThemeContext.get_for_stage (global.stage),
+              'changed',
+              Lang.bind(this, this.updateCustomTheme)
+            ],
+            // update :overview pseudoclass
+            [
+                Main.overview,
+                'showing',
+                Lang.bind(this, this._onOverviewShowing)
+            ],
+            [
+                Main.overview,
+                'hiding',
+                Lang.bind(this, this._onOverviewHiding)
+            ]
+        );
+
+        this._updateCustomStyleClasses();
+
+    },
+
+    destroy: function() {
+        this._signalsHandler.destroy();
+    },
+
+    _onOverviewShowing: function() {
+        this._actor.add_style_pseudo_class('overview');
+    },
+
+    _onOverviewHiding: function() {
+        this._actor.remove_style_pseudo_class('overview');
+    },
+
+    _updateBackgroundOpacity: function() {
+
+        let newAlpha = this._settings.get_double('background-opacity');
+
+        this._defaultBackground = 'rgba('+
+            this._defaultBackgroundColor.red + ','+
+            this._defaultBackgroundColor.green + ','+
+            this._defaultBackgroundColor.blue + ','+
+            Math.round(this._defaultBackgroundColor.alpha/2.55)/100 + ')';
+
+        this._customizedBackground = 'rgba('+
+            this._defaultBackgroundColor.red + ','+
+            this._defaultBackgroundColor.green + ','+
+            this._defaultBackgroundColor.blue + ','+
+            newAlpha + ')';
+    },
+
+    _getBackgroundColor: function() {
+
+        // Prevent shell crash if the actor is not on the stage.
+        // It happens enabling/disabling repeatedly the extension
+        if(!this._dash._container.get_stage())
+            return;
+
+        // Remove custom style
+        let oldStyle = this._dash._container.get_style();
+        this._dash._container.set_style(null);
+
+        let themeNode = this._dash._container.get_theme_node();
+        this._dash._container.set_style(oldStyle);
+
+        this._defaultBackgroundColor = themeNode.get_background_color();
+    },
+
+    _updateCustomStyleClasses: function() {
+
+        if (this._settings.get_boolean('apply-custom-theme'))
+            this._actor.add_style_class_name('dashtodock');
+        else {
+            this._actor.remove_style_class_name('dashtodock');
+        }
+
+        if (this._settings.get_boolean('custom-theme-shrink'))
+            this._actor.add_style_class_name('shrink');
+        else {
+            this._actor.remove_style_class_name('shrink');
+        }
+
+    },
+
+    updateCustomTheme: function() {
+        this._updateCustomStyleClasses();
+        this._getBackgroundColor();
+        this._updateBackgroundOpacity();
+        this._adjustTheme();
+        this._dash._redisplay();
+    },
+
+    /* Reimported back and adapted from atomdock */
+    _adjustTheme: function() {
+        // Prevent shell crash if the actor is not on the stage.
+        // It happens enabling/disabling repeatedly the extension
+        if (!this._dash._container.get_stage()) {
+            return;
+        }
+
+        // Remove prior style edits
+        this._dash._container.set_style(null);
+
+        /* If built-in theme is enabled do nothing else */
+        if( this._settings.get_boolean('apply-custom-theme') )
+            return;
+
+        let newStyle = '';
+        let position = Convenience.getPosition(this._settings);
+
+        if ( ! this._settings.get_boolean('custom-theme-shrink') ) {
+
+            // obtain theme border settings
+            let themeNode = this._dash._container.get_theme_node();
+            let borderColor = themeNode.get_border_color(St.Side.TOP);
+            let borderWidth = themeNode.get_border_width(St.Side.TOP);
+            let borderRadius = themeNode.get_border_radius(St.Corner.TOPRIGHT);
+
+            /* We're copying border and corner styles to left border and top-left
+            * corner, also removing bottom border and bottom-right corner styles
+            */
+            let borderInner = '';
+            let borderRadiusValue = '';
+            let borderMissingStyle = '';
+
+            if (this._rtl && position != St.Side.RIGHT) {
+                borderMissingStyle = 'border-right: ' + borderWidth + 'px solid ' +
+                       borderColor.to_string() + ';';
+            } else if (!this._rtl && position != St.Side.LEFT) {
+                borderMissingStyle = 'border-left: ' + borderWidth + 'px solid ' +
+                       borderColor.to_string() + ';';
+            }
+
+            switch(position) {
+                case St.Side.LEFT:
+                    borderInner = 'border-left';
+                    borderRadiusValue = '0 ' + borderRadius + 'px ' + borderRadius + 'px 0;';
+                    break;
+                case St.Side.RIGHT:
+                    borderInner = 'border-right';
+                    borderRadiusValue = borderRadius + 'px 0 0 ' + borderRadius + 'px;';
+                    break;
+                case St.Side.TOP:
+                    borderInner = 'border-top';
+                    borderRadiusValue = '0 0 ' + borderRadius + 'px ' + borderRadius + 'px;';
+                    break;
+                case St.Side.BOTTOM:
+                    borderInner = 'border-bottom';
+                    borderRadiusValue = borderRadius + 'px ' + borderRadius + 'px 0 0;';
+                    break;
+            }
+
+            newStyle = borderInner + ': none;' +
+            'border-radius: ' + borderRadiusValue +
+            borderMissingStyle ;
+
+            /* I do call set_style possibly twice so that only the background gets the transition.
+            *  The transition-property css rules seems to be unsupported
+            */
+            this._dash._container.set_style(newStyle);
+        }
+
+        /* Customize background */
+        if ( this._settings.get_boolean('opaque-background')  ) {
+            newStyle = newStyle + 'background-color:'+ this._customizedBackground + '; ' +
+                       'transition-delay: 0s; transition-duration: 0.250s;';
+            this._dash._container.set_style(newStyle);
+        }
+    },
+
+    _bindSettingsChanges: function() {
+
+         let keys = ['opaque-background',
+                     'background-opacity',
+                     'apply-custom-theme',
+                     'custom-theme-shrink',
+                     'extend-height'];
+
+         keys.forEach(function(key) {
+            this._settings.connect('changed::'+key,
+                                   Lang.bind(this, this.updateCustomTheme)
+            );
+          }, this );
+
+    }
+});

--- a/theming.js
+++ b/theming.js
@@ -27,44 +27,39 @@ const Convenience = Me.imports.convenience;
 const Icons = Me.imports.icons;
 const Windows = Me.imports.windows;
 
-/* 
+/**
  * Manage theme customization and custom theme support
-*/
+ */
 const ThemeManager = new Lang.Class({
     Name: 'DashToDock.ThemeManager',
 
     _init: function(settings, actor, dash) {
-
         this._settings = settings;
         this._bindSettingsChanges();
         this._actor = actor;
         this._dash = dash;
 
         // initialize colors with generic values
-        this._defaultBackground = {red: 0, green:0, blue: 0, alpha:0};
-        this._defaultBackgroundColor = {red: 0, green:0, blue: 0, alpha:0};
-        this._customizedBackground = {red: 0, green:0, blue: 0, alpha:0};
+        this._defaultBackground = {red: 0, green: 0, blue: 0, alpha: 0};
+        this._defaultBackgroundColor = {red: 0, green: 0, blue: 0, alpha: 0};
+        this._customizedBackground = {red: 0, green: 0, blue: 0, alpha: 0};
 
         this._signalsHandler = new Convenience.GlobalSignalsHandler();
-        this._signalsHandler.add(
+        this._signalsHandler.add([
             // When theme changes re-obtain default background color
-            [
-              St.ThemeContext.get_for_stage (global.stage),
-              'changed',
-              Lang.bind(this, this.updateCustomTheme)
-            ],
+            St.ThemeContext.get_for_stage (global.stage),
+            'changed',
+            Lang.bind(this, this.updateCustomTheme)
+        ], [
             // update :overview pseudoclass
-            [
-                Main.overview,
-                'showing',
-                Lang.bind(this, this._onOverviewShowing)
-            ],
-            [
-                Main.overview,
-                'hiding',
-                Lang.bind(this, this._onOverviewHiding)
-            ]
-        );
+            Main.overview,
+            'showing',
+            Lang.bind(this, this._onOverviewShowing)
+        ], [
+            Main.overview,
+            'hiding',
+            Lang.bind(this, this._onOverviewHiding)
+        ]);
 
         this._updateCustomStyleClasses();
 
@@ -83,27 +78,25 @@ const ThemeManager = new Lang.Class({
     },
 
     _updateBackgroundOpacity: function() {
-
         let newAlpha = this._settings.get_double('background-opacity');
 
-        this._defaultBackground = 'rgba('+
-            this._defaultBackgroundColor.red + ','+
-            this._defaultBackgroundColor.green + ','+
-            this._defaultBackgroundColor.blue + ','+
+        this._defaultBackground = 'rgba(' +
+            this._defaultBackgroundColor.red + ',' +
+            this._defaultBackgroundColor.green + ',' +
+            this._defaultBackgroundColor.blue + ',' +
             Math.round(this._defaultBackgroundColor.alpha/2.55)/100 + ')';
 
-        this._customizedBackground = 'rgba('+
-            this._defaultBackgroundColor.red + ','+
-            this._defaultBackgroundColor.green + ','+
-            this._defaultBackgroundColor.blue + ','+
+        this._customizedBackground = 'rgba(' +
+            this._defaultBackgroundColor.red + ',' +
+            this._defaultBackgroundColor.green + ',' +
+            this._defaultBackgroundColor.blue + ',' +
             newAlpha + ')';
     },
 
     _getBackgroundColor: function() {
-
         // Prevent shell crash if the actor is not on the stage.
         // It happens enabling/disabling repeatedly the extension
-        if(!this._dash._container.get_stage())
+        if (!this._dash._container.get_stage())
             return;
 
         // Remove custom style
@@ -117,19 +110,15 @@ const ThemeManager = new Lang.Class({
     },
 
     _updateCustomStyleClasses: function() {
-
         if (this._settings.get_boolean('apply-custom-theme'))
             this._actor.add_style_class_name('dashtodock');
-        else {
+        else
             this._actor.remove_style_class_name('dashtodock');
-        }
 
         if (this._settings.get_boolean('custom-theme-shrink'))
             this._actor.add_style_class_name('shrink');
-        else {
+        else
             this._actor.remove_style_class_name('shrink');
-        }
-
     },
 
     updateCustomTheme: function() {
@@ -140,78 +129,75 @@ const ThemeManager = new Lang.Class({
         this._dash._redisplay();
     },
 
-    /* Reimported back and adapted from atomdock */
+    /**
+     * Reimported back and adapted from atomdock
+     */
     _adjustTheme: function() {
         // Prevent shell crash if the actor is not on the stage.
         // It happens enabling/disabling repeatedly the extension
-        if (!this._dash._container.get_stage()) {
+        if (!this._dash._container.get_stage())
             return;
-        }
 
         // Remove prior style edits
         this._dash._container.set_style(null);
 
-        /* If built-in theme is enabled do nothing else */
-        if( this._settings.get_boolean('apply-custom-theme') )
+        // If built-in theme is enabled do nothing else
+        if (this._settings.get_boolean('apply-custom-theme'))
             return;
 
         let newStyle = '';
         let position = Convenience.getPosition(this._settings);
 
-        if ( ! this._settings.get_boolean('custom-theme-shrink') ) {
-
+        if (!this._settings.get_boolean('custom-theme-shrink')) {
             // obtain theme border settings
             let themeNode = this._dash._container.get_theme_node();
             let borderColor = themeNode.get_border_color(St.Side.TOP);
             let borderWidth = themeNode.get_border_width(St.Side.TOP);
             let borderRadius = themeNode.get_border_radius(St.Corner.TOPRIGHT);
 
-            /* We're copying border and corner styles to left border and top-left
-            * corner, also removing bottom border and bottom-right corner styles
-            */
+            // We're copying border and corner styles to left border and top-left
+            // corner, also removing bottom border and bottom-right corner styles
             let borderInner = '';
             let borderRadiusValue = '';
             let borderMissingStyle = '';
 
-            if (this._rtl && position != St.Side.RIGHT) {
+            if (this._rtl && (position != St.Side.RIGHT))
                 borderMissingStyle = 'border-right: ' + borderWidth + 'px solid ' +
                        borderColor.to_string() + ';';
-            } else if (!this._rtl && position != St.Side.LEFT) {
+            else if (!this._rtl && (position != St.Side.LEFT))
                 borderMissingStyle = 'border-left: ' + borderWidth + 'px solid ' +
                        borderColor.to_string() + ';';
-            }
 
-            switch(position) {
-                case St.Side.LEFT:
-                    borderInner = 'border-left';
-                    borderRadiusValue = '0 ' + borderRadius + 'px ' + borderRadius + 'px 0;';
-                    break;
-                case St.Side.RIGHT:
-                    borderInner = 'border-right';
-                    borderRadiusValue = borderRadius + 'px 0 0 ' + borderRadius + 'px;';
-                    break;
-                case St.Side.TOP:
-                    borderInner = 'border-top';
-                    borderRadiusValue = '0 0 ' + borderRadius + 'px ' + borderRadius + 'px;';
-                    break;
-                case St.Side.BOTTOM:
-                    borderInner = 'border-bottom';
-                    borderRadiusValue = borderRadius + 'px ' + borderRadius + 'px 0 0;';
-                    break;
+            switch (position) {
+            case St.Side.LEFT:
+                borderInner = 'border-left';
+                borderRadiusValue = '0 ' + borderRadius + 'px ' + borderRadius + 'px 0;';
+                break;
+            case St.Side.RIGHT:
+                borderInner = 'border-right';
+                borderRadiusValue = borderRadius + 'px 0 0 ' + borderRadius + 'px;';
+                break;
+            case St.Side.TOP:
+                borderInner = 'border-top';
+                borderRadiusValue = '0 0 ' + borderRadius + 'px ' + borderRadius + 'px;';
+                break;
+            case St.Side.BOTTOM:
+                borderInner = 'border-bottom';
+                borderRadiusValue = borderRadius + 'px ' + borderRadius + 'px 0 0;';
+                break;
             }
 
             newStyle = borderInner + ': none;' +
-            'border-radius: ' + borderRadiusValue +
-            borderMissingStyle ;
+                'border-radius: ' + borderRadiusValue +
+                borderMissingStyle;
 
-            /* I do call set_style possibly twice so that only the background gets the transition.
-            *  The transition-property css rules seems to be unsupported
-            */
+            // I do call set_style possibly twice so that only the background gets the transition.
+            // The transition-property css rules seems to be unsupported
             this._dash._container.set_style(newStyle);
         }
 
-        /* Customize background */
-        if ( this._settings.get_boolean('opaque-background')  ) {
+        // Customize background
+        if (this._settings.get_boolean('opaque-background')) {
             newStyle = newStyle + 'background-color:'+ this._customizedBackground + '; ' +
                        'transition-delay: 0s; transition-duration: 0.250s;';
             this._dash._container.set_style(newStyle);
@@ -219,18 +205,14 @@ const ThemeManager = new Lang.Class({
     },
 
     _bindSettingsChanges: function() {
+        let keys = ['opaque-background',
+                    'background-opacity',
+                    'apply-custom-theme',
+                    'custom-theme-shrink',
+                    'extend-height'];
 
-         let keys = ['opaque-background',
-                     'background-opacity',
-                     'apply-custom-theme',
-                     'custom-theme-shrink',
-                     'extend-height'];
-
-         keys.forEach(function(key) {
-            this._settings.connect('changed::'+key,
-                                   Lang.bind(this, this.updateCustomTheme)
-            );
-          }, this );
-
+        keys.forEach(function(key) {
+            this._settings.connect('changed::' + key, Lang.bind(this, this.updateCustomTheme));
+        }, this);
     }
 });

--- a/theming.js
+++ b/theming.js
@@ -16,7 +16,7 @@ const ThemeManager = new Lang.Class({
     Name: 'DashToDock.ThemeManager',
 
     _init: function(settings, actor, dash) {
-        this._settings = settings;
+        this._dtdSettings = settings;
         this._bindSettingsChanges();
         this._actor = actor;
         this._dash = dash;
@@ -60,7 +60,7 @@ const ThemeManager = new Lang.Class({
     },
 
     _updateBackgroundOpacity: function() {
-        let newAlpha = this._settings.get_double('background-opacity');
+        let newAlpha = this._dtdSettings.get_double('background-opacity');
 
         this._defaultBackground = 'rgba(' +
             this._defaultBackgroundColor.red + ',' +
@@ -92,12 +92,12 @@ const ThemeManager = new Lang.Class({
     },
 
     _updateCustomStyleClasses: function() {
-        if (this._settings.get_boolean('apply-custom-theme'))
+        if (this._dtdSettings.get_boolean('apply-custom-theme'))
             this._actor.add_style_class_name('dashtodock');
         else
             this._actor.remove_style_class_name('dashtodock');
 
-        if (this._settings.get_boolean('custom-theme-shrink'))
+        if (this._dtdSettings.get_boolean('custom-theme-shrink'))
             this._actor.add_style_class_name('shrink');
         else
             this._actor.remove_style_class_name('shrink');
@@ -124,13 +124,13 @@ const ThemeManager = new Lang.Class({
         this._dash._container.set_style(null);
 
         // If built-in theme is enabled do nothing else
-        if (this._settings.get_boolean('apply-custom-theme'))
+        if (this._dtdSettings.get_boolean('apply-custom-theme'))
             return;
 
         let newStyle = '';
-        let position = Convenience.getPosition(this._settings);
+        let position = Convenience.getPosition(this._dtdSettings);
 
-        if (!this._settings.get_boolean('custom-theme-shrink')) {
+        if (!this._dtdSettings.get_boolean('custom-theme-shrink')) {
             // obtain theme border settings
             let themeNode = this._dash._container.get_theme_node();
             let borderColor = themeNode.get_border_color(St.Side.TOP);
@@ -179,7 +179,7 @@ const ThemeManager = new Lang.Class({
         }
 
         // Customize background
-        if (this._settings.get_boolean('opaque-background')) {
+        if (this._dtdSettings.get_boolean('opaque-background')) {
             newStyle = newStyle + 'background-color:'+ this._customizedBackground + '; ' +
                        'transition-delay: 0s; transition-duration: 0.250s;';
             this._dash._container.set_style(newStyle);
@@ -194,7 +194,7 @@ const ThemeManager = new Lang.Class({
                     'extend-height'];
 
         keys.forEach(function(key) {
-            this._settings.connect('changed::' + key, Lang.bind(this, this.updateCustomTheme));
+            this._dtdSettings.connect('changed::' + key, Lang.bind(this, this.updateCustomTheme));
         }, this);
     }
 });

--- a/windows.js
+++ b/windows.js
@@ -16,8 +16,11 @@ let exampleSettings = [
 ];
 
 function getSettings(settings) {
-    let table = {};
+    if (!settings.get_boolean('support-window-stealing'))
+        return {};
     
+    let table = {};
+
     let array = settings.get_strv('window-stealing') || [];
     
     if ((array == null) || !array.length) {

--- a/windows.js
+++ b/windows.js
@@ -8,6 +8,7 @@ const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 
 const ModalDialog = imports.ui.modalDialog;
+const ShellEntry = imports.ui.shellEntry;
 
 // Example settings:
 let exampleSettings = [
@@ -152,7 +153,7 @@ const WindowStealingSettings = new Lang.Class({
     Extends: ModalDialog.ModalDialog,
     
     _init: function(app, settings) {
-        this.parent();
+        this.parent({styleClass: 'run-dialog'});
         
         this._app = app;
         this._dtdSettings = settings;
@@ -161,61 +162,72 @@ const WindowStealingSettings = new Lang.Class({
         
         let array = this._dtdSettings.get_strv('window-stealing') || [];
         for (let a in array) {
-            let entry = array[a].split(' ', 2);
-            if (entry.length == 2) {
-                if (this._app.id == entry[0]) {
-                    value = entry[1];
+            let c = array[a].indexOf(' ');
+            if (c != -1) {
+                if (this._app.id == array[a].substring(0, c)) {
+                    value = array[a].substring(c + 1);
                     break;
                 }
             }
         }
         
-        let mainContentBox = new St.BoxLayout({vertical: false});
+        let mainContentBox = new St.BoxLayout({vertical: true});
         this.contentLayout.add(mainContentBox, {
             x_fill: true,
             y_fill: true
         });
         
-        let messageBox = new St.BoxLayout({vertical: true});
-        mainContentBox.add(messageBox, {
-            expand: true,
-            y_align: St.Align.START
+        // Title
+        let appIdLabel = new St.Label({
+            style_class: 'run-dialog-label',
+            text: _('Application ID: ') + app.id
         });
-        
-        let appIdLabel = new St.Label({text: _('App ID: ') + app.id});
-        messageBox.add(appIdLabel, {
-            expand: true,
+        mainContentBox.add(appIdLabel, {
             x_fill: true,
             x_align: St.Align.MIDDLE
         });
 
-        let wmClassLabel = new St.Label({text: _('Space-separated list of WM_CLASS names')});
-        messageBox.add(wmClassLabel, {
+        // Instructions
+        let wmClassLabel = new St.Label({
+            style_class: 'run-dialog-label',
+            text: _('Enter space-separated list of WM_CLASS names to steal')
+        });
+        mainContentBox.add(wmClassLabel, {
+            x_fill: false,
+            x_align: St.Align.START,
+            y_align: St.Align.START
         });
         
-        this._entry = new St.Entry({can_focus: true});
+        // Entry
+        this._entry = new St.Entry({
+            style_class: 'run-dialog-entry',
+            can_focus: true
+        });
+        ShellEntry.addContextMenu(this._entry); // adds copy/paste context menu
         this._entry.set_text(value);
-        messageBox.add(this._entry, {
+        mainContentBox.add(this._entry, {
+            y_align: St.Align.START
         });
         this.setInitialKeyFocus(this._entry.clutter_text);
+        this._entry.clutter_text.connect('key-press-event', Lang.bind(this, function(owner, event) {
+            let symbol = event.get_key_symbol();
+            if ((symbol == Clutter.Return) || (symbol == Clutter.KP_Enter)) {
+                this._onSave();
+                return Clutter.EVENT_STOP;
+            }
+            return Clutter.EVENT_PROPAGATE;
+        }));
         
-        this._cancelButton = this.addButton({
+        // Buttons
+        this.setButtons([{
             label: _('Cancel'),
             action: Lang.bind(this, this._onCancel),
             key: Clutter.Escape
         }, {
-            expand: true
-        });
-
-        this._okButton = this.addButton({
             label: _('Save'),
             action: Lang.bind(this, this._onSave),
-            key: Clutter.Escape
-        }, {
-            expand: false,
-            x_fill: false,
-            x_align: St.Align.END
-        });
+            default: true
+        }]);
     },
     
     _onCancel: function() {
@@ -224,24 +236,50 @@ const WindowStealingSettings = new Lang.Class({
 
     _onSave: function() {
         let value = this._entry.get_text();
-        global.log('>>>>>>>>>> ' + value);
-        value = this._app.id + ' ' + value;
-        
+
+        // Cleanup
+        value = value.split(' ');
+        for (let v in value)
+            value[v] = value[v].trim();
+        value = value.join(' ');
+
         let array = this._dtdSettings.get_strv('window-stealing') || [];
-        let found = false;
-        for (let a in array) {
-            let entry = array[a].split(' ', 2);
-            if (entry.length == 2) {
-                if (this._app.id == entry[0]) {
-                    array[a] = value;
-                    found = true;
-                    break;
+        
+        if (value.length) {
+            value = this._app.id + ' ' + value;
+
+            // Change
+            let found = false;
+            for (let a in array) {
+                let entry = array[a].split(' ', 2);
+                if (entry.length == 2) {
+                    if (this._app.id == entry[0]) {
+                        array[a] = value;
+                        found = true;
+                        global.log('Changing window stealing: ' + value);
+                        break;
+                    }
                 }
             }
+
+            // Add
+            if (!found) {
+                array.push(value);
+                global.log('Adding window stealing: ' + value);
+            }
         }
-        
-        if (!found) {
-            array.push(value);
+        else {
+            // Remove
+            for (let a in array) {
+                let entry = array[a].split(' ', 2);
+                if (entry.length == 2) {
+                    if (this._app.id == entry[0]) {
+                        array.splice(a, 1);
+                        global.log('Removing window stealing: ' + this._app.id);
+                        break;
+                    }
+                }
+            }
         }
 
         this._dtdSettings.set_strv('window-stealing', array);

--- a/windows.js
+++ b/windows.js
@@ -1,0 +1,104 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Shell = imports.gi.Shell;
+
+let SETTINGS = {
+	'sapir-claws-mail.desktop': ['Claws-mail'],
+	'sapir-pidgin.desktop': ['Pidgin']
+};
+
+function isWindowStealer(app) {
+	return SETTINGS[app.id] != null;
+}
+
+function isStolen(app) {
+	return hasStolenWindows(app) && !getNonStolenWindows(app).length;
+}
+
+function isStealingFrom(app, stolenApp) {
+	if (stolenApp !== null) {
+		let windows = stolenApp.get_windows();
+		for (let w in windows) {
+			if (isStealingWindow(app, windows[w])) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+function isStolenWindow(window) {
+	let clazz = window.wm_class;
+	for (let id in SETTINGS) {
+		let classesToSteal = SETTINGS[id];
+		for (let i in classesToSteal) {
+			if (clazz == classesToSteal[i]) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+function isStealingWindow(app, window) {
+	let classesToSteal = SETTINGS[app.id];
+	if (classesToSteal) {
+		let clazz = window.wm_class;
+		for (let c in classesToSteal) {
+			if (classesToSteal[c] == clazz) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+function hasStolenWindows(app) {
+	let windows = app.get_windows();
+	for (let w in windows) {
+		if (isStolenWindow(windows[w])) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function getStolenWindows(app) {
+	return app.get_windows().filter(function(w) {
+		return isStolenWindow(w);
+	});
+}
+
+function getNonStolenWindows(app) {
+	return app.get_windows().filter(function(w) {
+		return !isStolenWindow(w);
+	});
+}
+
+// Includes stolen windows
+function getAllWindows(app) {
+	let windows = app.get_windows();
+	let classesToSteal = SETTINGS[app.id];
+	if (classesToSteal) {
+		let running = Shell.AppSystem.get_default().get_running();
+		running.forEach(function(r) {
+			r.get_windows().forEach(function(window) {
+				let clazz = window.wm_class;
+				for (let c in classesToSteal) {
+					if (classesToSteal[c] == clazz) {
+						windows.push(window);
+					}
+				}
+			});
+		});
+	}
+	return windows;
+}
+
+// Filter out unnecessary windows, for instance
+// nautilus desktop window.
+function getInterestingWindows(app) {
+    return getAllWindows(app).filter(function(w) {
+        return !w.skip_taskbar;
+    });
+}


### PR DESCRIPTION
This seems like a very massive pull request, but that's only because of the code-style cleanup. :) Actually, the change is just adding one file and a few smaller interventions.

**Cleanup involved:**

* Using more and smaller JS files, organized by "feature" (to be more like the Shell's codebase).
* Standardizing on one specific JS style (there were many different styles before: different use of spaces, indents; sometimes single line blocks had brackets and sometimes not; different styles of comments; different standards for camel-case; various conventions for GObject class names; and more).

**Window stealing feature:**

IMPORTANT: Let me say that I'll be happy to continue supporting this feature. And actually generally help you fix bugs in Dash to Dock, now that I know the codebase well. I'm not just dumping a feature on you, I really want to collaborate and help. :)

* The feature is disabled by default, but users can enable it in prefs, in the "behavior" pane.
* When enabled: an extra "Window Stealing" entry is added to the app icon popup menu. It entry will open a simple configuration dialog box that lets you enter a list of WM_CLASS names (or leave empty to remove stealing).
* Once set, those windows will now be "stolen" by this icon -- the icon show in the active style if any of these windows are open, and will have the correct number of dots. Click to minimize/maximize will also take these windows into consideration. Relatedly, the extra running app icons will not appear for those windows.

* Known bug: if you de-configure window stealing for an icon, the icon will immediately stop stealing, but the extra running icons for those windows will not reappear until restarting the Shell. This is rather hard to solve, and is also special edge case that would likely only appear during testing, so I don't think it should affect releasing the feature.

* Another tiny bug: window minimizing/maximizing animations originate at the location of the now-invisible stolen app icon on the dash, rather than the stealing one. This doesn't affect usability, of course, but is something I will try to improve.

The code is all in windows.js, however it also affects some code in dash.js and icons.js. Specifically, instead of calling app.get_windows, we are now calling Windows.getAllWindows which knows how to handle window stealing (if enabled). We are additionally adding some simple hooks to setting changes to make sure to refresh the icons.

**Right-click for settings:**

This adds to ability to right-click anywhere on the dash (outside the icons) and get a simple popup menu that lets you run the settings. This is very useful for users who don't have the applications icon enabled (otherwise they have no easy easy to get to settings).

The code is in dash.js line 81. Very straightforward!