### PR TITLE
Support Gnome shell 3.21

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-"shell-version": ["3.18", "3.20"],
+"shell-version": ["3.18", "3.20", "3.21.90", "3.21.91", "3.21.92"],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",
 "description": "A dock for the Gnome Shell. This extension moves the dash out of the overview transforming it in a dock for an easier launching of applications and a faster switching between windows and desktops. Side and bottom placement options are available.",


### PR DESCRIPTION
Hi

I test your great extension with new gnome shell 3.21. Works fine, I haven't seen any problem.
I suggest to update it for this new gnome shell release.

Thanks for this very useful extension !
