### PR TITLE
Workspace Isolation improvement

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1410,22 +1410,18 @@ const DockedDash = new Lang.Class({
             this._signalsHandler.addWithLabel(label, [
                 global.screen,
                 'restacked',
-                Lang.bind(this, RestackAction)
+                Lang.bind(this.dash, this.dash._queueRedisplay)
             ]);
             this._signalsHandler.addWithLabel(label, [
                 global.window_manager,
                 'switch-workspace',
-                Lang.bind(this, RestackAction)
+                Lang.bind(this.dash, this.dash._queueRedisplay)
             ]);
         }
 
         function disable() {
             this._injectionsHandler.removeWithLabel(label);
             this._signalsHandler.removeWithLabel(label);
-        }
-
-        function RestackAction() {
-            this.dash._queueRedisplay();
         }
 
         function IsolatedOverview() {

--- a/docking.js
+++ b/docking.js
@@ -1412,6 +1412,11 @@ const DockedDash = new Lang.Class({
                 'restacked',
                 Lang.bind(this, RestackAction)
             ]);
+            this._signalsHandler.addWithLabel(label, [
+                global.window_manager,
+                'switch-workspace',
+                Lang.bind(this, RestackAction)
+            ]);
         }
 
         function disable() {
@@ -1420,7 +1425,7 @@ const DockedDash = new Lang.Class({
         }
 
         function RestackAction() {
-            Shell.AppSystem.get_default().emit('installed-changed');
+            this.dash._queueRedisplay();
         }
 
         function IsolatedOverview() {


### PR DESCRIPTION
Hi Michele,

This is a tiny PR.

1. I added a signal `'switch-workspace'`, since in Wayland sessions `'restacked'` is not emitted when changing workspace.
2. The update to the `RestackAction()` function is simply to improve efficiency.

I've used these changes enough (as usual, Debian stable and testing, so 3.14 and 3.20) that I'm confident they don't introduce problems.

Similar changes were introduced in the workspace-isolated-dash extension.