### PR TITLE
Hotkey implementation

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -7,6 +7,11 @@
     <property name="step_increment">0.050000000000000003</property>
     <property name="page_increment">0.25</property>
   </object>
+  <object class="GtkAdjustment" id="shortcut_time_adjustment">
+    <property name="upper">10</property>
+    <property name="step_increment">0.250000000000000003</property>
+    <property name="page_increment">1</property>
+  </object>
   <object class="GtkAdjustment" id="custom_opacity_adjustement">
     <property name="upper">1</property>
     <property name="step_increment">0.01</property>
@@ -233,6 +238,266 @@
         <property name="expand">False</property>
         <property name="fill">True</property>
         <property name="position">0</property>
+      </packing>
+    </child>
+  </object>
+  <object class="GtkBox" id="box_overlay_shortcut">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="margin_left">12</property>
+    <property name="margin_right">12</property>
+    <property name="margin_top">12</property>
+    <property name="margin_bottom">12</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkFrame" id="frame_overlay_show_dock">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label_xalign">0</property>
+        <property name="shadow_type">in</property>
+        <child>
+          <object class="GtkListBox" id="listbox_overlay_shortcut">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="selection_mode">none</property>
+            <child>
+              <object class="GtkListBoxRow" id="listboxrow_overlay_shortcut">
+                <property name="width_request">100</property>
+                <property name="height_request">80</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_overlay">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkSwitch" id="overlay_switch">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                        <property name="height">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="overlay_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Number overlay</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="overlay_description">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Temporarily show the application numbers over the icons, corresponding to the hotkeys.</property>
+                        <property name="wrap">True</property>
+                        <property name="max-width-chars">40</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkListBoxRow" id="listboxrow_show_dock">
+                <property name="width_request">100</property>
+                <property name="height_request">80</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_show_dock">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkSwitch" id="show_dock_switch">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                        <property name="height">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="show_dock_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Show the dock if it is hidden</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="show_dock_description">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">If using autohide, the dock will appear for a short time when triggering the shortcut.</property>
+                        <property name="wrap">True</property>
+                        <property name="max-width-chars">40</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkListBoxRow" id="listboxrow_extra_shortcut">
+                <property name="width_request">100</property>
+                <property name="height_request">80</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_shortcut">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkEntry" id="shortcut_entry">
+                        <property name="width-chars">12</property>
+                        <property name="valign">center</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="shortcut_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Shortcut for the options above</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="shortcut_description">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="max-width-chars">40</property>
+                        <property name="label" translatable="yes">Syntax: &lt;Shift&gt;, &lt;Ctrl&gt;, &lt;Alt&gt;, &lt;Super&gt;</property>
+                        <property name="wrap">True</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkListBoxRow" id="listboxrow_timeout">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_timeout">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="hexpand">True</property>
+                    <property name="row_spacing">6</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkSpinButton" id="timeout_spinbutton">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">end</property>
+                        <property name="adjustment">shortcut_time_adjustment</property>
+                        <property name="digits">3</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="shortcut_timeout_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Hide timeout (s)</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="label_item">
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
       </packing>
     </child>
   </object>
@@ -1309,32 +1574,53 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkSwitch" id="hot_keys_switch">
+                          <object class="GtkBox" id="overlay_box">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="halign">end</property>
-                            <property name="valign">center</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkButton" id="overlay_button">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="xalign">0.46000000834465027</property>
+                                <child>
+                                  <object class="GtkImage" id="image_overlay">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="icon_name">emblem-system-symbolic</property>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="circular"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSwitch" id="hot_keys_switch">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">0</property>
+                                <property name="height">2</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
                             <property name="top_attach">0</property>
                             <property name="height">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="hotkeys_show_dock">
-                            <property name="label" translatable="yes">Quickly show the dock if it is hidden.</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="margin_top">12</property>
-                            <property name="xalign">0</property>
-                            <property name="draw_indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">2</property>
-                            <property name="width">2</property>
                           </packing>
                         </child>
                       </object>

--- a/Settings.ui
+++ b/Settings.ui
@@ -1295,6 +1295,22 @@
                             <property name="height">2</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkCheckButton" id="hotkeys_show_dock">
+                            <property name="label" translatable="yes">Quickly show the dock if it is hidden.</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="margin_top">12</property>
+                            <property name="xalign">0</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/Settings.ui
+++ b/Settings.ui
@@ -971,7 +971,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkBox" id="behaviour">
+      <object class="GtkBox" id="apps">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="margin_left">24</property>
@@ -1227,6 +1227,32 @@
             <property name="position">0</property>
           </packing>
         </child>
+      </object>
+      <packing>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child type="tab">
+      <object class="GtkLabel" id="apps_label">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Apps</property>
+      </object>
+      <packing>
+        <property name="position">1</property>
+        <property name="tab_fill">False</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox" id="behaviour">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_left">24</property>
+        <property name="margin_right">24</property>
+        <property name="margin_top">24</property>
+        <property name="margin_bottom">24</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">24</property>
         <child>
           <object class="GtkFrame" id="hot_keys_frame">
             <property name="visible">True</property>
@@ -1539,7 +1565,7 @@
         </child>
       </object>
       <packing>
-        <property name="position">1</property>
+        <property name="position">2</property>
       </packing>
     </child>
     <child type="tab">
@@ -1549,7 +1575,7 @@
         <property name="label" translatable="yes">Behavior</property>
       </object>
       <packing>
-        <property name="position">1</property>
+        <property name="position">2</property>
         <property name="tab_fill">False</property>
       </packing>
     </child>
@@ -2077,7 +2103,7 @@
         </child>
       </object>
       <packing>
-        <property name="position">2</property>
+        <property name="position">3</property>
       </packing>
     </child>
     <child type="tab">
@@ -2087,7 +2113,7 @@
         <property name="label" translatable="yes">Appearance</property>
       </object>
       <packing>
-        <property name="position">2</property>
+        <property name="position">3</property>
         <property name="tab_fill">False</property>
       </packing>
     </child>
@@ -2252,7 +2278,7 @@ See the &lt;a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"&gt;G
         </child>
       </object>
       <packing>
-        <property name="position">3</property>
+        <property name="position">4</property>
       </packing>
     </child>
     <child type="tab">
@@ -2262,7 +2288,7 @@ See the &lt;a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"&gt;G
         <property name="label" translatable="yes">About</property>
       </object>
       <packing>
-        <property name="position">3</property>
+        <property name="position">4</property>
         <property name="tab_fill">False</property>
       </packing>
     </child>

--- a/Settings.ui
+++ b/Settings.ui
@@ -497,7 +497,7 @@
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
-        <property name="position">1</property>
+        <property name="position">0</property>
       </packing>
     </child>
   </object>
@@ -1610,11 +1610,6 @@
                                 <property name="halign">end</property>
                                 <property name="valign">center</property>
                               </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">0</property>
-                                <property name="height">2</property>
-                              </packing>
                             </child>
                           </object>
                           <packing>

--- a/appIcons.js
+++ b/appIcons.js
@@ -107,6 +107,7 @@ const MyAppIcon = new Lang.Class({
         }));
         this._optionalScrollCycleWindows();
 
+        this._numberOverlay();
     },
 
     _onDestroy: function() {
@@ -513,6 +514,61 @@ const MyAppIcon = new Lang.Class({
         Clutter.cairo_set_source_color(cr, bodyColor);
         cr.fill();
         cr.$dispose();
+    },
+
+    _numberOverlay: function() {
+        // Add label for a Hot-Key visual aid
+        this._numberOverlayLabel = new St.Label();
+        this._numberOverlayBin = new St.Bin({child: this._numberOverlayLabel });
+        this._numberOverlayStyle = 'background-color: rgba(0,0,0,0.8);'
+        this._numberOverlayOrder = -1;
+        this._numberOverlayBin.hide();
+
+        // iconBox is a Shell.GenericContainer from IconGrid.BaseIcon
+        this.iconBox = new Shell.GenericContainer();
+        this._iconContainer.add_child(this.iconBox);
+        // We have to add allocation of counterBin.
+        this.iconBox.connect('allocate', Lang.bind(this, this._allocateIconBox));
+
+        this.iconBox.add_actor(this._numberOverlayBin);
+
+        this._updateNumberOverlay();
+    },
+
+    _allocateIconBox: function(actor, box, flags) {
+        let childBox = new Clutter.ActorBox();
+        let naturalHeight = this.icon.iconSize;
+        // Partial size for the overlay:
+        naturalHeight *= 0.6;
+
+        childBox.x1 = box.x2 - naturalHeight/2;
+        childBox.x2 = box.x2 + naturalHeight/2;
+        childBox.y1 = box.y2 - naturalHeight/2;
+        childBox.y2 = box.y2 + naturalHeight/2;
+
+        this._numberOverlayBin.allocate(childBox, flags);
+    },
+
+    _updateNumberOverlay: function() {
+        let size = this.icon.iconSize;
+        // Set the font size to something smaller than the whole icon so it is
+        // still visible. The border radius is large to make the shape circular
+        let font_size = Math.round(0.4 * size);
+        this._numberOverlayBin.set_style(this._numberOverlayStyle +
+                                         'font-size: ' + font_size + 'px;' +
+                                         'border-radius: ' + size + 'px;');
+    },
+
+    setNumberOverlay: function(number) {
+        this._numberOverlayOrder = number;
+        this._numberOverlayBin.get_child().set_text(number.toString());
+    },
+
+    toggleNumberOverlay: function(activate) {
+        if (activate && this._numberOverlayOrder > -1)
+           this._numberOverlayBin.show();
+        else
+           this._numberOverlayBin.hide();
     }
 });
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -524,15 +524,15 @@ const MyAppIcon = new Lang.Class({
         this._numberOverlayOrder = -1;
         this._numberOverlayBin.hide();
 
-        // iconBox is a Shell.GenericContainer from IconGrid.BaseIcon
-        this.iconBox = new Shell.GenericContainer();
-        this._iconContainer.add_child(this.iconBox);
+        // genericContainer is a Shell.GenericContainer from IconGrid.BaseIcon
+        let genericContainer = new Shell.GenericContainer();
+        this._iconContainer.add_child(genericContainer);
         // We have to add allocation of counterBin.
-        this.iconBox.connect('allocate', Lang.bind(this, this._allocateIconBox));
+        genericContainer.connect('allocate', Lang.bind(this, this._allocateIconBox));
 
-        this.iconBox.add_actor(this._numberOverlayBin);
+        genericContainer.add_actor(this._numberOverlayBin);
 
-        this._updateNumberOverlay();
+        this.updateNumberOverlay();
     },
 
     _allocateIconBox: function(actor, box, flags) {
@@ -549,7 +549,7 @@ const MyAppIcon = new Lang.Class({
         this._numberOverlayBin.allocate(childBox, flags);
     },
 
-    _updateNumberOverlay: function() {
+    updateNumberOverlay: function() {
         let size = this.icon.iconSize;
         // Set the font size to something smaller than the whole icon so it is
         // still visible. The border radius is large to make the shape circular

--- a/dash.js
+++ b/dash.js
@@ -860,6 +860,37 @@ const MyDash = new Lang.Class({
 
         // This is required for icon reordering when the scrollview is used.
         this._updateAppsIconGeometry();
+
+        // This will update the size, and the corresponding number for each icon
+        this._updateNumberOverlay();
+    },
+
+    _updateNumberOverlay: function() {
+        let appIcons = this._getAppIcons();
+        let counter = 1;
+        appIcons.forEach(function(icon) {
+            if (counter < 10){
+                icon.setNumberOverlay(counter);
+                counter++;
+            }
+            else if (counter == 10) {
+                icon.setNumberOverlay(0);
+                counter++;
+            }
+            else {
+                // No overlay after 10
+                icon.setNumberOverlay(-1);
+            }
+            icon._updateNumberOverlay();
+        });
+
+    },
+
+    toggleNumberOverlay: function(activate) {
+        let appIcons = this._getAppIcons();
+        appIcons.forEach(function(icon) {
+            icon.toggleNumberOverlay(activate);
+        });
     },
 
     setIconSize: function(max_size, doNotAnimate) {

--- a/dash.js
+++ b/dash.js
@@ -881,7 +881,7 @@ const MyDash = new Lang.Class({
                 // No overlay after 10
                 icon.setNumberOverlay(-1);
             }
-            icon._updateNumberOverlay();
+            icon.updateNumberOverlay();
         });
 
     },

--- a/docking.js
+++ b/docking.js
@@ -522,7 +522,7 @@ const DockedDash = new Lang.Class({
 
         // Remove keybindings
         this._disableHotKeys();
-        this._disableNumberOverlay();
+        this._disableExtraShortcut();
     },
 
     _bindSettingsChanges: function() {

--- a/prefs.js
+++ b/prefs.js
@@ -307,6 +307,14 @@ const Settings = new Lang.Class({
                             this._builder.get_object('hot_keys_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('hotkeys-show-dock',
+                            this._builder.get_object('hotkeys_show_dock'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('hot-keys',
+                            this._builder.get_object('hotkeys_show_dock'),
+                            'sensitive',
+                            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-favorites',
                             this._builder.get_object('show_favorite_switch'),
                             'active',

--- a/prefs.js
+++ b/prefs.js
@@ -289,7 +289,7 @@ const Settings = new Lang.Class({
         this._settings.bind('extend-height', this._builder.get_object('dock_size_scale'), 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN);
 
 
-        // Behavior panel
+        // Apps panel
 
         this._settings.bind('show-running',
                             this._builder.get_object('show_running_switch'),
@@ -302,18 +302,6 @@ const Settings = new Lang.Class({
         this._settings.bind('show-windows-preview',
                             this._builder.get_object('windows_preview_button'),
                             'active',
-                            Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('hot-keys',
-                            this._builder.get_object('hot_keys_switch'),
-                            'active',
-                            Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('hotkeys-show-dock',
-                            this._builder.get_object('hotkeys_show_dock'),
-                            'active',
-                            Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('hot-keys',
-                            this._builder.get_object('hotkeys_show_dock'),
-                            'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-favorites',
                             this._builder.get_object('show_favorite_switch'),
@@ -337,6 +325,22 @@ const Settings = new Lang.Class({
                             Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-show-apps-button',
                             this._builder.get_object('application_button_animation_button'),
+                            'sensitive',
+                            Gio.SettingsBindFlags.DEFAULT);
+
+
+        // Behavior panel
+
+        this._settings.bind('hot-keys',
+                            this._builder.get_object('hot_keys_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('hotkeys-show-dock',
+                            this._builder.get_object('hotkeys_show_dock'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('hot-keys',
+                            this._builder.get_object('hotkeys_show_dock'),
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
 

--- a/prefs.js
+++ b/prefs.js
@@ -335,12 +335,8 @@ const Settings = new Lang.Class({
                             this._builder.get_object('hot_keys_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('hotkeys-show-dock',
-                            this._builder.get_object('hotkeys_show_dock'),
-                            'active',
-                            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('hot-keys',
-                            this._builder.get_object('hotkeys_show_dock'),
+                            this._builder.get_object('overlay_button'),
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
 
@@ -363,6 +359,60 @@ const Settings = new Lang.Class({
         }));
         this._builder.get_object('shift_middle_click_action_combo').connect('changed', Lang.bind (this, function(widget) {
             this._settings.set_enum('shift-middle-click-action', widget.get_active());
+        }));
+
+        // Create dialog for number overlay options
+        this._builder.get_object('overlay_button').connect('clicked', Lang.bind(this, function() {
+
+            let dialog = new Gtk.Dialog({ title: _('Show dock and application numbers'),
+                                          transient_for: this.widget.get_toplevel(),
+                                          use_header_bar: true,
+                                          modal: true });
+
+            // GTK+ leaves positive values for application-defined response ids.
+            // Use +1 for the reset action
+            dialog.add_button(_('Reset to defaults'), 1);
+
+            let box = this._builder.get_object('box_overlay_shortcut');
+            dialog.get_content_area().add(box);
+
+            this._builder.get_object('overlay_switch').set_active(this._settings.get_boolean('hotkeys-overlay'));
+            this._builder.get_object('show_dock_switch').set_active(this._settings.get_boolean('hotkeys-show-dock'));
+
+            this._settings.bind('shortcut-text',
+                                this._builder.get_object('shortcut_entry'),
+                                'text',
+                                Gio.SettingsBindFlags.DEFAULT);
+            this._settings.bind('hotkeys-overlay',
+                                this._builder.get_object('overlay_switch'),
+                                'active',
+                                Gio.SettingsBindFlags.DEFAULT);
+            this._settings.bind('hotkeys-show-dock',
+                                this._builder.get_object('show_dock_switch'),
+                                'active',
+                                Gio.SettingsBindFlags.DEFAULT);
+            this._settings.bind('shortcut-timeout',
+                                this._builder.get_object('timeout_spinbutton'),
+                                'value',
+                                Gio.SettingsBindFlags.DEFAULT);
+
+            dialog.connect('response', Lang.bind(this, function(dialog, id) {
+                if (id == 1) {
+                    // restore default settings for the relevant keys
+                    let keys = ['shortcut-text', 'hotkeys-overlay', 'hotkeys-show-dock', 'shortcut-timeout'];
+                    keys.forEach(function(val) {
+                        this._settings.set_value(val, this._settings.get_default_value(val));
+                    }, this);
+                } else {
+                    // remove the settings box so it doesn't get destroyed;
+                    dialog.get_content_area().remove(box);
+                    dialog.destroy();
+                }
+                return;
+            }));
+
+            dialog.show_all();
+
         }));
 
         // Create dialog for middle-click options

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -247,6 +247,18 @@
       <summary>Super Hot-Keys</summary>
       <description>Launch and switch between dash items using Super+(0-9)</description>
     </key>
+    <key type="b" name="hotkeys-show-dock">
+      <default>true</default>
+      <summary>Show the dock when using the hotkeys</summary>
+      <description>The dock will be quickly shown so that the number-overlay is visible and app activation is easier</description>
+    </key>
+    <key name="number-overlay-key" type="as">
+      <default><![CDATA[['<Super>z']]]></default>
+      <summary>Keybinding to launch 1st dash app</summary>
+      <description>
+        Keybinding to launch 1st app.
+      </description>
+    </key>
     <key name="app-ctrl-hotkey-1" type="as">
       <default><![CDATA[['<Ctrl><Super>1']]]></default>
       <summary>Keybinding to launch 1st dash app</summary>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -252,12 +252,25 @@
       <summary>Show the dock when using the hotkeys</summary>
       <description>The dock will be quickly shown so that the number-overlay is visible and app activation is easier</description>
     </key>
-    <key name="number-overlay-key" type="as">
-      <default><![CDATA[['<Super>z']]]></default>
-      <summary>Keybinding to launch 1st dash app</summary>
-      <description>
-        Keybinding to launch 1st app.
-      </description>
+    <key type="s" name="shortcut-text">
+      <default>"&lt;Super&gt;q"</default>
+      <summary>Keybinding to show the dock and the number overlay.</summary>
+      <description>Behavior depends on hotkeys-show-dock and hotkeys-overlay.</description>
+    </key>
+    <key type="as" name="shortcut">
+      <default><![CDATA[['<Super>q']]]></default>
+      <summary>Keybinding to show the dock and the number overlay.</summary>
+      <description>Behavior depends on hotkeys-show-dock and hotkeys-overlay.</description>
+    </key>
+    <key type="d" name="shortcut-timeout">
+      <default>2</default>
+      <summary>Timeout to hide the dock</summary>
+      <description>Sets the time duration before the dock is hidden again.</description>
+    </key>
+    <key type="b" name="hotkeys-overlay">
+      <default>true</default>
+      <summary>Show the dock when using the hotkeys</summary>
+      <description>The dock will be quickly shown so that the number-overlay is visible and app activation is easier</description>
     </key>
     <key name="app-ctrl-hotkey-1" type="as">
       <default><![CDATA[['<Ctrl><Super>1']]]></default>


### PR DESCRIPTION
Hi,

I created 2 new branches to rebase more easily. Here is the pull request for the hotkey feature.

I have 3 comments:
1. When using "minimize" as the click action, we can't use Super+Num to unminimize, due to the use of modifiers (Super). You specifically changed that in this commit [529304bc07b7c03b9f69b7ca37bb80ea9e27e01b], so I didn't change it back. Is there a specific reason? Can I add the `SHIFT_MASK` again?
2. I am not sure that the setting option fits well where it is (Setting.ui, in the Behavior Tab). I just added it somewhere for testing purposes. Let me know if we should put it somewhere else!
1. This line (https://github.com/micheleg/dash-to-dock/blob/master/appIcons.js#L278) is emitting errors due to th use of `event.get_click_count()`. This is logical since we don't have real clicks when pressing Super+Num. Anyway we can avoid that? Just so we don't spam the logs.

Obviously, credit to @anprogrammer! (Reference: https://github.com/micheleg/dash-to-dock/pull/87)
