### PR TITLE
Click to show dock when window maximized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 UUID = dash-to-dock@micxgx.gmail.com
 BASE_MODULES = extension.js stylesheet.css metadata.json COPYING README.md
-EXTRA_MODULES = convenience.js dash.js docking.js appIcons.js intellihide.js prefs.js theming.js Settings.ui
+EXTRA_MODULES = convenience.js dash.js docking.js appIcons.js windowPreview.js intellihide.js prefs.js theming.js Settings.ui
 EXTRA_MEDIA = logo.svg
 TOLOCALIZE =  prefs.js
 MSGSRC = $(wildcard po/*.po)

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,14 @@ EXTRA_MODULES = convenience.js dash.js docking.js appIcons.js windowPreview.js i
 EXTRA_MEDIA = logo.svg
 TOLOCALIZE =  prefs.js
 MSGSRC = $(wildcard po/*.po)
-INSTALLBASE = ~/.local/share/gnome-shell/extensions
+ifeq ($(strip $(DESTDIR)),)
+	INSTALLBASE = $(HOME)/.local/share/gnome-shell/extensions
+else
+	INSTALLBASE = $(DESTDIR)/usr/share/gnome-shell/extensions
+endif
 INSTALLNAME = dash-to-dock@micxgx.gmail.com
 
-# The command line passed variable VERSION is used to set the version string 
+# The command line passed variable VERSION is used to set the version string
 # in the metadata and in the generated zip-file. If no VERSION is passed, the
 # current commit SHA1 is used as version number in the metadata while the
 # generated zip file has no string attached.

--- a/Settings.ui
+++ b/Settings.ui
@@ -7,6 +7,11 @@
     <property name="step_increment">0.050000000000000003</property>
     <property name="page_increment">0.25</property>
   </object>
+  <object class="GtkAdjustment" id="shortcut_time_adjustment">
+    <property name="upper">10</property>
+    <property name="step_increment">0.250000000000000003</property>
+    <property name="page_increment">1</property>
+  </object>
   <object class="GtkAdjustment" id="custom_opacity_adjustement">
     <property name="upper">1</property>
     <property name="step_increment">0.01</property>
@@ -217,6 +222,266 @@
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="label_item">
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+  </object>
+  <object class="GtkBox" id="box_overlay_shortcut">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="margin_left">12</property>
+    <property name="margin_right">12</property>
+    <property name="margin_top">12</property>
+    <property name="margin_bottom">12</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkFrame" id="frame_overlay_show_dock">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label_xalign">0</property>
+        <property name="shadow_type">in</property>
+        <child>
+          <object class="GtkListBox" id="listbox_overlay_shortcut">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="selection_mode">none</property>
+            <child>
+              <object class="GtkListBoxRow" id="listboxrow_overlay_shortcut">
+                <property name="width_request">100</property>
+                <property name="height_request">80</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_overlay">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkSwitch" id="overlay_switch">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                        <property name="height">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="overlay_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Number overlay</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="overlay_description">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Temporarily show the application numbers over the icons, corresponding to the shortcut.</property>
+                        <property name="wrap">True</property>
+                        <property name="max-width-chars">40</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkListBoxRow" id="listboxrow_show_dock">
+                <property name="width_request">100</property>
+                <property name="height_request">80</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_show_dock">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkSwitch" id="show_dock_switch">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                        <property name="height">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="show_dock_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Show the dock if it is hidden</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="show_dock_description">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">If using autohide, the dock will appear for a short time when triggering the shortcut.</property>
+                        <property name="wrap">True</property>
+                        <property name="max-width-chars">40</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkListBoxRow" id="listboxrow_extra_shortcut">
+                <property name="width_request">100</property>
+                <property name="height_request">80</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_shortcut">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkEntry" id="shortcut_entry">
+                        <property name="width-chars">12</property>
+                        <property name="valign">center</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="shortcut_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Shortcut for the options above</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="shortcut_description">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="max-width-chars">40</property>
+                        <property name="label" translatable="yes">Syntax: &lt;Shift&gt;, &lt;Ctrl&gt;, &lt;Alt&gt;, &lt;Super&gt;</property>
+                        <property name="wrap">True</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkListBoxRow" id="listboxrow_timeout">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_timeout">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="hexpand">True</property>
+                    <property name="row_spacing">6</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkSpinButton" id="timeout_spinbutton">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">end</property>
+                        <property name="adjustment">shortcut_time_adjustment</property>
+                        <property name="digits">3</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="shortcut_timeout_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Hide timeout (s)</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                   </object>
@@ -1233,10 +1498,10 @@
       </packing>
     </child>
     <child type="tab">
-      <object class="GtkLabel" id="apps_label">
+      <object class="GtkLabel" id="launchers_label">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Apps</property>
+        <property name="label" translatable="yes">Launchers</property>
       </object>
       <packing>
         <property name="position">1</property>
@@ -1301,7 +1566,7 @@
                             <property name="can_focus">False</property>
                             <property name="hexpand">True</property>
                             <property name="xalign">0</property>
-                            <property name="label" translatable="yes">Use hotkeys to activate apps</property>
+                            <property name="label" translatable="yes">Use keyboard shortcuts to activate apps</property>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
@@ -1309,32 +1574,48 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkSwitch" id="hot_keys_switch">
+                          <object class="GtkBox" id="overlay_box">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="halign">end</property>
-                            <property name="valign">center</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkButton" id="overlay_button">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
+                                <property name="xalign">0.46000000834465027</property>
+                                <child>
+                                  <object class="GtkImage" id="image_overlay">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="icon_name">emblem-system-symbolic</property>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="circular"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSwitch" id="hot_keys_switch">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                              </object>
+                            </child>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
                             <property name="top_attach">0</property>
                             <property name="height">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="hotkeys_show_dock">
-                            <property name="label" translatable="yes">Quickly show the dock if it is hidden.</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="margin_top">12</property>
-                            <property name="xalign">0</property>
-                            <property name="draw_indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">2</property>
-                            <property name="width">2</property>
                           </packing>
                         </child>
                       </object>

--- a/Settings.ui
+++ b/Settings.ui
@@ -1146,7 +1146,7 @@
                             <property name="can_focus">False</property>
                             <property name="hexpand">True</property>
                             <property name="xalign">0</property>
-                            <property name="label" translatable="yes">If disabled, these settings are acccessible from gnome-tweak-tool or the extension website.</property>
+                            <property name="label" translatable="yes">If disabled, these settings are accessible from gnome-tweak-tool or the extension website.</property>
                             <property name="wrap">True</property>
                             <style>
                               <class name="dim-label"/>

--- a/Settings.ui
+++ b/Settings.ui
@@ -1087,6 +1087,29 @@
                             <property name="width">2</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkCheckButton" id="windows_preview_button">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="margin_top">3</property>
+                            <property name="xalign">0</property>
+                            <property name="draw_indicator">True</property>
+                            <child>
+                              <object class="GtkLabel" id="windows_previews_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Show open windows previews.</property>
+                                <property name="use_markup">True</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/Settings.ui
+++ b/Settings.ui
@@ -1987,6 +1987,51 @@
                     </child>
                   </object>
                 </child>
+                <child>
+                  <object class="GtkListBoxRow" id="listboxrow_rnd_border">
+                    <property name="width_request">100</property>
+                    <property name="height_request">80</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="force_straight_corner_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="valign">center</property>
+                            <property name="xpad">12</property>
+                            <property name="label" translatable="yes">Force straight corner
+</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="force_straight_corner_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="valign">center</property>
+                            <property name="margin_left">3</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">12</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
             <child type="label_item">

--- a/Settings.ui
+++ b/Settings.ui
@@ -1228,6 +1228,90 @@
           </packing>
         </child>
         <child>
+          <object class="GtkFrame" id="hot_keys_frame">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label_xalign">0</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkListBox" id="hot_keys_listbox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="selection_mode">none</property>
+                <child>
+                  <object class="GtkListBoxRow" id="hot_keys_listboxrow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkGrid" id="hot_keys_grid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="hot_keys_description">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="xalign">0</property>
+                            <property name="label" translatable="yes">Enable Super+(0-9) as shortcuts to activate apps. It can also be used together with Shift and Ctrl.</property>
+                            <property name="use_markup">True</property>
+                            <property name="wrap">True</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="hot_keys_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="xalign">0</property>
+                            <property name="label" translatable="yes">Use hotkeys to activate apps</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="hot_keys_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                            <property name="height">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label_item">
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkFrame" id="built_in_theme_frame3">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -1335,7 +1419,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -1419,7 +1503,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/Settings.ui
+++ b/Settings.ui
@@ -236,6 +236,245 @@
       </packing>
     </child>
   </object>
+  <object class="GtkBox" id="box_middle_click_options">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="margin_left">12</property>
+    <property name="margin_right">12</property>
+    <property name="margin_top">12</property>
+    <property name="margin_bottom">12</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkFrame" id="frame_middle_click_options">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label_xalign">0</property>
+        <property name="shadow_type">in</property>
+        <child>
+          <object class="GtkListBox" id="listbox_middle_click_options">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="selection_mode">none</property>
+            <child>
+              <object class="GtkListBoxRow" id="listboxrow11">
+                <property name="width_request">100</property>
+                <property name="height_request">80</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="buitin_theme7">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkLabel" id="builtin_theme_description4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="max-width-chars">40</property>
+                        <property name="label" translatable="yes">When set to minimize, double clicking minimizes all the windows of the application.</property>
+                        <property name="wrap">True</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="builtin_theme_label4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Shift+Click action</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="shift_click_action_combo">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">center</property>
+                        <items>
+                          <item translatable="yes">Raise window</item>
+                          <item translatable="yes">Minimize window</item>
+                          <item translatable="yes">Launch new instance</item>
+                          <item translatable="yes">Cycle through windows</item>
+                          <item translatable="yes">Quit</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                        <property name="height">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkListBoxRow" id="listboxrow_middle_click">
+                <property name="width_request">100</property>
+                <property name="height_request">80</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_middle_click">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkLabel" id="description_middle_click">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="max-width-chars">40</property>
+                        <property name="label" translatable="yes">Behavior for Middle-Click.</property>
+                        <property name="wrap">True</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_middle_click">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Middle-Click action</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="middle_click_action_combo">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">center</property>
+                        <items>
+                          <item translatable="yes">Raise window</item>
+                          <item translatable="yes">Minimize window</item>
+                          <item translatable="yes">Launch new instance</item>
+                          <item translatable="yes">Cycle through windows</item>
+                          <item translatable="yes">Quit</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                        <property name="height">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkListBoxRow" id="listboxrow_shift_middle_click">
+                <property name="width_request">100</property>
+                <property name="height_request">80</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_shift_middle_click">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkLabel" id="description_shift_middle_click">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="max-width-chars">40</property>
+                        <property name="label" translatable="yes">Behavior for Shift+Middle-Click.</property>
+                        <property name="wrap">True</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_shift_middle_click">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Shift+Middle-Click action</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="shift_middle_click_action_combo">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">center</property>
+                        <items>
+                          <item translatable="yes">Raise window</item>
+                          <item translatable="yes">Minimize window</item>
+                          <item translatable="yes">Launch new instance</item>
+                          <item translatable="yes">Cycle through windows</item>
+                          <item translatable="yes">Quit</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                        <property name="height">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="label_item">
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+  </object>
   <object class="GtkAdjustment" id="hide_timeout_adjustment">
     <property name="upper">1</property>
     <property name="step_increment">0.050000000000000003</property>
@@ -1020,85 +1259,43 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxText" id="click_action_combo">
+                          <object class="GtkBox" id="click_box">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="valign">center</property>
-                            <items>
-                              <item translatable="yes">Do nothing</item>
-                              <item translatable="yes">Minimize</item>
-                              <item translatable="yes">Launch new instance</item>
-                              <item translatable="yes">Cycle through windows</item>
-                            </items>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkButton" id="middle_click_options_button">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="valign">center</property>
+                                <child>
+                                  <object class="GtkImage" id="middle_click_image">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="icon_name">emblem-system-symbolic</property>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="circular"/>
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkComboBoxText" id="click_action_combo">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="valign">center</property>
+                                <items>
+                                  <item translatable="yes">Raise window</item>
+                                  <item translatable="yes">Minimize</item>
+                                  <item translatable="yes">Launch new instance</item>
+                                  <item translatable="yes">Cycle through windows</item>
+                                </items>
+                              </object>
+                            </child>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">0</property>
-                            <property name="height">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkListBoxRow" id="listboxrow11">
-                    <property name="width_request">100</property>
-                    <property name="height_request">80</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <child>
-                      <object class="GtkGrid" id="buitin_theme7">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">12</property>
-                        <property name="margin_right">12</property>
-                        <property name="margin_top">12</property>
-                        <property name="margin_bottom">12</property>
-                        <property name="column_spacing">32</property>
-                        <child>
-                          <object class="GtkLabel" id="builtin_theme_description4">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="hexpand">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">When set to minimize, double clicking minimizes all the windows of the application.</property>
-                            <property name="wrap">True</property>
-                            <style>
-                              <class name="dim-label"/>
-                            </style>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="builtin_theme_label4">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="hexpand">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">Shift+Click action</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBoxText" id="shift_click_action_combo">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="valign">center</property>
-                            <items>
-                              <item translatable="yes">Do nothing</item>
-                              <item translatable="yes">Minimize window</item>
-                            </items>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">0</property>
                             <property name="height">2</property>
                           </packing>
                         </child>

--- a/Settings.ui
+++ b/Settings.ui
@@ -1423,7 +1423,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkFrame" id="built_in_theme_frame1">
+          <object class="GtkFrame" id="built_in_theme_frame_scroll">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="label_xalign">0</property>
@@ -1434,11 +1434,11 @@
                 <property name="can_focus">False</property>
                 <property name="selection_mode">none</property>
                 <child>
-                  <object class="GtkListBoxRow" id="listboxrow7">
+                  <object class="GtkListBoxRow" id="listboxrow_scroll">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <child>
-                      <object class="GtkGrid" id="switch_workspace_grid">
+                      <object class="GtkGrid" id="buitin_theme_scroll">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="margin_left">12</property>
@@ -1447,14 +1447,13 @@
                         <property name="margin_bottom">12</property>
                         <property name="column_spacing">32</property>
                         <child>
-                          <object class="GtkLabel" id="switch_workspace_description">
+                          <object class="GtkLabel" id="builtin_theme_description_scroll">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="hexpand">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">With fixed icon size, only the edge of the dock and the &lt;i&gt;Show Applications&lt;/i&gt; icon are active.</property>
-                            <property name="use_markup">True</property>
+                            <property name="label" translatable="yes">Behaviour when scrolling on the icon of an application.</property>
                             <property name="wrap">True</property>
+                            <property name="xalign">0</property>
                             <style>
                               <class name="dim-label"/>
                             </style>
@@ -1465,12 +1464,12 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="switch_workspace_label">
+                          <object class="GtkLabel" id="builtin_theme_label_scroll">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Scroll action</property>
                             <property name="xalign">0</property>
-                            <property name="label" translatable="yes">Switch workspace by scrolling on the dock</property>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
@@ -1478,11 +1477,27 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkSwitch" id="switch_workspace_switch">
+                          <object class="GtkBox" id="click_box_scroll">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="halign">end</property>
-                            <property name="valign">center</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkComboBoxText" id="scroll_action_combo">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="valign">center</property>
+                                <items>
+                                  <item translatable="yes">Do nothing</item>
+                                  <item translatable="yes">Cycle through windows</item>
+                                  <item translatable="yes">Switch workspace</item>
+                                </items>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>

--- a/Settings.ui
+++ b/Settings.ui
@@ -1295,6 +1295,22 @@
                             <property name="height">2</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkCheckButton" id="hotkeys_show_dock">
+                            <property name="label" translatable="yes">Quickly show the dock if it is hidden.</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="margin_top">12</property>
+                            <property name="xalign">0</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/Settings.ui
+++ b/Settings.ui
@@ -971,7 +971,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkBox" id="behaviour">
+      <object class="GtkBox" id="apps">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="margin_left">24</property>
@@ -1227,6 +1227,32 @@
             <property name="position">0</property>
           </packing>
         </child>
+      </object>
+      <packing>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child type="tab">
+      <object class="GtkLabel" id="apps_label">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Apps</property>
+      </object>
+      <packing>
+        <property name="position">1</property>
+        <property name="tab_fill">False</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox" id="behaviour">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_left">24</property>
+        <property name="margin_right">24</property>
+        <property name="margin_top">24</property>
+        <property name="margin_bottom">24</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">24</property>
         <child>
           <object class="GtkFrame" id="hot_keys_frame">
             <property name="visible">True</property>
@@ -1539,7 +1565,7 @@
         </child>
       </object>
       <packing>
-        <property name="position">1</property>
+        <property name="position">2</property>
       </packing>
     </child>
     <child type="tab">
@@ -1549,7 +1575,7 @@
         <property name="label" translatable="yes">Behavior</property>
       </object>
       <packing>
-        <property name="position">1</property>
+        <property name="position">2</property>
         <property name="tab_fill">False</property>
       </packing>
     </child>
@@ -2077,7 +2103,7 @@
         </child>
       </object>
       <packing>
-        <property name="position">2</property>
+        <property name="position">3</property>
       </packing>
     </child>
     <child type="tab">
@@ -2087,7 +2113,7 @@
         <property name="label" translatable="yes">Appearance</property>
       </object>
       <packing>
-        <property name="position">2</property>
+        <property name="position">3</property>
         <property name="tab_fill">False</property>
       </packing>
     </child>
@@ -2252,7 +2278,7 @@ See the &lt;a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"&gt;G
         </child>
       </object>
       <packing>
-        <property name="position">3</property>
+        <property name="position">4</property>
       </packing>
     </child>
     <child type="tab">
@@ -2262,7 +2288,7 @@ See the &lt;a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"&gt;G
         <property name="label" translatable="yes">About</property>
       </object>
       <packing>
-        <property name="position">3</property>
+        <property name="position">4</property>
         <property name="tab_fill">False</property>
       </packing>
     </child>

--- a/appIcons.js
+++ b/appIcons.js
@@ -234,7 +234,7 @@ const MyAppIcon = new Lang.Class({
         let focusedApp = tracker.focus_app;
 
         // Only consider SHIFT and CONTROL as modifiers (exclude SUPER, CAPS-LOCK, etc.)
-        modifiers = modifiers & (Clutter.ModifierType.SHIFT_MASK | Clutter.ModifierType.CTRL_MASK);
+        modifiers = modifiers & (Clutter.ModifierType.SHIFT_MASK | Clutter.ModifierType.CONTROL_MASK);
 
         // We don't change the CTRL-click behaviour: in such case we just chain
         // up the parent method and return.

--- a/appIcons.js
+++ b/appIcons.js
@@ -716,6 +716,20 @@ const MyAppIconMenu = new Lang.Class({
                     this._appendSeparator();
                 }
 
+
+                if (AppDisplay.discreteGpuAvailable &&
+                    this._source.app.state == Shell.AppState.STOPPED &&
+                    actions.indexOf('activate-discrete-gpu') == -1) {
+                    this._onDiscreteGpuMenuItem = this._appendMenuItem(_("Launch using Dedicated Graphics Card"));
+                    this._onDiscreteGpuMenuItem.connect('activate', Lang.bind(this, function() {
+                        if (this._source.app.state == Shell.AppState.STOPPED)
+                            this._source.animateLaunch();
+
+                        this._source.app.launch(0, -1, true);
+                        this.emit('activate-window', null);
+                    }));
+                }
+
                 for (let i = 0; i < actions.length; i++) {
                     let action = actions[i];
                     let item = this._appendMenuItem(appInfo.get_action_name(action));

--- a/appIcons.js
+++ b/appIcons.js
@@ -305,7 +305,10 @@ const MyAppIcon = new Lang.Class({
                     if (this.app == focusedApp || button == 2 || modifiers & Clutter.ModifierType.SHIFT_MASK) {
                         // minimize all windows on double click and always in the case of primary click without
                         // additional modifiers
-                        let all_windows = (button == 1 && ! modifiers) || event.get_click_count() > 1
+                        let click_count = 0;
+                        if (Clutter.EventType.CLUTTER_BUTTON_PRESS)
+                            click_count = event.get_click_count();
+                        let all_windows = (button == 1 && ! modifiers) || click_count > 1;
                         minimizeWindow(this.app, all_windows, this._dtdSettings);
                     }
                     else

--- a/appIcons.js
+++ b/appIcons.js
@@ -625,27 +625,40 @@ function closeAllWindows(app, settings) {
         windows[i].delete(global.get_current_time());
 }
 
-/*
-* This is used as a workaround for a bug resulting in no new windows being opened
-* for certain running applications when calling open_new_window().
-*
-* https://bugzilla.gnome.org/show_bug.cgi?id=756844
-*
-* Similar to what done when generating the popupMenu entries, if the application provides
-*  a "New Window" action, use it instead of direclt requesting a new window with
-* open_new_window(), which fails for certain application, notably Nautilus.
-*/
+/* Try to do the right thing when attempting to launch a new window of an app. In
+ * particular, if the application doens't allow to launch a new window, activate
+ * the existing window instead.
+ */
 function appLaunchNewWindow(app) {
     let appInfo = app.get_app_info();
     let actions = appInfo.list_actions();
-    if (actions.indexOf('new-window') == -1) {
-        app.open_new_window(-1);
+    if (app.can_open_new_window()) {
+        // This is used as a workaround for a bug resulting in no new windows being opened
+        // for certain running applications when calling open_new_window().
+        //
+        // https://bugzilla.gnome.org/show_bug.cgi?id=756844
+        //
+        // Similar to what done when generating the popupMenu entries, if the application provides
+        // a "New Window" action, use it instead of directly requesting a new window with
+        // open_new_window(), which fails for certain application, notably Nautilus.
+        if (actions.indexOf('new-window') == -1) {
+            app.open_new_window(-1);
+        }
+        else {
+            i = actions.indexOf('new-window');
+            if (i !== -1)
+                app.launch_action(actions[i], global.get_current_time(), -1);
+        }
     }
     else {
-        i = actions.indexOf('new-window');
-        if (i !== -1)
-            app.launch_action(actions[i], global.get_current_time(), -1);
-
+        // Try to manually activate the first window. Otherwise, when the app is activated by
+        // switching to a different workspace, a launch spinning icon is shown and disappers only
+        // after a timeout.
+        let windows = app.get_windows();
+        if (windows.length > 0)
+            Main.activateWindow(windows[0])
+        else
+            app.activate();
     }
 }
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -24,6 +24,7 @@ const Workspace = imports.ui.workspace;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
+const WindowPreview = Me.imports.windowPreview;
 
 let tracker = Shell.WindowTracker.get_default();
 
@@ -194,6 +195,19 @@ const MyAppIcon = new Lang.Class({
             this._menu.connect('open-state-changed', Lang.bind(this, function(menu, isPoppedUp) {
                 if (!isPoppedUp)
                     this._onMenuPoppedDown();
+                else {
+                    // Setting the max-height is s useful if part of the menu is
+                    // scrollable so the minimum height is smaller than the natural height.
+                    let monitor_index = Main.layoutManager.findIndexForActor(this.actor);
+                    let workArea = Main.layoutManager.getWorkAreaForMonitor(monitor_index);
+                    let position = Convenience.getPosition(this._dtdSettings);
+                    this._isHorizontal = ( position == St.Side.TOP ||
+                                           position == St.Side.BOTTOM);
+                    // If horizontal also remove the height of the dash
+                    let additional_margin = this._isHorizontal && !this._dtdSettings.get_boolean('dock-fixed') ? Main.overview._dash.actor.height : 0;
+                    let verticalMargins = this._menu.actor.margin_top + this._menu.actor.margin_bottom;
+                    this._menu.actor.style = ('max-height: ' + Math.round(workArea.height - additional_margin - verticalMargins) + 'px;');
+                }
             }));
             let id = Main.overview.connect('hiding', Lang.bind(this, function() {
                 this._menu.close();
@@ -515,7 +529,9 @@ function resetRecentlyClickedApp() {
  * - set popup arrow side based on dash orientation
  * - Add close windows option based on quitfromdash extension
  *   (https://github.com/deuill/shell-extension-quitfromdash)
+ * - Add open windows thumbnails instead of list
  */
+const SHOW_WINDOWS_PREVIEW = true;
 const MyAppIconMenu = new Lang.Class({
     Name: 'DashToDock.MyAppIconMenu',
     Extends: AppDisplay.AppIconMenu,
@@ -537,7 +553,119 @@ const MyAppIconMenu = new Lang.Class({
     },
 
     _redisplay: function() {
-        this.parent();
+        this.removeAll();
+
+        if (SHOW_WINDOWS_PREVIEW) {
+            // Display the app windows menu items and the separator between windows
+            // of the current desktop and other windows.
+
+            let windows = this._source.app.get_windows().filter(function(w) {
+                return !w.skip_taskbar;
+            });
+
+            if (windows.length > 0) {
+
+                this._allWindowsMenuItem = new PopupMenu.PopupSubMenuMenuItem(_('All Windows'), false);
+                this.addMenuItem(this._allWindowsMenuItem);
+
+                let activeWorkspace = global.screen.get_active_workspace();
+                let separatorShown =  windows[0].get_workspace() != activeWorkspace;
+
+                for (let i = 0; i < windows.length; i++) {
+                    let window = windows[i];
+                    if (!separatorShown && window.get_workspace() != activeWorkspace) {
+                        this._allWindowsMenuItem.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+                        separatorShown = true;
+                    }
+
+                    let item = new WindowPreview.WindowPreviewMenuItem(window);
+                    this._allWindowsMenuItem.menu.addMenuItem(item);
+                    item.connect('activate', Lang.bind(this, function() {
+                        this.emit('activate-window', window);
+                    }));
+
+                }
+
+                // Try to set the width to that of the submenu.
+                // TODO: can't get the actual size, getting a bit less.
+                // Temporary workaround: add 15px to compensate
+                this._allWindowsMenuItem.actor.width =  this._allWindowsMenuItem.menu.actor.width + 15;
+
+            }
+
+            if (!this._source.app.is_window_backed()) {
+                this._appendSeparator();
+
+                let appInfo = this._source.app.get_app_info();
+                let actions = appInfo.list_actions();
+                if (this._source.app.can_open_new_window() &&
+                    actions.indexOf('new-window') == -1) {
+                    this._newWindowMenuItem = this._appendMenuItem(_("New Window"));
+                    this._newWindowMenuItem.connect('activate', Lang.bind(this, function() {
+                        if (this._source.app.state == Shell.AppState.STOPPED)
+                            this._source.animateLaunch();
+
+                        this._source.app.open_new_window(-1);
+                        this.emit('activate-window', null);
+                    }));
+                    this._appendSeparator();
+                }
+
+                for (let i = 0; i < actions.length; i++) {
+                    let action = actions[i];
+                    let item = this._appendMenuItem(appInfo.get_action_name(action));
+                    item.connect('activate', Lang.bind(this, function(emitter, event) {
+                        this._source.app.launch_action(action, event.get_time(), -1);
+                        this.emit('activate-window', null);
+                    }));
+                }
+
+                let canFavorite = global.settings.is_writable('favorite-apps');
+
+                if (canFavorite) {
+                    this._appendSeparator();
+
+                    let isFavorite = AppFavorites.getAppFavorites().isFavorite(this._source.app.get_id());
+
+                    if (isFavorite) {
+                        let item = this._appendMenuItem(_("Remove from Favorites"));
+                        item.connect('activate', Lang.bind(this, function() {
+                            let favs = AppFavorites.getAppFavorites();
+                            favs.removeFavorite(this._source.app.get_id());
+                        }));
+                    } else {
+                        let item = this._appendMenuItem(_("Add to Favorites"));
+                        item.connect('activate', Lang.bind(this, function() {
+                            let favs = AppFavorites.getAppFavorites();
+                            favs.addFavorite(this._source.app.get_id());
+                        }));
+                    }
+                }
+
+                if (Shell.AppSystem.get_default().lookup_app('org.gnome.Software.desktop')) {
+                    this._appendSeparator();
+                    let item = this._appendMenuItem(_("Show Details"));
+                    item.connect('activate', Lang.bind(this, function() {
+                        let id = this._source.app.get_id();
+                        let args = GLib.Variant.new('(ss)', [id, '']);
+                        Gio.DBus.get(Gio.BusType.SESSION, null,
+                            function(o, res) {
+                                let bus = Gio.DBus.get_finish(res);
+                                bus.call('org.gnome.Software',
+                                         '/org/gnome/Software',
+                                         'org.gtk.Actions', 'Activate',
+                                         GLib.Variant.new('(sava{sv})',
+                                                          ['details', [args], null]),
+                                         null, 0, -1, null, null);
+                                Main.overview.hide();
+                            });
+                    }));
+                }
+            }
+
+        } else {
+            this.parent();
+        }
 
         // quit menu
         let app = this._source.app;
@@ -557,6 +685,7 @@ const MyAppIconMenu = new Lang.Class({
         }
     }
 });
+Signals.addSignalMethods(MyAppIconMenu.prototype);
 
 // Filter out unnecessary windows, for instance
 // nautilus desktop window.

--- a/appIcons.js
+++ b/appIcons.js
@@ -233,6 +233,9 @@ const MyAppIcon = new Lang.Class({
         let modifiers = event ? event.get_state() : 0;
         let focusedApp = tracker.focus_app;
 
+        // Only consider SHIFT and CONTROL as modifiers (exclude SUPER, CAPS-LOCK, etc.)
+        modifiers = modifiers & (Clutter.ModifierType.SHIFT_MASK | Clutter.ModifierType.CTRL_MASK);
+
         // We don't change the CTRL-click behaviour: in such case we just chain
         // up the parent method and return.
         if (modifiers & Clutter.ModifierType.CONTROL_MASK) {

--- a/appIcons.js
+++ b/appIcons.js
@@ -652,11 +652,7 @@ const MyAppIconMenu = new Lang.Class({
         this._appendSeparator();
         this._quitfromDashMenuItem = this._appendMenuItem(_("Quit"));
         this._quitfromDashMenuItem.connect('activate', Lang.bind(this, function() {
-            let app = this._source.app;
-            let windows = app.get_windows();
-            for (let i = 0; i < windows.length; i++) {
-                this._closeWindowInstance(windows[i])
-            }
+            closeAllWindows(this._source.app, this._dtdSettings);
         }));
 
         this.update();
@@ -668,9 +664,7 @@ const MyAppIconMenu = new Lang.Class({
 
       if(this._dtdSettings.get_boolean('show-windows-preview')){
 
-          let windows = this._source.app.get_windows().filter(function(w) {
-              return !w.skip_taskbar;
-          });
+          let windows = getInterestingWindows(this._source.app, this._dtdSettings);
 
           // update, show or hide the quit menu
           if ( windows.length > 0) {

--- a/appIcons.js
+++ b/appIcons.js
@@ -543,7 +543,6 @@ function resetRecentlyClickedApp() {
  * - Add open windows thumbnails instead of list
  * - update menu when application windows change
  */
-const SHOW_WINDOWS_PREVIEW = true;
 const MyAppIconMenu = new Lang.Class({
     Name: 'DashToDock.MyAppIconMenu',
     Extends: AppDisplay.AppIconMenu,
@@ -567,7 +566,7 @@ const MyAppIconMenu = new Lang.Class({
     _redisplay: function() {
         this.removeAll();
 
-        if (SHOW_WINDOWS_PREVIEW) {
+        if (this._dtdSettings.get_boolean('show-windows-preview')) {
             // Display the app windows menu items and the separator between windows
             // of the current desktop and other windows.
 
@@ -667,7 +666,7 @@ const MyAppIconMenu = new Lang.Class({
     // acting on windows (closing) are performed while the menu is shown.
     update: function() {
 
-      if(SHOW_WINDOWS_PREVIEW){
+      if(this._dtdSettings.get_boolean('show-windows-preview')){
 
           let windows = this._source.app.get_windows().filter(function(w) {
               return !w.skip_taskbar;

--- a/appIcons.js
+++ b/appIcons.js
@@ -100,6 +100,12 @@ const MyAppIcon = new Lang.Class({
     _onDestroy: function() {
         this.parent();
 
+        // This is necessary due to an upstream bug
+        // https://bugzilla.gnome.org/show_bug.cgi?id=757556
+        // It can be safely removed once it get solved upstrea.
+        if (this._menu)
+            this._menu.close(false);
+
         // Disconect global signals
         // stateChangedId is already handled by parent)
         if (this._focusAppId > 0)

--- a/appIcons.js
+++ b/appIcons.js
@@ -107,6 +107,7 @@ const MyAppIcon = new Lang.Class({
         }));
         this._optionalScrollCycleWindows();
 
+        this._numberOverlay();
     },
 
     _onDestroy: function() {
@@ -513,6 +514,61 @@ const MyAppIcon = new Lang.Class({
         Clutter.cairo_set_source_color(cr, bodyColor);
         cr.fill();
         cr.$dispose();
+    },
+
+    _numberOverlay: function() {
+        // Add label for a Hot-Key visual aid
+        this._numberOverlayLabel = new St.Label();
+        this._numberOverlayBin = new St.Bin({child: this._numberOverlayLabel });
+        this._numberOverlayStyle = 'background-color: rgba(0,0,0,0.8);'
+        this._numberOverlayOrder = -1;
+        this._numberOverlayBin.hide();
+
+        // iconBox is a Shell.GenericContainer from IconGrid.BaseIcon
+        this.iconBox = new Shell.GenericContainer();
+        this._iconContainer.add_child(this.iconBox);
+        // We have to add allocation of counterBin.
+        this.iconBox.connect('allocate', Lang.bind(this, this._allocateIconBox));
+
+        this.iconBox.add_actor(this._numberOverlayBin);
+
+        this._updateNumberOverlay();
+    },
+
+    _allocateIconBox: function(actor, box, flags) {
+        let childBox = new Clutter.ActorBox();
+        let naturalHeight = this.icon.iconSize;
+        // Partial size for the overlay:
+        naturalHeight *= 0.6;
+
+        childBox.x1 = box.x2 - naturalHeight/2;
+        childBox.x2 = box.x2 + naturalHeight/2;
+        childBox.y1 = box.y2 - naturalHeight/2;
+        childBox.y2 = box.y2 + naturalHeight/2;
+
+        this._numberOverlayBin.allocate(childBox, flags);
+    },
+
+    _updateNumberOverlay: function() {
+        let size = this.icon.iconSize;
+        // Set the font size to something smaller than the whole icon so it is
+        // still visible. The border radius is large to make the shape circular
+        let font_size = Math.round(0.4 * size);
+        this._numberOverlayBin.set_style(this._numberOverlayStyle +
+                                         'font-size: ' + font_size + 'px;' +
+                                         'border-radius: ' + size + 'px;');
+    },
+
+    setNumberOverlay: function(number) {
+        this._numberOverlayOrder = number;
+        this._numberOverlayLabel.set_text(number.toString());
+    },
+
+    toggleNumberOverlay: function(activate) {
+        if (activate && this._numberOverlayOrder > -1)
+           this._numberOverlayBin.show();
+        else
+           this._numberOverlayBin.hide();
     }
 });
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -54,6 +54,7 @@ let recentlyClickedAppIndex = 0;
  * - Add a .focused style to the focused app
  * - Customize click actions.
  * - Update minimization animation target
+ * - Update menu if open on windows change
  */
 const MyAppIcon = new Lang.Class({
     Name: 'DashToDock.AppIcon',
@@ -113,6 +114,10 @@ const MyAppIcon = new Lang.Class({
     },
 
     onWindowsChanged: function() {
+
+        if (this._menu && this._menu.isOpen)
+            this._menu.update();
+
         this._updateRunningStyle();
         this.updateIconGeometry();
     },
@@ -536,6 +541,7 @@ function resetRecentlyClickedApp() {
  * - Add close windows option based on quitfromdash extension
  *   (https://github.com/deuill/shell-extension-quitfromdash)
  * - Add open windows thumbnails instead of list
+ * - update menu when application windows change
  */
 const SHOW_WINDOWS_PREVIEW = true;
 const MyAppIconMenu = new Lang.Class({
@@ -565,39 +571,8 @@ const MyAppIconMenu = new Lang.Class({
             // Display the app windows menu items and the separator between windows
             // of the current desktop and other windows.
 
-            let windows = this._source.app.get_windows().filter(function(w) {
-                return !w.skip_taskbar;
-            });
-
-            if (windows.length > 0) {
-
-                this._allWindowsMenuItem = new PopupMenu.PopupSubMenuMenuItem(_('All Windows'), false);
-                this.addMenuItem(this._allWindowsMenuItem);
-
-                let activeWorkspace = global.screen.get_active_workspace();
-                let separatorShown =  windows[0].get_workspace() != activeWorkspace;
-
-                for (let i = 0; i < windows.length; i++) {
-                    let window = windows[i];
-                    if (!separatorShown && window.get_workspace() != activeWorkspace) {
-                        this._allWindowsMenuItem.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-                        separatorShown = true;
-                    }
-
-                    let item = new WindowPreview.WindowPreviewMenuItem(window);
-                    this._allWindowsMenuItem.menu.addMenuItem(item);
-                    item.connect('activate', Lang.bind(this, function() {
-                        this.emit('activate-window', window);
-                    }));
-
-                }
-
-                // Try to set the width to that of the submenu.
-                // TODO: can't get the actual size, getting a bit less.
-                // Temporary workaround: add 15px to compensate
-                this._allWindowsMenuItem.actor.width =  this._allWindowsMenuItem.menu.actor.width + 15;
-
-            }
+            this._allWindowsMenuItem = new PopupMenu.PopupSubMenuMenuItem(_('All Windows'), false);
+            this.addMenuItem(this._allWindowsMenuItem);
 
             if (!this._source.app.is_window_backed()) {
                 this._appendSeparator();
@@ -674,22 +649,100 @@ const MyAppIconMenu = new Lang.Class({
         }
 
         // quit menu
-        let app = this._source.app;
-        let count = getInterestingWindows(app, this._dtdSettings).length;
-        if ( count > 0) {
-            this._appendSeparator();
-            let quitFromDashMenuText = '';
-            if (count == 1)
-                quitFromDashMenuText = _('Quit');
-            else
-                quitFromDashMenuText = _('Quit') + ' ' + count + ' ' + _('Windows');
+        this._appendSeparator();
+        this._quitfromDashMenuItem = this._appendMenuItem(_("Quit"));
+        this._quitfromDashMenuItem.connect('activate', Lang.bind(this, function() {
+            let app = this._source.app;
+            let windows = app.get_windows();
+            for (let i = 0; i < windows.length; i++) {
+                this._closeWindowInstance(windows[i])
+            }
+        }));
 
-            this._quitfromDashMenuItem = this._appendMenuItem(quitFromDashMenuText);
-            this._quitfromDashMenuItem.connect('activate', Lang.bind(this, function() {
-                closeAllWindows(this._source.app, this._dtdSettings);
-            }));
-        }
-    }
+        this.update();
+    },
+
+    // update menu content when application windows change. This is desirable as actions
+    // acting on windows (closing) are performed while the menu is shown.
+    update: function() {
+
+      if(SHOW_WINDOWS_PREVIEW){
+
+          let windows = this._source.app.get_windows().filter(function(w) {
+              return !w.skip_taskbar;
+          });
+
+          // update, show or hide the quit menu
+          if ( windows.length > 0) {
+              let quitFromDashMenuText = "";
+              if (windows.length == 1)
+                  this._quitfromDashMenuItem.label.set_text(_("Quit"));
+              else
+                  this._quitfromDashMenuItem.label.set_text(_("Quit") + ' ' + windows.length + ' ' + _("Windows"));
+
+              this._quitfromDashMenuItem.actor.show();
+
+          } else {
+              this._quitfromDashMenuItem.actor.hide();
+          }
+
+          // update, show, or hide the allWindows menu
+          // Check if there are new windows not already displayed. In such case, repopulate the allWindows
+          // menu. Windows removal is already handled by each preview being connected to the destroy signal
+          let old_windows = this._allWindowsMenuItem.menu._getMenuItems().map(function(item){
+              if (item._window)
+                  return item._window;
+          })
+
+          let new_windows = windows.filter(function(w) {return old_windows.indexOf(w) < 0;});
+          if (new_windows.length > 0) {
+              this._populateAllWindowMenu(windows);
+
+              // Try to set the width to that of the submenu.
+              // TODO: can't get the actual size, getting a bit less.
+              // Temporary workaround: add 15px to compensate
+              this._allWindowsMenuItem.actor.width =  this._allWindowsMenuItem.menu.actor.width + 15;
+
+              }
+
+          if (windows.length > 0){
+              this._allWindowsMenuItem.actor.show();
+          } else {
+              this._allWindowsMenuItem.actor.hide();
+              this._allWindowsMenuItem.menu.close();
+          }
+
+          // Update separators
+          this._getMenuItems().forEach(Lang.bind(this, this._updateSeparatorVisibility));
+      }
+
+
+    },
+
+    _populateAllWindowMenu: function(windows) {
+
+        this._allWindowsMenuItem.menu.removeAll();
+
+            if (windows.length > 0) {
+
+                let activeWorkspace = global.screen.get_active_workspace();
+                let separatorShown =  windows[0].get_workspace() != activeWorkspace;
+
+                for (let i = 0; i < windows.length; i++) {
+                    let window = windows[i];
+                    if (!separatorShown && window.get_workspace() != activeWorkspace) {
+                        this._allWindowsMenuItem.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+                        separatorShown = true;
+                    }
+
+                    let item = new WindowPreview.WindowPreviewMenuItem(window);
+                    this._allWindowsMenuItem.menu.addMenuItem(item);
+                    item.connect('activate', Lang.bind(this, function() {
+                        this.emit('activate-window', window);
+                    }));
+                }
+            }
+    },
 });
 Signals.addSignalMethods(MyAppIconMenu.prototype);
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -285,7 +285,9 @@ const MyAppIcon = new Lang.Class({
                     // If horizontal also remove the height of the dash
                     let additional_margin = this._isHorizontal && !this._dtdSettings.get_boolean('dock-fixed') ? Main.overview._dash.actor.height : 0;
                     let verticalMargins = this._menu.actor.margin_top + this._menu.actor.margin_bottom;
-                    this._menu.actor.style = ('max-height: ' + Math.round(workArea.height - additional_margin - verticalMargins) + 'px;');
+                    // Also set a max width to the menu, so long labels (long windows title) get truncated
+                    this._menu.actor.style = ('max-height: ' + Math.round(workArea.height - additional_margin - verticalMargins) + 'px;' +
+                                              'max-width: 400px');
                 }
             }));
             let id = Main.overview.connect('hiding', Lang.bind(this, function() {

--- a/appIcons.js
+++ b/appIcons.js
@@ -572,6 +572,7 @@ const MyAppIconMenu = new Lang.Class({
             // of the current desktop and other windows.
 
             this._allWindowsMenuItem = new PopupMenu.PopupSubMenuMenuItem(_('All Windows'), false);
+            this._allWindowsMenuItem.actor.hide();
             this.addMenuItem(this._allWindowsMenuItem);
 
             if (!this._source.app.is_window_backed()) {
@@ -703,13 +704,13 @@ const MyAppIconMenu = new Lang.Class({
               // Temporary workaround: add 15px to compensate
               this._allWindowsMenuItem.actor.width =  this._allWindowsMenuItem.menu.actor.width + 15;
 
-              }
+          }
 
+          // The menu is created hidden and never hidded after being shown. Instead, a singlal
+          // connected to its items destroy will set is insensitive if no more windows preview are shown.
           if (windows.length > 0){
               this._allWindowsMenuItem.actor.show();
-          } else {
-              this._allWindowsMenuItem.actor.hide();
-              this._allWindowsMenuItem.menu.close();
+              this._allWindowsMenuItem.setSensitive(true);
           }
 
           // Update separators
@@ -739,6 +740,12 @@ const MyAppIconMenu = new Lang.Class({
                     this._allWindowsMenuItem.menu.addMenuItem(item);
                     item.connect('activate', Lang.bind(this, function() {
                         this.emit('activate-window', window);
+                    }));
+
+                    // This is to achieve a more gracefull transition when the last windows is closed.
+                    item.connect('destroy', Lang.bind(this, function() {
+                        if(this._allWindowsMenuItem.menu._getMenuItems().length == 1) // It's still counting the item just going to be destroyed
+                            this._allWindowsMenuItem.setSensitive(false);
                     }));
                 }
             }

--- a/appIcons.js
+++ b/appIcons.js
@@ -553,10 +553,12 @@ const MyAppIcon = new Lang.Class({
     },
 
     toggleNumberOverlay: function(activate) {
-        if (activate && this._numberOverlayOrder > -1)
-           this._numberOverlayBin.show();
+        if (activate && this._numberOverlayOrder > -1) {
+            this.updateNumberOverlay();
+            this._numberOverlayBin.show();
+        }
         else
-           this._numberOverlayBin.hide();
+            this._numberOverlayBin.hide();
     }
 });
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -519,44 +519,32 @@ const MyAppIcon = new Lang.Class({
     _numberOverlay: function() {
         // Add label for a Hot-Key visual aid
         this._numberOverlayLabel = new St.Label();
-        this._numberOverlayBin = new St.Bin({child: this._numberOverlayLabel });
+        this._numberOverlayBin = new St.Bin({
+            child: this._numberOverlayLabel,
+            x_align: St.Align.START, y_align: St.Align.START,
+            x_expand: true, y_expand: true
+        });
         this._numberOverlayStyle = 'background-color: rgba(0,0,0,0.8);'
         this._numberOverlayOrder = -1;
         this._numberOverlayBin.hide();
 
-        // genericContainer is a Shell.GenericContainer from IconGrid.BaseIcon
-        let genericContainer = new Shell.GenericContainer();
-        this._iconContainer.add_child(genericContainer);
-        // We have to add allocation of counterBin.
-        genericContainer.connect('allocate', Lang.bind(this, this._allocateIconBox));
+        this._iconContainer.add_child(this._numberOverlayBin);
 
-        genericContainer.add_actor(this._numberOverlayBin);
-
-        this.updateNumberOverlay();
-    },
-
-    _allocateIconBox: function(actor, box, flags) {
-        let childBox = new Clutter.ActorBox();
-        let naturalHeight = this.icon.iconSize;
-        // Partial size for the overlay:
-        naturalHeight *= 0.6;
-
-        childBox.x1 = box.x2 - naturalHeight/2;
-        childBox.x2 = box.x2 + naturalHeight/2;
-        childBox.y1 = box.y2 - naturalHeight/2;
-        childBox.y2 = box.y2 + naturalHeight/2;
-
-        this._numberOverlayBin.allocate(childBox, flags);
     },
 
     updateNumberOverlay: function() {
-        let size = this.icon.iconSize;
         // Set the font size to something smaller than the whole icon so it is
         // still visible. The border radius is large to make the shape circular
-        let font_size = Math.round(0.4 * size);
-        this._numberOverlayBin.set_style(this._numberOverlayStyle +
-                                         'font-size: ' + font_size + 'px;' +
-                                         'border-radius: ' + size + 'px;');
+        let [minWidth, natWidth] = this._iconContainer.get_preferred_width(-1);
+        let font_size =  Math.round(Math.max(12, 0.3*natWidth));
+        let size = Math.round(font_size*1.2);
+        this._numberOverlayLabel.set_style(
+            this._numberOverlayStyle +
+           'font-size: ' + font_size + 'px;' +
+           'text-align: center;' +
+           'border-radius: ' + this.icon.iconSize + 'px;' +
+           'width: ' + size + 'px; height: ' + size +'px;'
+        );
     },
 
     setNumberOverlay: function(number) {

--- a/appIcons.js
+++ b/appIcons.js
@@ -166,15 +166,17 @@ const MyAppIcon = new Lang.Class({
         }
 
         let focusedApp = tracker.focus_app;
-        if (!Main.overview._shown){
+        if (!Main.overview._shown) {
             let reversed = direction === Meta.MotionDirection.UP;
             if (this.app == focusedApp)
                 cycleThroughWindows(this.app, this._dtdSettings, reversed);
             else {
                 // Activate the first window
                 let windows = getInterestingWindows(this.app, this._dtdSettings);
-                let w = windows[0];
-                Main.activateWindow(w);
+                if (windows.length > 0) {
+                    let w = windows[0];
+                    Main.activateWindow(w);
+                }
             }
         }
         else
@@ -643,6 +645,9 @@ function cycleThroughWindows(app, settings, reversed) {
     let MEMORY_TIME=3000;
 
     let app_windows = getInterestingWindows(app, settings);
+
+    if (app_windows.length <1)
+        return
 
     if (recentlyClickedAppLoopId > 0)
         Mainloop.source_remove(recentlyClickedAppLoopId);

--- a/appIcons.js
+++ b/appIcons.js
@@ -272,10 +272,14 @@ const MyAppIcon = new Lang.Class({
                 // In overview just activate the app, unless the acion is explicitely
                 // requested with a keyboard modifier
                 if (!Main.overview._shown || modifiers){
-                    // If we have button=2 or Shift, allow minimization even if
+                    // If we have button=2 or a modifier, allow minimization even if
                     // the app is not focused
-                    if (this.app == focusedApp || button == 2 || modifiers)
-                        minimizeWindow(this.app, event.get_click_count() > 1, this._dtdSettings);
+                    if (this.app == focusedApp || button == 2 || modifiers & Clutter.ModifierType.SHIFT_MASK) {
+                        // minimize all windows on double click and always in the case of primary click without
+                        // additional modifiers
+                        let all_windows = (button == 1 && ! modifiers) || event.get_click_count() > 1
+                        minimizeWindow(this.app, all_windows, this._dtdSettings);
+                    }
                     else
                         activateAllWindows(this.app, this._dtdSettings);
                 }

--- a/appIcons.js
+++ b/appIcons.js
@@ -761,7 +761,7 @@ const MyAppIconMenu = new Lang.Class({
           // menu. Windows removal is already handled by each preview being connected to the destroy signal
           let old_windows = this._allWindowsMenuItem.menu._getMenuItems().map(function(item){
               if (item._window)
-                  return item._window;
+                  return;
           })
 
           let new_windows = windows.filter(function(w) {return old_windows.indexOf(w) < 0;});

--- a/appIcons.js
+++ b/appIcons.js
@@ -140,6 +140,16 @@ const MyAppIcon = new Lang.Class({
     },
 
     onScrollEvent: function(actor, event) {
+
+        // We only activate windows of running applications, i.e. we never open new windows
+        // We check if the app is running, and that the # of windows is > 0 in
+        // case we use workspace isolation,
+        let appIsRunning = this.app.state == Shell.AppState.RUNNING
+            && getInterestingWindows(this.app, this._dtdSettings).length > 0;
+
+        if (!appIsRunning)
+            return false
+
         if (this._optionalScrollCycleWindowsDeadTimeId > 0)
             return false;
         else

--- a/appIcons.js
+++ b/appIcons.js
@@ -524,15 +524,15 @@ const MyAppIcon = new Lang.Class({
         this._numberOverlayOrder = -1;
         this._numberOverlayBin.hide();
 
-        // iconBox is a Shell.GenericContainer from IconGrid.BaseIcon
-        this.iconBox = new Shell.GenericContainer();
-        this._iconContainer.add_child(this.iconBox);
+        // genericContainer is a Shell.GenericContainer from IconGrid.BaseIcon
+        let genericContainer = new Shell.GenericContainer();
+        this._iconContainer.add_child(genericContainer);
         // We have to add allocation of counterBin.
-        this.iconBox.connect('allocate', Lang.bind(this, this._allocateIconBox));
+        genericContainer.connect('allocate', Lang.bind(this, this._allocateIconBox));
 
-        this.iconBox.add_actor(this._numberOverlayBin);
+        genericContainer.add_actor(this._numberOverlayBin);
 
-        this._updateNumberOverlay();
+        this.updateNumberOverlay();
     },
 
     _allocateIconBox: function(actor, box, flags) {
@@ -549,7 +549,7 @@ const MyAppIcon = new Lang.Class({
         this._numberOverlayBin.allocate(childBox, flags);
     },
 
-    _updateNumberOverlay: function() {
+    updateNumberOverlay: function() {
         let size = this.icon.iconSize;
         // Set the font size to something smaller than the whole icon so it is
         // still visible. The border radius is large to make the shape circular

--- a/appIcons.js
+++ b/appIcons.js
@@ -406,7 +406,7 @@ const MyAppIcon = new Lang.Class({
 
             case clickAction.LAUNCH:
                 this.animateLaunch();
-                this.app.open_new_window(-1);
+                appLaunchNewWindow(this.app);
                 break;
 
             case clickAction.QUIT:
@@ -420,7 +420,7 @@ const MyAppIcon = new Lang.Class({
         }
         else {
             this.animateLaunch();
-            this.app.open_new_window(-1);
+            appLaunchNewWindow(this.app);
         }
 
         Main.overview.hide();
@@ -611,6 +611,30 @@ function closeAllWindows(app, settings) {
     let windows = getInterestingWindows(app, settings);
     for (let i = 0; i < windows.length; i++)
         windows[i].delete(global.get_current_time());
+}
+
+/*
+* This is used as a workaround for a bug resulting in no new windows being opened
+* for certain running applications when calling open_new_window().
+*
+* https://bugzilla.gnome.org/show_bug.cgi?id=756844
+*
+* Similar to what done when generating the popupMenu entries, if the application provides
+*  a "New Window" action, use it instead of direclt requesting a new window with
+* open_new_window(), which fails for certain application, notably Nautilus.
+*/
+function appLaunchNewWindow(app) {
+    let appInfo = app.get_app_info();
+    let actions = appInfo.list_actions();
+    if (actions.indexOf('new-window') == -1) {
+        app.open_new_window(-1);
+    }
+    else {
+        i = actions.indexOf('new-window');
+        if (i !== -1)
+            app.launch_action(actions[i], global.get_current_time(), -1);
+
+    }
 }
 
 function cycleThroughWindows(app, settings, reversed) {

--- a/appIcons.js
+++ b/appIcons.js
@@ -38,6 +38,12 @@ const clickAction = {
     QUIT: 4
 };
 
+const scrollAction = {
+    DO_NOTHING: 0,
+    CYCLE_WINDOWS: 1,
+    SWITCH_WORKSPACE: 2
+};
+
 let recentlyClickedAppLoopId = 0;
 let recentlyClickedApp = null;
 let recentlyClickedAppWindows = null;
@@ -81,7 +87,6 @@ const MyAppIcon = new Lang.Class({
         this._focuseAppChangeId = tracker.connect('notify::focus-app',
                                                 Lang.bind(this,
                                                           this._onFocusAppChanged));
-
         this._dots = null;
 
         let keys = ['apply-custom-theme',
@@ -96,6 +101,12 @@ const MyAppIcon = new Lang.Class({
         }, this);
 
         this._toggleDots();
+
+        this._dtdSettings.connect('changed::scroll-action', Lang.bind(this, function() {
+            this._optionalScrollCycleWindows();
+        }));
+        this._optionalScrollCycleWindows();
+
     },
 
     _onDestroy: function() {
@@ -111,6 +122,63 @@ const MyAppIcon = new Lang.Class({
         // stateChangedId is already handled by parent)
         if (this._focusAppId > 0)
             tracker.disconnect(this._focusAppId);
+
+        if (this._scrollEventHandler)
+            this.actor.disconnect(this._scrollEventHandler);
+    },
+
+    _optionalScrollCycleWindows: function() {
+        if (this._scrollEventHandler)
+            this.actor.disconnect(this._scrollEventHandler);
+
+        let isEnabled = this._dtdSettings.get_enum('scroll-action') === scrollAction.CYCLE_WINDOWS;
+        if (!isEnabled) return;
+
+        this._scrollEventHandler = this.actor.connect('scroll-event', Lang.bind(this,
+                                                          this.onScrollEvent));
+    },
+
+    onScrollEvent: function(actor, event) {
+        if (this._optionalScrollCycleWindowsDeadTimeId > 0)
+            return false;
+        else
+            this._optionalScrollCycleWindowsDeadTimeId = Mainloop.timeout_add(250, Lang.bind(this, function() {
+                this._optionalScrollCycleWindowsDeadTimeId = 0;
+            }));
+
+        let direction = null;
+
+        switch (event.get_scroll_direction()) {
+        case Clutter.ScrollDirection.UP:
+            direction = Meta.MotionDirection.UP;
+            break;
+        case Clutter.ScrollDirection.DOWN:
+            direction = Meta.MotionDirection.DOWN;
+            break;
+        case Clutter.ScrollDirection.SMOOTH:
+            let [dx, dy] = event.get_scroll_delta();
+            if (dy < 0)
+                direction = Meta.MotionDirection.UP;
+            else if (dy > 0)
+                direction = Meta.MotionDirection.DOWN;
+            break;
+        }
+
+        let focusedApp = tracker.focus_app;
+        if (!Main.overview._shown){
+            let reversed = direction === Meta.MotionDirection.UP;
+            if (this.app == focusedApp)
+                cycleThroughWindows(this.app, this._dtdSettings, reversed);
+            else {
+                // Activate the first window
+                let windows = getInterestingWindows(this.app, this._dtdSettings);
+                let w = windows[0];
+                Main.activateWindow(w);
+            }
+        }
+        else
+            this.app.activate();
+        return true;
     },
 
     onWindowsChanged: function() {
@@ -497,7 +565,7 @@ function closeAllWindows(app, settings) {
         windows[i].delete(global.get_current_time());
 }
 
-function cycleThroughWindows(app, settings) {
+function cycleThroughWindows(app, settings, reversed) {
     // Store for a little amount of time last clicked app and its windows
     // since the order changes upon window interaction
     let MEMORY_TIME=3000;
@@ -518,7 +586,12 @@ function cycleThroughWindows(app, settings) {
         recentlyClickedAppIndex = 0;
     }
 
-    recentlyClickedAppIndex++;
+    if (reversed) {
+        recentlyClickedAppIndex--;
+        if (recentlyClickedAppIndex < 0) recentlyClickedAppIndex = recentlyClickedAppWindows.length - 1;
+    } else {
+        recentlyClickedAppIndex++;
+    }
     let index = recentlyClickedAppIndex % recentlyClickedAppWindows.length;
     let window = recentlyClickedAppWindows[index];
 

--- a/dash.js
+++ b/dash.js
@@ -860,6 +860,37 @@ const MyDash = new Lang.Class({
 
         // This is required for icon reordering when the scrollview is used.
         this._updateAppsIconGeometry();
+
+        // This will update the size, and the corresponding number for each icon
+        this._updateNumberOverlay();
+    },
+
+    _updateNumberOverlay: function() {
+        let appIcons = this._getAppIcons();
+        let counter = 1;
+        appIcons.forEach(function(icon) {
+            if (counter < 10){
+                icon.setNumberOverlay(counter);
+                counter++;
+            }
+            else if (counter == 10) {
+                icon.setNumberOverlay(0);
+                counter++;
+            }
+            else {
+                // No overlay after 10
+                icon.setNumberOverlay(-1);
+            }
+            icon._updateNumberOverlay();
+        });
+
+    },
+
+    toggleNumberOverlay: function(activate) {
+        let appIcons = this._getAppIcons();
+        appIcons.forEach(function(icon) {
+            icon.toggleNumberOverlay(activate);
+        });
     },
 
     setIconSize: function(max_size, doNotAnimate) {

--- a/dash.js
+++ b/dash.js
@@ -610,6 +610,11 @@ const MyDash = new Lang.Class({
         if (this._maxHeight == -1)
             return;
 
+        // Check if the container is present in the stage. This avoids critical
+        // errors when unlocking the screen
+        if (!this._container.get_stage())
+            return;
+
         let themeNode = this._container.get_theme_node();
         let maxAllocation = new Clutter.ActorBox({
             x1: 0,

--- a/dash.js
+++ b/dash.js
@@ -173,6 +173,7 @@ const baseIconSizes = [16, 22, 24, 32, 48, 64, 96, 128];
  *   ensure actor is visible on keyfocus inseid the scrollview
  * - add 128px icon size, might be usefull for hidpi display
  * - sync minimization application target position.
+ * - keep running apps ordered.
  */
 const MyDash = new Lang.Class({
     Name: 'DashToDock.MyDash',
@@ -730,7 +731,20 @@ const MyDash = new Lang.Class({
                 newApps.push(favorites[id]);
         }
 
+        // We reorder the running apps so that they don't change position on the
+        // dash with every redisplay() call
         if (this._dtdSettings.get_boolean('show-running')) {
+            // First: add the apps from the oldApps list that are still running
+            for (let i = 0; i < oldApps.length; i++) {
+                let index = running.indexOf(oldApps[i]);
+                if (index > -1) {
+                    let app = running.splice(index, 1)[0];
+                    if (this._dtdSettings.get_boolean('show-favorites') && (app.get_id() in favorites))
+                        continue;
+                    newApps.push(app);
+                }
+            }
+            // Second: add the new apps
             for (let i = 0; i < running.length; i++) {
                 let app = running[i];
                 if (this._dtdSettings.get_boolean('show-favorites') && (app.get_id() in favorites))

--- a/dash.js
+++ b/dash.js
@@ -881,7 +881,7 @@ const MyDash = new Lang.Class({
                 // No overlay after 10
                 icon.setNumberOverlay(-1);
             }
-            icon._updateNumberOverlay();
+            icon.updateNumberOverlay();
         });
 
     },

--- a/dash.js
+++ b/dash.js
@@ -468,7 +468,6 @@ const MyDash = new Lang.Class({
         extendDashItemContainer(item, this._dtdSettings);
         item.setChild(appIcon.actor);
 
-        item.setChild(appIcon.actor);
         appIcon.actor.connect('notify::hover', Lang.bind(this, function() {
             if (appIcon.actor.hover) {
                 this._ensureAppIconVisibilityTimeoutId = Mainloop.timeout_add(100, Lang.bind(this, function() {

--- a/docking.js
+++ b/docking.js
@@ -30,6 +30,8 @@ const Theming = Me.imports.theming;
 const MyDash = Me.imports.dash;
 
 const DOCK_DWELL_CHECK_INTERVAL = 100;
+const NUMBER_OVERLAY_INTERVAL = 2000;
+const SUPER_KEY_ID = 64;
 
 const State = {
     HIDDEN:  0,
@@ -386,6 +388,7 @@ const DockedDash = new Lang.Class({
         this._optionalScrollWorkspaceSwitch();
         this._optionalWorkspaceIsolation();
         this._optionalHotKeys();
+        this._optionalNumberOverlay();
 
          // Delay operations that require the shell to be fully loaded and with
          // user theme applied.
@@ -520,6 +523,7 @@ const DockedDash = new Lang.Class({
 
         // Remove keybindings
         this._disableHotKeys();
+        this._disableNumberOverlay();
     },
 
     _bindSettingsChanges: function() {
@@ -1567,8 +1571,70 @@ const DockedDash = new Lang.Class({
         }, this);
 
         this._hotKeysEnabled = false;
-    }
+    },
 
+    _optionalNumberOverlay: function() {
+        if (this._settings.get_boolean('hot-keys'))
+            this._enableNumberOverlay();
+
+        this._signalsHandler.add([
+            this._settings,
+            'changed::hot-keys',
+            Lang.bind(this, function() {
+                    if (this._settings.get_boolean('hot-keys'))
+                        this._enableNumberOverlay();
+                    else
+                        this._disableNumberOverlay();
+            })
+        ]);
+    },
+
+    _enableNumberOverlay: function() {
+        Main.wm.addKeybinding('number-overlay-key', this._settings,
+                              Meta.KeyBindingFlags.NONE,
+                              Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
+                              Lang.bind(this, this._showOverlay));
+
+    },
+
+    _disableNumberOverlay: function() {
+        Main.wm.removeKeybinding('number-overlay-key');
+    },
+
+    _showOverlay: function() {
+        this.dash.toggleNumberOverlay(true);
+
+        // Restart the counting if the shortcut is pressed again
+        if (this._numberOverlayTimeoutId) {
+            Mainloop.source_remove(this._numberOverlayTimeoutId);
+            this._numberOverlayTimeoutId = 0;
+        }
+
+        // Hide the overlay after the timeout
+        this._numberOverlayTimeoutId = Mainloop.timeout_add(NUMBER_OVERLAY_INTERVAL, Lang.bind(this, function() {
+            this._numberOverlayTimeoutId = 0;
+            this._HideOverlay();
+        }));
+
+        // Show the dock if it is hidden
+        if (this._settings.get_boolean('hotkeys-show-dock')) {
+            let showDock = (this._intellihideIsEnabled || this._autohideIsEnabled);
+            if (showDock)
+                this._show();
+        }
+    },
+
+    _HideOverlay: function() {
+        this.dash.toggleNumberOverlay(false);
+
+        // Hide the dock again if necessary
+        if (this._settings.get_boolean('hotkeys-show-dock')) {
+            let hideDock = (this._intellihideIsEnabled || this._autohideIsEnabled) &&
+                           (this._dockState == State.SHOWN || this._dockState == State.SHOWING);
+            if (hideDock)
+                this._updateDashVisibility();
+        }
+    }
 });
 
 Signals.addSignalMethods(DockedDash.prototype);

--- a/docking.js
+++ b/docking.js
@@ -968,7 +968,7 @@ const DockedDash = new Lang.Class({
             if (this._position == St.Side.LEFT) {
                 x1 = this._monitor.x + 1;
                 x2 = x1;
-                y1 = workArea.y - 1;
+                y1 = workArea.y + 1;
                 y2 = workArea.y + workArea.height - 1;
                 direction = Meta.BarrierDirection.POSITIVE_X;
             }

--- a/docking.js
+++ b/docking.js
@@ -1447,7 +1447,7 @@ const DockedDash = new Lang.Class({
         let label = 'optionalWorkspaceIsolation';
 
         this._settings.connect('changed::isolate-workspaces', Lang.bind(this, function() {
-            this.dash._queueRedisplay();
+            this.dash.resetAppIcons();
             if (this._settings.get_boolean('isolate-workspaces'))
                 Lang.bind(this, enable)();
             else

--- a/docking.js
+++ b/docking.js
@@ -1550,7 +1550,10 @@ const DockedDash = new Lang.Class({
                 Main.wm.addKeybinding(key + (i + 1), this._settings,
                                       Meta.KeyBindingFlags.NONE,
                                       Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
-                                      Lang.bind(this, function() {this._activateApp(appNum);}));
+                                      Lang.bind(this, function() {
+                                          this._activateApp(appNum);
+                                          this._showOverlay();
+                                      }));
             }
         }, this);
 

--- a/docking.js
+++ b/docking.js
@@ -1654,7 +1654,8 @@ const DockedDash = new Lang.Class({
         this._numberOverlayTimeoutId = Mainloop.timeout_add(timeout, Lang.bind(this, function() {
                 this._numberOverlayTimeoutId = 0;
                 this.dash.toggleNumberOverlay(false);
-                this._hideDock();
+                // Hide the dock again if necessary
+                this._updateDashVisibility();
         }));
 
         // Show the dock if it is hidden
@@ -1663,17 +1664,8 @@ const DockedDash = new Lang.Class({
             if (showDock)
                 this._show();
         }
-    },
-
-    _hideDock: function() {
-        // Hide the dock again if necessary
-        if (this._settings.get_boolean('hotkeys-show-dock')) {
-            let hideDock = (this._intellihideIsEnabled || this._autohideIsEnabled) &&
-                           (this._dockState == State.SHOWN || this._dockState == State.SHOWING);
-            if (hideDock)
-                this._updateDashVisibility();
-        }
     }
+
 });
 
 Signals.addSignalMethods(DockedDash.prototype);

--- a/docking.js
+++ b/docking.js
@@ -30,8 +30,6 @@ const Theming = Me.imports.theming;
 const MyDash = Me.imports.dash;
 
 const DOCK_DWELL_CHECK_INTERVAL = 100;
-const NUMBER_OVERLAY_INTERVAL = 2000;
-const SUPER_KEY_ID = 64;
 
 const State = {
     HIDDEN:  0,
@@ -523,7 +521,7 @@ const DockedDash = new Lang.Class({
 
         // Remove keybindings
         this._disableHotKeys();
-        this._disableNumberOverlay();
+        this._disableExtraShortcut();
     },
 
     _bindSettingsChanges: function() {
@@ -1574,35 +1572,76 @@ const DockedDash = new Lang.Class({
     },
 
     _optionalNumberOverlay: function() {
-        if (this._settings.get_boolean('hot-keys'))
-            this._enableNumberOverlay();
+        this._shortcutIsSet = false;
+        // Enable extra shortcut if either 'overlay' or 'show-dock' are true
+        if (this._settings.get_boolean('hot-keys') &&
+           (this._settings.get_boolean('hotkeys-overlay') || this._settings.get_boolean('hotkeys-show-dock')))
+            this._enableExtraShortcut();
 
         this._signalsHandler.add([
             this._settings,
             'changed::hot-keys',
-            Lang.bind(this, function() {
-                    if (this._settings.get_boolean('hot-keys'))
-                        this._enableNumberOverlay();
-                    else
-                        this._disableNumberOverlay();
-            })
+            Lang.bind(this, this._checkHotkeysOptions)
+        ], [
+            this._settings,
+            'changed::hotkeys-overlay',
+            Lang.bind(this, this._checkHotkeysOptions)
+        ], [
+            this._settings,
+            'changed::hotkeys-show-dock',
+            Lang.bind(this, this._checkHotkeysOptions)
+        ], [
+            this._settings,
+            'changed::shortcut-text',
+            Lang.bind(this, this._setShortcut)
         ]);
     },
 
-    _enableNumberOverlay: function() {
-        Main.wm.addKeybinding('number-overlay-key', this._settings,
-                              Meta.KeyBindingFlags.NONE,
-                              Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
-                              Lang.bind(this, this._showOverlay));
-
+    _checkHotkeysOptions: function() {
+        if (this._settings.get_boolean('hot-keys') &&
+           (this._settings.get_boolean('hotkeys-overlay') || this._settings.get_boolean('hotkeys-show-dock')))
+            this._enableExtraShortcut();
+        else
+            this._disableExtraShortcut();
     },
 
-    _disableNumberOverlay: function() {
-        Main.wm.removeKeybinding('number-overlay-key');
+    _enableExtraShortcut: function() {
+        let shortcut_is_valid = this._setShortcut();
+
+        if (shortcut_is_valid && !this._shortcutIsSet) {
+            Main.wm.addKeybinding('shortcut', this._settings,
+                                  Meta.KeyBindingFlags.NONE,
+                                  Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
+                                  Lang.bind(this, this._showOverlay));
+            this._shortcutIsSet = true;
+        }
+    },
+
+    _setShortcut: function() {
+        let shortcut_text = this._settings.get_string('shortcut-text');
+        let [key, mods] = Gtk.accelerator_parse(shortcut_text);
+
+        if (Gtk.accelerator_valid(key, mods)) {
+            let shortcut = Gtk.accelerator_name(key, mods);
+            this._settings.set_strv('shortcut', [shortcut]);
+            return true;
+        }
+        else {
+            this._settings.set_strv('shortcut', []);
+            return false;
+        }
+    },
+
+    _disableExtraShortcut: function() {
+        if (this._shortcutIsSet) {
+            Main.wm.removeKeybinding('shortcut');
+            this._shortcutIsSet = false;
+        }
     },
 
     _showOverlay: function() {
-        this.dash.toggleNumberOverlay(true);
+        if (this._settings.get_boolean('hotkeys-overlay'))
+            this.dash.toggleNumberOverlay(true);
 
         // Restart the counting if the shortcut is pressed again
         if (this._numberOverlayTimeoutId) {
@@ -1610,10 +1649,12 @@ const DockedDash = new Lang.Class({
             this._numberOverlayTimeoutId = 0;
         }
 
-        // Hide the overlay after the timeout
-        this._numberOverlayTimeoutId = Mainloop.timeout_add(NUMBER_OVERLAY_INTERVAL, Lang.bind(this, function() {
-            this._numberOverlayTimeoutId = 0;
-            this._HideOverlay();
+        // Hide the overlay/dock after the timeout
+        let timeout = this._settings.get_double('shortcut-timeout') * 1000;
+        this._numberOverlayTimeoutId = Mainloop.timeout_add(timeout, Lang.bind(this, function() {
+                this._numberOverlayTimeoutId = 0;
+                this.dash.toggleNumberOverlay(false);
+                this._hideDock();
         }));
 
         // Show the dock if it is hidden
@@ -1624,9 +1665,7 @@ const DockedDash = new Lang.Class({
         }
     },
 
-    _HideOverlay: function() {
-        this.dash.toggleNumberOverlay(false);
-
+    _hideDock: function() {
         // Hide the dock again if necessary
         if (this._settings.get_boolean('hotkeys-show-dock')) {
             let hideDock = (this._intellihideIsEnabled || this._autohideIsEnabled) &&

--- a/docking.js
+++ b/docking.js
@@ -424,13 +424,15 @@ const DockedDash = new Lang.Class({
         this._slider.add_child(this._box);
         this._box.add_actor(this.dash.actor);
 
-        // Add aligning container without tracking it for input region (old affectsinputRegion: false that was removed).
-        // The public method trackChrome requires the actor to be child of a tracked actor. Since I don't want the parent
-        // to be tracked I use the private internal _trackActor instead.
+        // Add aligning container without tracking it for input region
         Main.uiGroup.add_child(this.actor);
 
-        if (this._settings.get_boolean('dock-fixed'))
-            Main.layoutManager._trackActor(this._slider.actor, {affectsStruts: true, trackFullscreen: true});
+        if (this._settings.get_boolean('dock-fixed')) {
+            // Note: tracking the fullscreen directly on the slider actor causes some hiccups when fullscreening
+            // windows of certain applications
+            Main.layoutManager._trackActor(this.actor, {affectsInputRegion: false, trackFullscreen: true});
+            Main.layoutManager._trackActor(this._slider.actor, {affectsStruts: true});
+        }
         else
             Main.layoutManager._trackActor(this._slider.actor);
 
@@ -555,9 +557,12 @@ const DockedDash = new Lang.Class({
         this._settings.connect('changed::dock-fixed', Lang.bind(this, function() {
 
             if (this._settings.get_boolean('dock-fixed')) {
+                Main.layoutManager._untrackActor(this.actor);
+                Main.layoutManager._trackActor(this.actor, {affectsInputRegion: false, trackFullscreen: true});
                 Main.layoutManager._untrackActor(this._slider.actor);
-                Main.layoutManager._trackActor(this._slider.actor, {affectsStruts: true, trackFullscreen: true});
+                Main.layoutManager._trackActor(this._slider.actor, {affectsStruts: true});
             } else {
+                Main.layoutManager._untrackActor(this.actor);
                 Main.layoutManager._untrackActor(this._slider.actor);
                 Main.layoutManager._trackActor(this._slider.actor);
              }

--- a/docking.js
+++ b/docking.js
@@ -778,16 +778,16 @@ const DockedDash = new Lang.Class({
 
         let workArea = Main.layoutManager.getWorkAreaForMonitor(this._monitor.index)
         let shouldDwell;
-        // Check for the correct screen edge
-        // Position is approximated to the lower integer
+        // Check for the correct screen edge, extending the sensitive area to the whole workarea,
+        // minus 1 px to avoid conflicting with other active corners.
         if (this._position == St.Side.LEFT)
-            shouldDwell = (x == this._monitor.x) && (y >= workArea.y) && (y <= workArea.y + workArea.height);
+            shouldDwell = (x == this._monitor.x) && (y > workArea.y) && (y < workArea.y + workArea.height);
         else if (this._position == St.Side.RIGHT)
-            shouldDwell = (x == this._monitor.x + this._monitor.width - 1) && (y >= workArea.y) && (y <= workArea.y + workArea.height);
+            shouldDwell = (x == this._monitor.x + this._monitor.width - 1) && (y > workArea.y) && (y < workArea.y + workArea.height);
         else if (this._position == St.Side.TOP)
-            shouldDwell = (y == this._monitor.y) && (x >= workArea.x) && (x <= workArea.x + workArea.width);
+            shouldDwell = (y == this._monitor.y) && (x > workArea.x) && (x < workArea.x + workArea.width);
         else if (this._position == St.Side.BOTTOM)
-            shouldDwell = (y == this._monitor.y + this._monitor.height - 1) && (x >= workArea.x) && (x <= workArea.x + workArea.width);
+            shouldDwell = (y == this._monitor.y + this._monitor.height - 1) && (x > workArea.x) && (x < workArea.x + workArea.width);
 
         if (shouldDwell) {
             // We only set up dwell timeout when the user is not hovering over the dock
@@ -959,37 +959,38 @@ const DockedDash = new Lang.Class({
         }
 
         // Create new barrier
-        // Note: dash in fixed position doesn't use pressure barrier
+        // The barrier extends to the whole workarea, minus 1 px to avoid conflicting with other active corners
+        // Note: dash in fixed position doesn't use pressure barrier.
         if (this._canUsePressure && this._autohideIsEnabled && this._settings.get_boolean('require-pressure-to-show')) {
             let x1, x2, y1, y2, direction;
             let workArea = Main.layoutManager.getWorkAreaForMonitor(this._monitor.index)
 
             if (this._position == St.Side.LEFT) {
-                x1 = this._monitor.x;
-                x2 = this._monitor.x;
-                y1 = workArea.y;
-                y2 = workArea.y + workArea.height;
+                x1 = this._monitor.x + 1;
+                x2 = x1;
+                y1 = workArea.y - 1;
+                y2 = workArea.y + workArea.height - 1;
                 direction = Meta.BarrierDirection.POSITIVE_X;
             }
             else if (this._position == St.Side.RIGHT) {
-                x1 = this._monitor.x + this._monitor.width;
-                x2 = this._monitor.x + this._monitor.width;
-                y1 = workArea.y;
-                y2 = workArea.y + workArea.height;
+                x1 = this._monitor.x + this._monitor.width - 1;
+                x2 = x2;
+                y1 = workArea.y + 1;
+                y2 = workArea.y + workArea.height - 1;
                 direction = Meta.BarrierDirection.NEGATIVE_X;
             }
             else if (this._position == St.Side.TOP) {
-                x1 = workArea.x;
-                x2 = workArea.x + workArea.width;
+                x1 = workArea.x + 1;
+                x2 = workArea.x + workArea.width - 1;
                 y1 = this._monitor.y;
-                y2 = this._monitor.y;
+                y2 = y1;
                 direction = Meta.BarrierDirection.POSITIVE_Y;
             }
             else if (this._position == St.Side.BOTTOM) {
-                x1 = workArea.x;
-                x2 = workArea.x + workArea.width;
+                x1 = workArea.x + 1;
+                x2 = workArea.x + workArea.width - 1;
                 y1 = this._monitor.y + this._monitor.height;
-                y2 = this._monitor.y + this._monitor.height;
+                y2 = y1;
                 direction = Meta.BarrierDirection.NEGATIVE_Y;
             }
 

--- a/docking.js
+++ b/docking.js
@@ -774,21 +774,17 @@ const DockedDash = new Lang.Class({
 
     _checkDockDwell: function(x, y) {
         let monitor = this._monitor;
-
-        // Check for the dock area
-        let shouldDwell = (x >= this.staticBox.x1 && x <= this.staticBox.x2 &&
-                           y >= this.staticBox.y1  && y <= this.staticBox.y2);
-
+        let shouldDwell;
         // Check for the correct screen edge
         // Position is approximated to the lower integer
         if (this._position == St.Side.LEFT)
-            shouldDwell = shouldDwell && (x == this._monitor.x);
+            shouldDwell = (x == this._monitor.x);
         else if (this._position == St.Side.RIGHT)
-            shouldDwell = shouldDwell && (x == this._monitor.x + this._monitor.width - 1);
+            shouldDwell = (x == this._monitor.x + this._monitor.width - 1);
         else if (this._position == St.Side.TOP)
-            shouldDwell = shouldDwell && (y == this._monitor.y);
+            shouldDwell = (y == this._monitor.y);
         else if (this._position == St.Side.BOTTOM)
-            shouldDwell = shouldDwell && (y == this._monitor.y + this._monitor.height - 1);
+            shouldDwell = (y == this._monitor.y + this._monitor.height - 1);
 
         if (shouldDwell) {
             // We only set up dwell timeout when the user is not hovering over the dock
@@ -882,8 +878,50 @@ const DockedDash = new Lang.Class({
         // would never be triggered and the dock would stay visible forever.
         let triggerTimeoutId =  Mainloop.timeout_add(250, Lang.bind(this, function() {
             triggerTimeoutId = 0;
-            this._hoverChanged();
-            return GLib.SOURCE_REMOVE;
+
+            let [x, y, mods] = global.get_pointer();
+            let shouldHide = true;
+            switch (this._position) {
+            case St.Side.LEFT:
+                if (x <= this.staticBox.x2 &&
+                    x >= this._monitor.x &&
+                    y >= this._monitor.y &&
+                    y <= this._monitor.y + this._monitor.height) {
+                    shouldHide = false;
+                }
+                break;
+            case St.Side.RIGHT:
+                if (x >= this.staticBox.x1 &&
+                    x <= this._monitor.x + this._monitor.width &&
+                    y >= this._monitor.y &&
+                    y <= this._monitor.y + this._monitor.height) {
+                    shouldHide = false;
+                }
+                break;
+            case St.Side.TOP:
+                if (x >= this._monitor.x &&
+                    x <= this._monitor.x + this._monitor.width &&
+                    y <= this.staticBox.y2 &&
+                    y >= this._monitor.y) {
+                    shouldHide = false;
+                }
+                break;
+            case St.Side.BOTTOM:
+                if (x >= this._monitor.x &&
+                    x <= this._monitor.x + this._monitor.width &&
+                    y >= this.staticBox.y1 &&
+                    y <= this._monitor.y + this._monitor.height) {
+                    shouldHide = false;
+                }
+            }
+            if (shouldHide) {
+                this._hoverChanged();
+                return GLib.SOURCE_REMOVE;
+            }
+            else {
+                return GLib.SOURCE_CONTINUE;
+            }
+
         }));
 
         this._show();
@@ -923,31 +961,31 @@ const DockedDash = new Lang.Class({
             let x1, x2, y1, y2, direction;
 
             if (this._position == St.Side.LEFT) {
-                x1 = this.staticBox.x1;
-                x2 = this.staticBox.x1;
-                y1 = this.staticBox.y1;
-                y2 = this.staticBox.y2;
+                x1 = this._monitor.x;
+                x2 = this._monitor.x;
+                y1 = this._monitor.y;
+                y2 = this._monitor.y + this._monitor.height;
                 direction = Meta.BarrierDirection.POSITIVE_X;
             }
             else if (this._position == St.Side.RIGHT) {
-                x1 = this.staticBox.x2;
-                x2 = this.staticBox.x2;
-                y1 = this.staticBox.y1;
-                y2 = this.staticBox.y2;
+                x1 = this._monitor.x + this._monitor.width;
+                x2 = this._monitor.x + this._monitor.width;
+                y1 = this._monitor.y;
+                y2 = this._monitor.y + this._monitor.height;
                 direction = Meta.BarrierDirection.NEGATIVE_X;
             }
             else if (this._position == St.Side.TOP) {
-                x1 = this.staticBox.x1;
-                x2 = this.staticBox.x2;
-                y1 = this.staticBox.y1;
-                y2 = this.staticBox.y1;
+                x1 = this._monitor.x;
+                x2 = this._monitor.x + this._monitor.width;
+                y1 = this._monitor.y;
+                y2 = this._monitor.y;
                 direction = Meta.BarrierDirection.POSITIVE_Y;
             }
             else if (this._position == St.Side.BOTTOM) {
-                x1 = this.staticBox.x1;
-                x2 = this.staticBox.x2;
-                y1 = this.staticBox.y2;
-                y2 = this.staticBox.y2;
+                x1 = this._monitor.x;
+                x2 = this._monitor.x + this._monitor.width;
+                y1 = this._monitor.y + this._monitor.height;
+                y2 = this._monitor.y + this._monitor.height;
                 direction = Meta.BarrierDirection.NEGATIVE_Y;
             }
 

--- a/docking.js
+++ b/docking.js
@@ -970,12 +970,20 @@ const DockedDash = new Lang.Class({
         let monitorIndex = this._settings.get_int('preferred-monitor');
         let extendHeight = this._settings.get_boolean('extend-height');
 
-        if ((monitorIndex > 0) && (monitorIndex < Main.layoutManager.monitors.length))
-            this._monitor = Main.layoutManager.monitors[monitorIndex];
+        // The dock goes on the primary monitor if requested (monitorIndex==0) or if the setting
+        // is incosistent (e.g. desired monitor not connected).
+        if ((monitorIndex <= 0) || (monitorIndex > Main.layoutManager.monitors.length -1))
+            monitorIndex = Main.layoutManager.primaryIndex;
         else {
-            monitorIndex = Main.layoutManager.primaryIndex
-            this._monitor = Main.layoutManager.primaryMonitor;
+            // Gdk and shell monitors numbering differ at least under wayland:
+            // While the primary monitor appears to be always index 0 in Gdk,
+            // the shell can assign a different number (Main.layoutManager.primaryMonitor)
+            // remap monitors numbering from settings (Gdk) to shell
+            if (monitorIndex <= Main.layoutManager.primaryIndex)
+                monitorIndex = (monitorIndex + 1) % Main.layoutManager.monitors.length;
         }
+
+        this._monitor = Main.layoutManager.monitors[monitorIndex];
 
         // Note: do not use the workarea coordinates in the direction on which the dock is placed,
         // to avoid a loop [position change -> workArea change -> position change] with

--- a/docking.js
+++ b/docking.js
@@ -1261,10 +1261,9 @@ const DockedDash = new Lang.Class({
                 // runs if we are already inside the overview.
                 if (!Main.overview._shown) {
                     this.forcedOverview = true;
+                    let view = Main.overview.viewSelector.appDisplay._views[visibleView].view;
+                    let grid = view._grid;
                     if (animate) {
-                        let view = Main.overview.viewSelector.appDisplay._views[visibleView].view;
-                        let grid = view._grid;
-
                         // Animate in the the appview, hide the appGrid to avoiud flashing
                         // Go to the appView before entering the overview, skipping the workspaces.
                         // Do this manually avoiding opacity in transitions so that the setting of the opacity
@@ -1288,6 +1287,12 @@ const DockedDash = new Lang.Class({
                             }));
                         }));
                     }
+                    else {
+                        Main.overview.viewSelector._activePage = Main.overview.viewSelector._appsPage;
+                        Main.overview.viewSelector._activePage.show();
+                        grid.actor.opacity = 255;
+                    }
+
                 }
 
                 // Finally show the overview

--- a/docking.js
+++ b/docking.js
@@ -1064,7 +1064,6 @@ const DockedDash = new Lang.Class({
         this._adjustPanelCorners();
 
         this._adjustLegacyTray();
-        this._updateStaticBox();
     },
 
     _adjustLegacyTray: function() {

--- a/docking.js
+++ b/docking.js
@@ -1447,7 +1447,7 @@ const DockedDash = new Lang.Class({
         let label = 'optionalWorkspaceIsolation';
 
         this._settings.connect('changed::isolate-workspaces', Lang.bind(this, function() {
-            this.dash.resetAppIcons();
+            this.dash._queueRedisplay();
             if (this._settings.get_boolean('isolate-workspaces'))
                 Lang.bind(this, enable)();
             else

--- a/docking.js
+++ b/docking.js
@@ -1410,17 +1410,18 @@ const DockedDash = new Lang.Class({
             this._signalsHandler.addWithLabel(label, [
                 global.screen,
                 'restacked',
-                Lang.bind(this, RestackAction)
+                Lang.bind(this.dash, this.dash._queueRedisplay)
+            ]);
+            this._signalsHandler.addWithLabel(label, [
+                global.window_manager,
+                'switch-workspace',
+                Lang.bind(this.dash, this.dash._queueRedisplay)
             ]);
         }
 
         function disable() {
             this._injectionsHandler.removeWithLabel(label);
             this._signalsHandler.removeWithLabel(label);
-        }
-
-        function RestackAction() {
-            Shell.AppSystem.get_default().emit('installed-changed');
         }
 
         function IsolatedOverview() {

--- a/docking.js
+++ b/docking.js
@@ -437,10 +437,6 @@ const DockedDash = new Lang.Class({
         // Keep the dash below the modalDialogGroup
         Main.layoutManager.uiGroup.set_child_below_sibling(this.actor,Main.layoutManager.modalDialogGroup);
 
-        // pretend this._slider is isToplevel child so that fullscreen is actually tracked
-        let index = Main.layoutManager._findActor(this._slider.actor);
-        Main.layoutManager._trackedActors[index].isToplevel = true;
-
         // Set initial position
         this._resetPosition();
     },

--- a/docking.js
+++ b/docking.js
@@ -775,18 +775,19 @@ const DockedDash = new Lang.Class({
     },
 
     _checkDockDwell: function(x, y) {
-        let monitor = this._monitor;
+
+        let workArea = Main.layoutManager.getWorkAreaForMonitor(this._monitor.index)
         let shouldDwell;
         // Check for the correct screen edge
         // Position is approximated to the lower integer
         if (this._position == St.Side.LEFT)
-            shouldDwell = (x == this._monitor.x);
+            shouldDwell = (x == this._monitor.x) && (y >= workArea.y) && (y <= workArea.y + workArea.height);
         else if (this._position == St.Side.RIGHT)
-            shouldDwell = (x == this._monitor.x + this._monitor.width - 1);
+            shouldDwell = (x == this._monitor.x + this._monitor.width - 1) && (y >= workArea.y) && (y <= workArea.y + workArea.height);
         else if (this._position == St.Side.TOP)
-            shouldDwell = (y == this._monitor.y);
+            shouldDwell = (y == this._monitor.y) && (x >= workArea.x) && (x <= workArea.x + workArea.width);
         else if (this._position == St.Side.BOTTOM)
-            shouldDwell = (y == this._monitor.y + this._monitor.height - 1);
+            shouldDwell = (y == this._monitor.y + this._monitor.height - 1) && (x >= workArea.x) && (x <= workArea.x + workArea.width);
 
         if (shouldDwell) {
             // We only set up dwell timeout when the user is not hovering over the dock
@@ -961,31 +962,32 @@ const DockedDash = new Lang.Class({
         // Note: dash in fixed position doesn't use pressure barrier
         if (this._canUsePressure && this._autohideIsEnabled && this._settings.get_boolean('require-pressure-to-show')) {
             let x1, x2, y1, y2, direction;
+            let workArea = Main.layoutManager.getWorkAreaForMonitor(this._monitor.index)
 
             if (this._position == St.Side.LEFT) {
                 x1 = this._monitor.x;
                 x2 = this._monitor.x;
-                y1 = this._monitor.y;
-                y2 = this._monitor.y + this._monitor.height;
+                y1 = workArea.y;
+                y2 = workArea.y + workArea.height;
                 direction = Meta.BarrierDirection.POSITIVE_X;
             }
             else if (this._position == St.Side.RIGHT) {
                 x1 = this._monitor.x + this._monitor.width;
                 x2 = this._monitor.x + this._monitor.width;
-                y1 = this._monitor.y;
-                y2 = this._monitor.y + this._monitor.height;
+                y1 = workArea.y;
+                y2 = workArea.y + workArea.height;
                 direction = Meta.BarrierDirection.NEGATIVE_X;
             }
             else if (this._position == St.Side.TOP) {
-                x1 = this._monitor.x;
-                x2 = this._monitor.x + this._monitor.width;
+                x1 = workArea.x;
+                x2 = workArea.x + workArea.width;
                 y1 = this._monitor.y;
                 y2 = this._monitor.y;
                 direction = Meta.BarrierDirection.POSITIVE_Y;
             }
             else if (this._position == St.Side.BOTTOM) {
-                x1 = this._monitor.x;
-                x2 = this._monitor.x + this._monitor.width;
+                x1 = workArea.x;
+                x2 = workArea.x + workArea.width;
                 y1 = this._monitor.y + this._monitor.height;
                 y2 = this._monitor.y + this._monitor.height;
                 direction = Meta.BarrierDirection.NEGATIVE_Y;

--- a/docking.js
+++ b/docking.js
@@ -38,6 +38,12 @@ const State = {
     HIDING:  3
 };
 
+const scrollAction = {
+    DO_NOTHING: 0,
+    CYCLE_WINDOWS: 1,
+    SWITCH_WORKSPACE: 2
+};
+
 /**
  * A simple St.Widget with one child whose allocation takes into account the
  * slide out of its child via the _slidex parameter ([0:1]).
@@ -517,8 +523,8 @@ const DockedDash = new Lang.Class({
     },
 
     _bindSettingsChanges: function() {
-        this._settings.connect('changed::scroll-switch-workspace', Lang.bind(this, function() {
-            this._optionalScrollWorkspaceSwitch(this._settings.get_boolean('scroll-switch-workspace'));
+        this._settings.connect('changed::scroll-action', Lang.bind(this, function() {
+            this._optionalScrollWorkspaceSwitch();
         }));
 
         this._settings.connect('changed::dash-max-icon-size', Lang.bind(this, function() {
@@ -1296,14 +1302,18 @@ const DockedDash = new Lang.Class({
     _optionalScrollWorkspaceSwitch: function() {
         let label = 'optionalScrollWorkspaceSwitch';
 
-        this._settings.connect('changed::scroll-switch-workspace', Lang.bind(this, function() {
-            if (this._settings.get_boolean('scroll-switch-workspace'))
+        function isEnabled() {
+            return this._settings.get_enum('scroll-action') === scrollAction.SWITCH_WORKSPACE;
+        }
+
+        this._settings.connect('changed::scroll-action', Lang.bind(this, function() {
+            if (Lang.bind(this, isEnabled)())
                 Lang.bind(this, enable)();
             else
                 Lang.bind(this, disable)();
         }));
 
-        if (this._settings.get_boolean('scroll-switch-workspace'))
+        if (Lang.bind(this, isEnabled)())
             Lang.bind(this, enable)();
 
         function enable() {

--- a/intellihide.js
+++ b/intellihide.js
@@ -200,9 +200,18 @@ const Intellihide = new Lang.Class({
 
             let monitorIndex = this._settings.get_int('preferred-monitor');
 
-            if ((monitorIndex < 0) || (monitorIndex > Main.layoutManager.monitors.length -1))
-
+            // The dock goes on the primary monitor if requested (monitorIndex==0) or if the setting
+            // is incosistent (e.g. desired monitor not connected).
+            if ((monitorIndex <= 0) || (monitorIndex > Main.layoutManager.monitors.length -1))
                 monitorIndex = Main.layoutManager.primaryIndex;
+            else {
+                // Gdk and shell monitors numbering differ at least under wayland:
+                // While the primary monitor appears to be always index 0 in Gdk,
+                // the shell can assign a different number (Main.layoutManager.primaryMonitor)
+                // remap monitors numbering from settings (Gdk) to shell
+                if (monitorIndex <= Main.layoutManager.primaryIndex)
+                    monitorIndex = (monitorIndex + 1) % Main.layoutManager.monitors.length;
+            }
 
             let topWindow = null;
             for (let i = windows.length - 1; i >= 0; i--) {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-"shell-version": ["3.18", "3.20", "3.22"],
+"shell-version": ["3.18", "3.20", "3.22", "3.24"],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",
 "description": "A dock for the Gnome Shell. This extension moves the dash out of the overview transforming it in a dock for an easier launching of applications and a faster switching between windows and desktops. Side and bottom placement options are available.",

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-"shell-version": ["3.18", "3.20"],
+"shell-version": ["3.18", "3.20", "3.22"],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",
 "description": "A dock for the Gnome Shell. This extension moves the dash out of the overview transforming it in a dock for an easier launching of applications and a faster switching between windows and desktops. Side and bottom placement options are available.",

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2015-04-18 18:01+0100\n"
 "Last-Translator: Jean-Baptiste Le Cz <jb.lecoz@gmail.com>\n"
 "Language-Team: Faissal Chamekh <chamfay@gmail.com>\n"
@@ -20,31 +20,36 @@ msgstr ""
 "X-Generator: Poedit 1.7.5\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "الشاشة الرئيسية"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "الشاشة الثانوية"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "يمين"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "يسار"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "تخصيص الإخفاء التلقائي"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "العودة للافتراضي"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "خصّص الإعتام"
+
+#: prefs.js:419
 #, fuzzy
 msgid "Customize running indicators"
 msgstr "أظهر التطبيقات قيد التشغيل"
@@ -67,191 +72,226 @@ msgid "Border width"
 msgstr ""
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "أظهر المرساة فوق"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "الموضع على الشاشة"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "أسفل"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "أعلى"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr "إخفاء المرساة عندما تحجب نافذة التطبيق الحالي. تخصيصات أكثر متوفرة."
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "إخفاء تلقائي ذكي"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "حدّ حجم المرساة"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "نمط الشريط: تمديد إلى حواف الشاشة"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "حدّ حجم الأيقونة"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr "حجم أيقونات ثابت: استعمل التمرير لكشف أيقونات أخرى"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "الموضع والحجم"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "أظهر التطبيقات المفضّلة"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "أظهر التطبيقات قيد التشغيل"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-
-#: Settings.ui.h:21
-#, fuzzy
-msgid "Show <i>Show Applications</i> icon"
-msgstr "أظهر أيقونة التطبيقات أولا"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr ""
-
-#: Settings.ui.h:23
-#, fuzzy
-msgid "Animate <i>Show Applications</i>."
-msgstr "أظهر أيقونة التطبيقات أولا"
-
-#: Settings.ui.h:24
-#, fuzzy
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "التصرّف عن النقر على أيقونة التطبيق قيد التشغيل."
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr "حدث النقر"
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "لا تفعل شيئا"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "صغّر"
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "شغّل نسخة جديدة"
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "التبديل بين النوافذ"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
 msgstr ""
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr "حدث Shift+Click"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "صغّر النافذة"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "صغّر النافذة"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "شغّل نسخة جديدة"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "التبديل بين النوافذ"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "حدث النقر"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "حدث Shift+Click"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "أظهر المرساة فوق"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "الموضع على الشاشة"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "أسفل"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "أعلى"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr "إخفاء المرساة عندما تحجب نافذة التطبيق الحالي. تخصيصات أكثر متوفرة."
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "إخفاء تلقائي ذكي"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "حدّ حجم المرساة"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "نمط الشريط: تمديد إلى حواف الشاشة"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "حدّ حجم الأيقونة"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr "حجم أيقونات ثابت: استعمل التمرير لكشف أيقونات أخرى"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "الموضع والحجم"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "أظهر التطبيقات المفضّلة"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "أظهر التطبيقات قيد التشغيل"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+
 #: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
+msgstr "أظهر أيقونة التطبيقات أولا"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr ""
+
+#: Settings.ui.h:35
+#, fuzzy
+msgid "Animate <i>Show Applications</i>."
+msgstr "أظهر أيقونة التطبيقات أولا"
+
+#: Settings.ui.h:36
+#, fuzzy
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "التصرّف عن النقر على أيقونة التطبيق قيد التشغيل."
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "حدث النقر"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "صغّر"
+
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
 msgstr ""
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "بدّل مساحة العمل عند التمرير فوق المرساة"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "السلوك"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
 msgstr ""
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "استعمل السمة المضمّنة"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr ""
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "تقليص المرساة"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "أظهر نقطة لكل نوافذة من التطبيق."
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "أظهر مؤشرات عدد النوافذ"
 
-#: Settings.ui.h:42
-msgid "Tune the dash background opacity."
-msgstr "ضبط إعتام خلفية المرساة."
-
-#: Settings.ui.h:43
-msgid "Customize opacity"
-msgstr "خصّص الإعتام"
-
-#: Settings.ui.h:44
-msgid "Opacity"
-msgstr "العتمة"
-
-#: Settings.ui.h:45
-msgid "Appearance"
-msgstr "المظهر"
-
-#: Settings.ui.h:46
-msgid "version: "
-msgstr "الإصدار:"
-
-#: Settings.ui.h:47
-msgid "Moves the dash out of the overview transforming it in a dock"
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
 msgstr ""
 
-#: Settings.ui.h:48
-msgid "Created by"
-msgstr "أنشئ من طرف"
-
 #: Settings.ui.h:49
-msgid "Webpage"
+msgid "Customize the dash color"
 msgstr ""
 
 #: Settings.ui.h:50
+msgid "Tune the dash background opacity."
+msgstr "ضبط إعتام خلفية المرساة."
+
+#: Settings.ui.h:51
+msgid "Customize opacity"
+msgstr "خصّص الإعتام"
+
+#: Settings.ui.h:52
+msgid "Opacity"
+msgstr "العتمة"
+
+#: Settings.ui.h:53
+msgid "Appearance"
+msgstr "المظهر"
+
+#: Settings.ui.h:54
+msgid "version: "
+msgstr "الإصدار:"
+
+#: Settings.ui.h:55
+msgid "Moves the dash out of the overview transforming it in a dock"
+msgstr ""
+
+#: Settings.ui.h:56
+msgid "Created by"
+msgstr "أنشئ من طرف"
+
+#: Settings.ui.h:57
+msgid "Webpage"
+msgstr ""
+
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -261,66 +301,69 @@ msgstr ""
 "لمزيد من المعلومات أنظر <a href=\"https://www.gnu.org/licenses/old-licenses/"
 "gpl-2.0.html\">رخصة غنو العمومية، الإصدارة 2 فما فوق.</span>"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr "حول"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "أظهر المرساة بتمرير الفأرة على حافة النافذة"
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "إخفاء تلقائي"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "اضغط للإظهار: يتطلب ضغطا لإظهار المرساة"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr ""
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "إظهار المرساة عندما لا تحجب نوافذ التطبيق."
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr ""
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr ""
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr ""
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 #, fuzzy
 msgid "Only maximized windows"
 msgstr "صغّر النافذة"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "مدة التحريك (ثا)"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "زمن الاختفاء (ثا)"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "زمن الظهور (ثا)"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "عتبة الضغط"
+
+#~ msgid "Do nothing"
+#~ msgstr "لا تفعل شيئا"
 
 #~ msgid "Main Settings"
 #~ msgstr "الخصائص الأساسية"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2015-05-21 21:17+0100\n"
 "Last-Translator: Jiří Doubravský <jiri.doubravsky@gmail.com>\n"
 "Language-Team: CZECH <jiri.doubravsky@gmail.com>\n"
@@ -18,31 +18,36 @@ msgstr ""
 "X-Generator: Poedit 1.7.5\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "Primární obrazovka"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "Sekundární obrazovka"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "Vpravo"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "Vlevo"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "Přizpůsobení chytrého skrývání"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Vrátit výchozí nastavení"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Volitelná průhlednost"
+
+#: prefs.js:419
 #, fuzzy
 msgid "Customize running indicators"
 msgstr "Zobrazit spuštěné aplikace"
@@ -65,108 +70,6 @@ msgid "Border width"
 msgstr ""
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "Kde zobrazit dok"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "Umístění na obrazovce"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "Dole"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "Nahoře"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-"Skývat dok automaticky kdykoliv by překážel otevřenému oknu aktivní "
-"aplikace. Více možností k dispozici."
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "Chytré skrývání"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "Maximální velikost doku"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "Režim zobrazení: roztáhnout od kraje ke kraji"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "Maximální velikost ikon"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr "Neměnná velikost ikon: rolováním je možné zobrazit další"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "Umístění a velikost"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "Zobrazit oblíbené aplikace"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "Zobrazit spuštěné aplikace"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-
-#: Settings.ui.h:21
-#, fuzzy
-msgid "Show <i>Show Applications</i> icon"
-msgstr "<i>Zobrazit tlačítko všech aplikací</i> jako první"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Přesunout tlačítko přístupu ke všem aplikacím na začátek"
-
-#: Settings.ui.h:23
-#, fuzzy
-msgid "Animate <i>Show Applications</i>."
-msgstr "<i>Zobrazit tlačítko všech aplikací</i> jako první"
-
-#: Settings.ui.h:24
-#, fuzzy
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "Akce klepnutím na ikonu běžící aplikace"
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr "Akce klepnutím"
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "Nedělat nic"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "Minimalizovat"
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "Otevřít nové okno"
-
-#: Settings.ui.h:29
-#, fuzzy
-msgid "Cycle through windows"
-msgstr "Přepínat mezi existujícími okny"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
@@ -174,15 +77,144 @@ msgstr ""
 "Pokud zvolíte minimalizaci, dvojté poklepání minimalizuje všechna okna "
 "aplikace."
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr "Shift+Klik akce"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Minimalizovat okno"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "Minimalizovat okno"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "Otevřít nové okno"
+
+#: Settings.ui.h:10
+#, fuzzy
+msgid "Cycle through windows"
+msgstr "Přepínat mezi existujícími okny"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Akce klepnutím"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Shift+Klik akce"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "Kde zobrazit dok"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "Umístění na obrazovce"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "Dole"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "Nahoře"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+"Skývat dok automaticky kdykoliv by překážel otevřenému oknu aktivní "
+"aplikace. Více možností k dispozici."
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "Chytré skrývání"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "Maximální velikost doku"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "Režim zobrazení: roztáhnout od kraje ke kraji"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "Maximální velikost ikon"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr "Neměnná velikost ikon: rolováním je možné zobrazit další"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "Umístění a velikost"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "Zobrazit oblíbené aplikace"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "Zobrazit spuštěné aplikace"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+
 #: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
+msgstr "<i>Zobrazit tlačítko všech aplikací</i> jako první"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr "Přesunout tlačítko přístupu ke všem aplikacím na začátek"
+
+#: Settings.ui.h:35
+#, fuzzy
+msgid "Animate <i>Show Applications</i>."
+msgstr "<i>Zobrazit tlačítko všech aplikací</i> jako první"
+
+#: Settings.ui.h:36
+#, fuzzy
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "Akce klepnutím na ikonu běžící aplikace"
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "Akce klepnutím"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "Minimalizovat"
+
+#: Settings.ui.h:39
 #, fuzzy
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
@@ -190,76 +222,84 @@ msgid ""
 msgstr ""
 "Oblast po okrajích doku a tlačítko zobrazení všech aplikací jsou aktivní."
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Přepínat pracovní plochy kolečkem myši nad dokem."
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Chování"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 #, fuzzy
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
 msgstr "Výchozí motiv doku nebo alternativní přizpůsobitelný motiv."
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Použít výchozí motiv doku"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "Prostorově méně náročné zobrazení, zmenšením volného místa kolem ikon"
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Zmenšit panel"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Zobrazit pod ikonou tečku indikující každé otevřené okno aplikace."
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Zobrazit indikátory počtu oken"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Nastavit průhlednost panelu."
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Volitelná průhlednost"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Průhlednost"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Vzhled"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "verze:"
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr ""
 "Verplaatst de dash naar buiten het activiteitenoverzicht zodat het een dock "
 "wordt"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Autor "
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr ""
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -269,67 +309,70 @@ msgstr ""
 "Podrobněji viz <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0."
 "html\">GNU General Public License, verze 2 nebo pozdější</a>.</span>"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr "O tomto doplňku"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Zobrazit dok najetím myši ke kraji obrazovky."
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Automatické skrývání"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "Zatlač: k zobrazení doku je potřeba na kraj přitlačit"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr ""
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Zobrazit dok, kdykoliv sám nepřekáží spuštěným aplikacím"
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Uhýbat oknům"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 #, fuzzy
 msgid "All windows"
 msgstr "Uhýbat oknům"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr ""
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 #, fuzzy
 msgid "Only maximized windows"
 msgstr "Minimalizovat okno"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Délka efektů (s)"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Odklad skrývání (s)"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Odklad zobrazení (s)"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Míra tlaku (px)"
+
+#~ msgid "Do nothing"
+#~ msgstr "Nedělat nic"
 
 #~ msgid "Only consider windows of the focused application"
 #~ msgstr "Brát v úvahu jen okna aktivní aplikace"

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2015-10-29 14:54-0300\n"
 "Last-Translator: Jonatan Zeidler <jonatan_zeidler@gmx.de>\n"
 "Language-Team: jonius <jonatan_zeidler@gmx.de>\n"
@@ -20,33 +20,38 @@ msgstr ""
 "X-Generator: Poedit 1.7.7\n"
 
 # Konjugation wegen Stellung im Satz
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "Primärer Anzeige"
 
 # Konjugation wegen Stellung im Satz
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "Sekundärer Anzeige"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "Rechts"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "Links"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "Automatisches Ausblenden anpassen"
 
 # Verwende Übersetzung aus Nautilus
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Auf Vorgaben zurücksetzen"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Transparenz anpassen"
+
+#: prefs.js:419
 #, fuzzy
 msgid "Customize running indicators"
 msgstr "Laufende Anwendungen anzeigen"
@@ -69,22 +74,74 @@ msgid "Border width"
 msgstr ""
 
 #: Settings.ui.h:5
+msgid ""
+"When set to minimize, double clicking minimizes all the windows of the "
+"application."
+msgstr ""
+"Wenn auf »Minimieren« eingestellt, können durch Doppelklick alle Fenster der "
+"Anwendung gleichzeitig minimiert werden."
+
+#: Settings.ui.h:6
+msgid "Shift+Click action"
+msgstr "Wirkung bei Umschalttaste + Mausklick"
+
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Minimieren"
+
+#: Settings.ui.h:8
+msgid "Minimize window"
+msgstr "Minimieren"
+
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "Neues Fenster"
+
+# Vielleicht einen Tick besser als „umschalten“?
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "Zwischen den Fenstern der Anwendung wechseln"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Wirkung bei Mausklick"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Wirkung bei Umschalttaste + Mausklick"
+
+#: Settings.ui.h:16
 msgid "Show the dock on"
 msgstr "Dock anzeigen auf"
 
-#: Settings.ui.h:6
+#: Settings.ui.h:17
 msgid "Position on screen"
 msgstr "Position auf Bildschirm"
 
-#: Settings.ui.h:8
+#: Settings.ui.h:19
 msgid "Bottom"
 msgstr "Unten"
 
-#: Settings.ui.h:9
+#: Settings.ui.h:20
 msgid "Top"
 msgstr "Oben"
 
-#: Settings.ui.h:11
+#: Settings.ui.h:22
 msgid ""
 "Hide the dock when it obstructs a window of the the current application. "
 "More refined settings are available."
@@ -92,39 +149,43 @@ msgstr ""
 "Das Dock automatisch ausblenden, falls es ein Fenster der laufenden "
 "Anwendung überlagert. Einstellungen können weiter verfeinert werden."
 
-#: Settings.ui.h:12
+#: Settings.ui.h:23
 msgid "Intelligent autohide"
 msgstr "Automatisch ausblenden"
 
-#: Settings.ui.h:13
+#: Settings.ui.h:24
 msgid "Dock size limit"
 msgstr "Maximale Dockgröße"
 
-#: Settings.ui.h:14
+#: Settings.ui.h:25
 msgid "Panel mode: extend to the screen edge"
 msgstr "Panelmodus: bis zu Bildschirmkanten ausdehnen"
 
-#: Settings.ui.h:15
+#: Settings.ui.h:26
 msgid "Icon size limit"
 msgstr "Maximale Icongröße"
 
-#: Settings.ui.h:16
+#: Settings.ui.h:27
 msgid "Fixed icon size: scroll to reveal other icons"
 msgstr "Feste Icongröße: andere Icons durch Scrollen sichtbar machen"
 
-#: Settings.ui.h:17
+#: Settings.ui.h:28
 msgid "Position and size"
 msgstr "Position und Größe"
 
-#: Settings.ui.h:18
+#: Settings.ui.h:29
 msgid "Show favorite applications"
 msgstr "Favoriten anzeigen"
 
-#: Settings.ui.h:19
+#: Settings.ui.h:30
 msgid "Show running applications"
 msgstr "Laufende Anwendungen anzeigen"
 
-#: Settings.ui.h:20
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
 msgid ""
 "If disabled, these settings are acccessible from gnome-tweak-tool or the "
 "extension website."
@@ -133,62 +194,34 @@ msgstr ""
 "oder die Erweiterungsseite erreichbar."
 
 # Durchkopplung von Kompositum
-#: Settings.ui.h:21
-msgid "Show <i>Show Applications</i> icon"
+#: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
 msgstr "Symbol <i>Anwendungen anzeigen</i> anzeigen"
 
-#: Settings.ui.h:22
+#: Settings.ui.h:34
 msgid "Move the applications button at the beginning of the dock."
 msgstr "Anwendungen-anzeigen-Button an den Anfang verschieben."
 
 # Durchkopplung von Kompositum
-#: Settings.ui.h:23
+#: Settings.ui.h:35
 #, fuzzy
 msgid "Animate <i>Show Applications</i>."
 msgstr "Symbol <i>Anwendungen anzeigen</i> anzeigen"
 
-#: Settings.ui.h:24
+#: Settings.ui.h:36
 msgid "Behaviour when clicking on the icon of a running application."
 msgstr "Verhalten bei Mausklick auf das Icon einer laufenden Anwendung."
 
-#: Settings.ui.h:25
+#: Settings.ui.h:37
 msgid "Click action"
 msgstr "Wirkung bei Mausklick"
 
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "Nichts tun"
-
-#: Settings.ui.h:27
+#: Settings.ui.h:38
 msgid "Minimize"
 msgstr "Minimieren"
 
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "Neues Fenster"
-
-# Vielleicht einen Tick besser als „umschalten“?
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "Zwischen den Fenstern der Anwendung wechseln"
-
-#: Settings.ui.h:30
-msgid ""
-"When set to minimize, double clicking minimizes all the windows of the "
-"application."
-msgstr ""
-"Wenn auf »Minimieren« eingestellt, können durch Doppelklick alle Fenster der "
-"Anwendung gleichzeitig minimiert werden."
-
-#: Settings.ui.h:31
-msgid "Shift+Click action"
-msgstr "Wirkung bei Umschalttaste + Mausklick"
-
-#: Settings.ui.h:32
-msgid "Minimize window"
-msgstr "Minimieren"
-
-#: Settings.ui.h:33
+#: Settings.ui.h:39
 #, fuzzy
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
@@ -197,16 +230,16 @@ msgstr ""
 "Falls es zu viele Symbole auf dem Dock werden, dann bleibt nur "
 "<i>Anwendungen anzeigen</i> aktiv."
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Arbeitsfläche durch Scrollen wechseln"
 
 # Verwende Übersetzung aus Nautilus
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 #, fuzzy
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
@@ -216,59 +249,67 @@ msgstr ""
 "Thema eingepasst werden soll. Alternativ können im Folgenden besondere "
 "Einstellungen vorgenommen werden."
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Angepasstes Thema dieser Erweiterung nutzen"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "Platz sparen, indem Innenabstand und Eckenradius verkleinert werden."
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Dash verkleinern"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Für jedes Fenster einer Anwendung einen kleinen Indikator einblenden."
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Indikatoren für Fensterzahl"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Die Hintergrundtransparenz des Docks einstellen."
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Transparenz anpassen"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Transparenz"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Erscheinungsbild"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "Version: "
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr "Verwandelt das Dash aus dem Übersichtsmodus in ein Dock"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Erstellt von"
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "Internetseite"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -280,68 +321,71 @@ msgstr ""
 "a>.</span>"
 
 # Verwende Übersetzung aus Nautilus
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr "Info"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Dock einblenden, wenn Mauszeiger an Bildschirmkante anliegt."
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Automatisch verstecken"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr ""
 "Anstoßen erforderlich: Dock nur einblenden, wenn Mauszeiger schnell gegen "
 "Bildschirmkante stößt"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr ""
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Dock einblenden, falls es keine Anwendungsfenster überlagert."
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Fenstern ausweichen"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr "Alle Fenstern"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr "Nur Anwendungsfenster mit Fokus"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 msgid "Only maximized windows"
 msgstr "Nur maximierte Fenster"
 
 # Nach DIN 1313 werden Einheiten nicht in Klammern gesetzt
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Animationsdauer in s"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0,000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Ausblende-Verzögerung in s"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Einblende-Verzögerung in s"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Stoßschwellwert"
+
+#~ msgid "Do nothing"
+#~ msgstr "Nichts tun"
 
 #~ msgid "Only consider windows of the focused application"
 #~ msgstr "Nur Fenster der fokussierten Anwendung einbeziehen"

--- a/po/es.po
+++ b/po/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2015-12-23 10:19+0100\n"
 "Last-Translator: Hugo Olabera <hugolabe@gmail.com>\n"
 "Language-Team: \n"
@@ -17,31 +17,36 @@ msgstr ""
 "X-Generator: Poedit 1.8.5\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "Pantalla principal"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "Pantalla secundaria"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "Derecha"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "Izquierda"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "Opciones de auto ocultado"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Restaurar"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Personalizar estilo del indicador"
+
+#: prefs.js:419
 msgid "Customize running indicators"
 msgstr "Personalizar indicadores de ejecución"
 
@@ -62,106 +67,6 @@ msgid "Border width"
 msgstr "Grosor del borde"
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "Mostrar el dock en"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "Posición en pantalla"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "Abajo"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "Arriba"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-"Ocultar el dock cuando cubre una ventana de la aplicación activa. Otras "
-"opciones disponibles."
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "Auto ocultado inteligente"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "Tamaño máximo del dock"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "Modo panel: extender hasta los bordes de la pantalla"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "Tamaño máximo de los iconos"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr "Tamaño fijo de los iconos: desplazarse para mostrar otros"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "Posición y tamaño"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "Mostrar aplicaciones favoritas"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "Mostrar aplicaciones en ejecución"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-"Si está deshabilitado, estas opciones están accesibles desde gnome-tweak-"
-"tool o desde el sitio web de extensiones."
-
-#: Settings.ui.h:21
-msgid "Show <i>Applications</i> icon"
-msgstr "Mostrar el icono <i>Mostrar aplicaciones</i>"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Mover el botón de aplicaciones al comienzo del dock"
-
-#: Settings.ui.h:23
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animar <i>Mostrar aplicaciones</i>"
-
-#: Settings.ui.h:24
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "Comportamiento al pulsar el icono de una aplicación en ejecución"
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr "Acción del Click"
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "No hacer nada"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "Minimizar"
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "Lanzar una nueva instancia"
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "Alternar entre ventanas"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
@@ -169,31 +74,158 @@ msgstr ""
 "Cuando está seleccionado minimizar, doble click minimiza todas las ventanas "
 "de la aplicación."
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr "Acción de Mayúsculas+Click"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Minimizar ventana"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "Minimizar ventana"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "Lanzar una nueva instancia"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "Alternar entre ventanas"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Acción del Click"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Acción de Mayúsculas+Click"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "Mostrar el dock en"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "Posición en pantalla"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "Abajo"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "Arriba"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+"Ocultar el dock cuando cubre una ventana de la aplicación activa. Otras "
+"opciones disponibles."
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "Auto ocultado inteligente"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "Tamaño máximo del dock"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "Modo panel: extender hasta los bordes de la pantalla"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "Tamaño máximo de los iconos"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr "Tamaño fijo de los iconos: desplazarse para mostrar otros"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "Posición y tamaño"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "Mostrar aplicaciones favoritas"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "Mostrar aplicaciones en ejecución"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr "Aislar los epacios de trabajo."
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+"Si está deshabilitado, estas opciones están accesibles desde gnome-tweak-"
+"tool o desde el sitio web de extensiones."
+
 #: Settings.ui.h:33
+msgid "Show <i>Applications</i> icon"
+msgstr "Mostrar el icono <i>Mostrar aplicaciones</i>"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr "Mover el botón de aplicaciones al comienzo del dock"
+
+#: Settings.ui.h:35
+msgid "Animate <i>Show Applications</i>."
+msgstr "Animar <i>Mostrar aplicaciones</i>"
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "Comportamiento al pulsar el icono de una aplicación en ejecución"
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "Acción del Click"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "Minimizar"
+
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
 msgstr ""
-"Con iconos de tamaño fijo, sólo el borde del dock y del icono "
-"<i>Mostrar aplicaciones</i> están activos."
+"Con iconos de tamaño fijo, sólo el borde del dock y del icono <i>Mostrar "
+"aplicaciones</i> están activos."
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Cambiar de espacio de trabajo haciendo scroll en el dock"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Comportamiento"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
@@ -201,68 +233,68 @@ msgstr ""
 "Utilizar el tema predeterminado de GNOME. Alternativamente, pueden elegirse "
 "ciertas opciones más abajo."
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Utilizar el tema por defecto"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "Reducir los márgenes para ganar espacio"
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Encoger el dock"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Mostrar un punto por cada ventana de la aplicación."
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Mostrar contador de ventanas"
 
-#: Settings.ui.h:42
-msgid "Customize the dash color"
-msgstr "Personalizar el color del dock"
-
-#: Settings.ui.h:43
+#: Settings.ui.h:48
 msgid "Set the background color for the dash."
 msgstr "Escoger el color de fondo del dock."
 
-#: Settings.ui.h:44
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr "Personalizar el color del dock"
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Ajustar la opacidad del fondo del dock."
 
-#: Settings.ui.h:45
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Personalizar opacidad"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Opacidad"
 
-#: Settings.ui.h:47
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Apariencia"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "versión: "
 
-#: Settings.ui.h:49
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr ""
 "Mueve el panel fuera de la vista de actividades trasformándolo en un dock"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Creado por"
 
-#: Settings.ui.h:51
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "Sitio web"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -273,68 +305,65 @@ msgstr ""
 "\">Licencia Pública General de GNU, versión 2 o posterior</a> para obtener "
 "más detalles.</span>"
 
-#: Settings.ui.h:54
+#: Settings.ui.h:60
 msgid "About"
 msgstr "Acerca de"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Mostrar el dock al mover el puntero al borde de la pantalla"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Auto ocultar"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "Empujar para mostrar: requiere hacer presión para mostrar el dock"
 
-#: Settings.ui.h:58
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr ""
 
-#: Settings.ui.h:59
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Mostrar el dock cuando no cubra otras ventanas de aplicaciones"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Auto ocultado inteligente"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr "Todas las ventanas"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr "Sólo las ventanas de la aplicación activa"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:69
 msgid "Only maximized windows"
 msgstr "Sólo las ventanas maximizadas"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Duración de la animación"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Tiempo de ocultación"
 
-#: Settings.ui.h:67
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Tiempo de aparición"
 
-#: Settings.ui.h:68
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Nivel de presión"
 
-#: Settings.ui.h:69
-msgid "Isolate workspaces."
-msgstr "Aislar los epacios de trabajo."
-
-
+#~ msgid "Do nothing"
+#~ msgstr "No hacer nada"

--- a/po/es.po
+++ b/po/es.po
@@ -1,20 +1,20 @@
 # Dash to Dock spanish translation.
 # This file is distributed under the same license as the Dash to Dock package.
 # Hugo Olabera <hugolabe@gmail.com>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-09 23:29+0100\n"
-"PO-Revision-Date: 2015-12-23 10:19+0100\n"
+"PO-Revision-Date: 2017-02-17 12:11+0100\n"
 "Last-Translator: Hugo Olabera <hugolabe@gmail.com>\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.5\n"
+"X-Generator: Poedit 1.8.11\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: prefs.js:98
@@ -42,9 +42,8 @@ msgid "Reset to defaults"
 msgstr "Restaurar"
 
 #: prefs.js:346
-#, fuzzy
 msgid "Customize middle-click behavior"
-msgstr "Personalizar estilo del indicador"
+msgstr "Personalizar comportamiento del botón central"
 
 #: prefs.js:419
 msgid "Customize running indicators"
@@ -79,9 +78,8 @@ msgid "Shift+Click action"
 msgstr "Acción de Mayúsculas+Click"
 
 #: Settings.ui.h:7
-#, fuzzy
 msgid "Raise window"
-msgstr "Minimizar ventana"
+msgstr "Elevar ventana"
 
 #: Settings.ui.h:8
 msgid "Minimize window"
@@ -97,25 +95,23 @@ msgstr "Alternar entre ventanas"
 
 #: Settings.ui.h:11
 msgid "Quit"
-msgstr ""
+msgstr "Salir"
 
 #: Settings.ui.h:12
 msgid "Behavior for Middle-Click."
-msgstr ""
+msgstr "Comportamiento del botón central"
 
 #: Settings.ui.h:13
-#, fuzzy
 msgid "Middle-Click action"
-msgstr "Acción del Click"
+msgstr "Acción del botón central"
 
 #: Settings.ui.h:14
 msgid "Behavior for Shift+Middle-Click."
-msgstr ""
+msgstr "Comportamiento para Mayúsculas+Botón-Central"
 
 #: Settings.ui.h:15
-#, fuzzy
 msgid "Shift+Middle-Click action"
-msgstr "Acción de Mayúsculas+Click"
+msgstr "Acción de Mayúsculas+Botón-Central"
 
 #: Settings.ui.h:16
 msgid "Show the dock on"
@@ -175,7 +171,7 @@ msgstr "Mostrar aplicaciones en ejecución"
 
 #: Settings.ui.h:31
 msgid "Isolate workspaces."
-msgstr "Aislar los epacios de trabajo."
+msgstr "Aislar los espacios de trabajo."
 
 #: Settings.ui.h:32
 msgid ""
@@ -323,7 +319,7 @@ msgstr "Empujar para mostrar: requiere hacer presión para mostrar el dock"
 
 #: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
-msgstr ""
+msgstr "Habilitar en modo pantalla completa"
 
 #: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2015-09-10 19:41+0100\n"
 "Last-Translator: Thomas GONET <th.gonet@gmail.com>\n"
 "Language-Team: Jean-Baptiste Le Cz <jb.lecoz@gmail.com>\n"
@@ -17,31 +17,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.6.10\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "Moniteur principal"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "Moniteur secondaire"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "Droite"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "Gauche"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "Personnalisation du masquage automatique"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Restaurer la configuration par défaut"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Régler le style des indicateurs"
+
+#: prefs.js:419
 msgid "Customize running indicators"
 msgstr "Régler les indicateurs de fenêtres"
 
@@ -62,106 +67,6 @@ msgid "Border width"
 msgstr "Épaisseur de la bordure"
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "Afficher le dock sur le"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "Position sur l'écran"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "Bas"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "Haut"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-"Cache le dock quand il gène l'application principale. D'autres paramètres "
-"plus spécifiques sont disponibles."
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "Masquage intelligent"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "Taille maximum du dock"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "Mode barre: étendre aux bords de l'écran"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "Taille maximum des icônes"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr "Taille des icônes fixe: faire défiler pour voir les autres icônes"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "Position et taille"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "Afficher les applications favorites"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "Afficher les applications en cours"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-"Si désactivés, ces paramètres sont acccessibles via gnome-tweak-tool ou le "
-"site d'extension GNOME."
-
-#: Settings.ui.h:21
-msgid "Show <i>Applications</i> icon"
-msgstr "Afficher le raccourci <i>Afficher les Applications</i>"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Placer le raccourci <i>Afficher les Applications</i> en première position"
-
-#: Settings.ui.h:23
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animer le raccourci <i>Afficher les Applications</i>"
-
-#: Settings.ui.h:24
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "Comportement du clic sur l'icône d'une application ouverte."
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr "Action du clic"
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "Ne rien faire"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "Minimiser la fenêtre"
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "Lancer une nouvelle fenêtre"
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "Cycler sur les fenêtres"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
@@ -169,15 +74,143 @@ msgstr ""
 "Quand réglé sur Minimiser, double-cliquer minimise toutes les fenêtres de "
 "l'application."
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr "Action Shift+Clic"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Minimiser la fenêtre"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "Minimiser la fenêtre"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "Lancer une nouvelle fenêtre"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "Cycler sur les fenêtres"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Action du clic"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Action Shift+Clic"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "Afficher le dock sur le"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "Position sur l'écran"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "Bas"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "Haut"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+"Cache le dock quand il gène l'application principale. D'autres paramètres "
+"plus spécifiques sont disponibles."
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "Masquage intelligent"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "Taille maximum du dock"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "Mode barre: étendre aux bords de l'écran"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "Taille maximum des icônes"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr "Taille des icônes fixe: faire défiler pour voir les autres icônes"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "Position et taille"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "Afficher les applications favorites"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "Afficher les applications en cours"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr "Isoler les espaces de travail."
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+"Si désactivés, ces paramètres sont acccessibles via gnome-tweak-tool ou le "
+"site d'extension GNOME."
+
 #: Settings.ui.h:33
+msgid "Show <i>Applications</i> icon"
+msgstr "Afficher le raccourci <i>Afficher les Applications</i>"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr ""
+"Placer le raccourci <i>Afficher les Applications</i> en première position"
+
+#: Settings.ui.h:35
+msgid "Animate <i>Show Applications</i>."
+msgstr "Animer le raccourci <i>Afficher les Applications</i>"
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "Comportement du clic sur l'icône d'une application ouverte."
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "Action du clic"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "Minimiser la fenêtre"
+
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
@@ -185,15 +218,15 @@ msgstr ""
 "Avec des icônes de taille fixe, seulement les bordures et le raccourci "
 "<i>Afficher les Applications</i> sont actifs."
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Changer d'espace de travail par défilement au-dessus du dock"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Comportement"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
@@ -201,67 +234,67 @@ msgstr ""
 "Assortir le dock avec le thème par défaut. Sinon, vous pouvez personnaliser "
 "quelques paramètres ci-dessous."
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Utiliser le thème par défaut"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "Réduire la taille des marges pour gagner de la place."
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Réduire les marges"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Afficher un point pour chaque fenêtre ouverte de l'application."
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Afficher un compteur de fenêtres"
 
-#: Settings.ui.h:42
-msgid "Customize the dash color"
-msgstr "Changer la couleur du dock"
-
-#: Settings.ui.h:43
+#: Settings.ui.h:48
 msgid "Set the background color for the dash."
 msgstr "Choisir la couleur de fond du dock."
 
-#: Settings.ui.h:44
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr "Changer la couleur du dock"
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Régler l'opacité en fond du dock."
 
-#: Settings.ui.h:45
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Régler l'opacité du dock"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Opacité"
 
-#: Settings.ui.h:47
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Apparence"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "Version: "
 
-#: Settings.ui.h:49
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr "Place le dash hors de l'aperçu des fenêtres, le transformant en dock"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Conçu par"
 
-#: Settings.ui.h:51
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "Site web"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -272,69 +305,68 @@ msgstr ""
 "\">Licence Générale Publique GNU version 2 ou plus récente</a> pour plus "
 "d'informations.</span>"
 
-#: Settings.ui.h:54
+#: Settings.ui.h:60
 msgid "About"
 msgstr "À propos"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Afficher le dock en survolant le bord de l'écran."
 
-#: Settings.ui.h:56
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Masquage automatique"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "Pousser pour Afficher: requiert une pression pour afficher le dock"
 
-#: Settings.ui.h:58
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr "Activer en mode plein-écran"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Afficher le dock quand il ne gêne pas les fenêtres."
 
-#: Settings.ui.h:60
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Masquage automatique intelligent"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr "Toutes les fenêtres"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr "Seulement la fenêtre de l'application active"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:69
 msgid "Only maximized windows"
 msgstr "Seulement les fenêtres maximisées"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Durée de l'animation (s)"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Délai de masquage (s)"
 
-#: Settings.ui.h:67
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Délai d'apparition (s)"
 
-#: Settings.ui.h:68
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Seuil de pression"
 
-#: Settings.ui.h:69
-msgid "Isolate workspaces."
-msgstr "Isoler les espaces de travail."
+#~ msgid "Do nothing"
+#~ msgstr "Ne rien faire"
 
 #~ msgid "Only consider windows of the focused application"
 #~ msgstr "Ne prendre en compte que l'application courante"

--- a/po/fr.po
+++ b/po/fr.po
@@ -42,9 +42,8 @@ msgid "Reset to defaults"
 msgstr "Restaurer la configuration par défaut"
 
 #: prefs.js:346
-#, fuzzy
 msgid "Customize middle-click behavior"
-msgstr "Régler le style des indicateurs"
+msgstr "Personnaliser le comportement du clique-milieu"
 
 #: prefs.js:419
 msgid "Customize running indicators"
@@ -81,7 +80,7 @@ msgstr "Action Shift+Clic"
 #: Settings.ui.h:7
 #, fuzzy
 msgid "Raise window"
-msgstr "Minimiser la fenêtre"
+msgstr "Faire apparaître la fenêtre"
 
 #: Settings.ui.h:8
 msgid "Minimize window"
@@ -97,11 +96,11 @@ msgstr "Cycler sur les fenêtres"
 
 #: Settings.ui.h:11
 msgid "Quit"
-msgstr ""
+msgstr "Quitter"
 
 #: Settings.ui.h:12
 msgid "Behavior for Middle-Click."
-msgstr ""
+msgstr "Comportement pour le clic-milieu"
 
 #: Settings.ui.h:13
 #, fuzzy
@@ -110,7 +109,7 @@ msgstr "Action du clic"
 
 #: Settings.ui.h:14
 msgid "Behavior for Shift+Middle-Click."
-msgstr ""
+msgstr "Comportement pour Shift+Clic-milieu"
 
 #: Settings.ui.h:15
 #, fuzzy
@@ -138,7 +137,7 @@ msgid ""
 "Hide the dock when it obstructs a window of the the current application. "
 "More refined settings are available."
 msgstr ""
-"Cache le dock quand il gène l'application principale. D'autres paramètres "
+"Cache le dock quand il gêne l'application principale. D'autres paramètres "
 "plus spécifiques sont disponibles."
 
 #: Settings.ui.h:23

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,365 +7,426 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-09 23:29+0100\n"
-"PO-Revision-Date: 2012-12-22 22:04+0100\n"
+"POT-Creation-Date: 2017-02-17 18:29+0100\n"
+"PO-Revision-Date: 2017-02-17 19:24+0100\n"
 "Last-Translator: giroresh <giroresh@gmail.com>\n"
 "Language-Team: giroresh <giroresh@gmail.com>\n"
-"Language: zh_CN\n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.5.4\n"
+"X-Generator: Poedit 1.8.11\n"
 
 #: prefs.js:98
 msgid "Primary monitor"
-msgstr ""
+msgstr "Elsődleges képernyő"
 
 #: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
-msgstr ""
+msgstr "Masodlagos képernyő"
 
-#: prefs.js:139 Settings.ui.h:21
+#: prefs.js:139 Settings.ui.h:28
 msgid "Right"
-msgstr ""
+msgstr "Jobb"
 
-#: prefs.js:140 Settings.ui.h:18
+#: prefs.js:140 Settings.ui.h:25
 msgid "Left"
-msgstr ""
+msgstr "Bal"
 
 #: prefs.js:190
 msgid "Intelligent autohide customization"
-msgstr ""
+msgstr "Okos elrejtésnek testreszabása"
 
-#: prefs.js:197 prefs.js:353
+#: prefs.js:197 prefs.js:374 prefs.js:428
 msgid "Reset to defaults"
-msgstr ""
+msgstr "Visszaállítás"
 
-#: prefs.js:346
-#, fuzzy
+#: prefs.js:367
+msgid "Show dock and application numbers"
+msgstr "Dock és az alkalmazások mennyisége mutatása"
+
+#: prefs.js:421
 msgid "Customize middle-click behavior"
-msgstr "A Dock háttér átláthatósága testre szabható"
+msgstr "Középső-Kattintás viselkedésének testreszabása"
 
-#: prefs.js:419
-#, fuzzy
+#: prefs.js:492
 msgid "Customize running indicators"
-msgstr "Mutasd a futtatott alkalmazások ikonjait"
+msgstr "Futó alkalmazások mutatójának testreszabása"
 
 #: Settings.ui.h:1
-#, fuzzy
 msgid "Customize indicator style"
-msgstr "A Dock háttér átláthatósága testre szabható"
+msgstr "Mutató stílusának testreszabása"
 
 #: Settings.ui.h:2
 msgid "Color"
-msgstr ""
+msgstr "Szín"
 
 #: Settings.ui.h:3
 msgid "Border color"
-msgstr ""
+msgstr "Szegélyszíne"
 
 #: Settings.ui.h:4
 msgid "Border width"
-msgstr ""
+msgstr "Szegély szélessége"
 
 #: Settings.ui.h:5
+msgid "Number overlay"
+msgstr "Réteg száma"
+
+#: Settings.ui.h:6
+msgid ""
+"Temporarily show the application numbers over the icons, corresponding to "
+"the shortcut."
+msgstr ""
+"Ideiglenesen mutasd az alkalmazás számat az ikon felett a hozzá illő "
+"billentyűparancs-hoz."
+
+#: Settings.ui.h:7
+msgid "Show the dock if it is hidden"
+msgstr "Mutasd a dock-ot ha el van rejtve"
+
+#: Settings.ui.h:8
+msgid ""
+"If using autohide, the dock will appear for a short time when triggering the "
+"shortcut."
+msgstr ""
+"Egy rövid ideig látható a dock, ha egy billentyűparancsot aktiváltak - "
+"automatikus elrejtés használata kor is."
+
+#: Settings.ui.h:9
+msgid "Shortcut for the options above"
+msgstr "Billentyűparancs a fenti opciókhoz"
+
+#: Settings.ui.h:10
+msgid "Syntax: <Shift>, <Ctrl>, <Alt>, <Super>"
+msgstr "Szintaxis: <Shift>, <Ctrl>, <Alt>, <Szuper>"
+
+#: Settings.ui.h:11
+msgid "Hide timeout (s)"
+msgstr "Elrejtés időzítője (mp)"
+
+#: Settings.ui.h:12
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
 msgstr ""
+"Ha minimalizálásra állított, akkor dupla kattintáskor minden ablak "
+"minimalizálódik."
 
-#: Settings.ui.h:6
+#: Settings.ui.h:13
 msgid "Shift+Click action"
-msgstr ""
+msgstr "Shift+Kattintás művelete"
 
-#: Settings.ui.h:7
-#, fuzzy
+#: Settings.ui.h:14
 msgid "Raise window"
-msgstr "Kicsinyítés"
+msgstr "Ablak nagyitása"
 
-#: Settings.ui.h:8
-#, fuzzy
+#: Settings.ui.h:15
 msgid "Minimize window"
-msgstr "Kicsinyítés"
+msgstr "Ablak kicsinyítés"
 
-#: Settings.ui.h:9
-#, fuzzy
+#: Settings.ui.h:16
 msgid "Launch new instance"
-msgstr "Új ablak nyitása"
+msgstr "Új folyamat inditása"
 
-#: Settings.ui.h:10
-#, fuzzy
+#: Settings.ui.h:17
 msgid "Cycle through windows"
 msgstr "Körözzön az alkalmazások ablakai közt"
 
-#: Settings.ui.h:11
+#: Settings.ui.h:18
 msgid "Quit"
-msgstr ""
-
-#: Settings.ui.h:12
-msgid "Behavior for Middle-Click."
-msgstr ""
-
-#: Settings.ui.h:13
-msgid "Middle-Click action"
-msgstr ""
-
-#: Settings.ui.h:14
-msgid "Behavior for Shift+Middle-Click."
-msgstr ""
-
-#: Settings.ui.h:15
-msgid "Shift+Middle-Click action"
-msgstr ""
-
-#: Settings.ui.h:16
-msgid "Show the dock on"
-msgstr ""
-
-#: Settings.ui.h:17
-msgid "Position on screen"
-msgstr ""
+msgstr "Bezárás"
 
 #: Settings.ui.h:19
-msgid "Bottom"
-msgstr ""
+msgid "Behavior for Middle-Click."
+msgstr "Középső-Kattintás viselkedése"
 
 #: Settings.ui.h:20
-msgid "Top"
-msgstr ""
+msgid "Middle-Click action"
+msgstr "Középső-Kattintás művelete"
+
+#: Settings.ui.h:21
+msgid "Behavior for Shift+Middle-Click."
+msgstr "Shift+Középső-Kattintás viselkedése"
 
 #: Settings.ui.h:22
+msgid "Shift+Middle-Click action"
+msgstr "Shift+Középső-Kattintás művelete"
+
+#: Settings.ui.h:23
+msgid "Show the dock on"
+msgstr "Mutasd a dock-ot"
+
+#: Settings.ui.h:24
+msgid "Position on screen"
+msgstr "Elhelyezkedése a képernyőn"
+
+#: Settings.ui.h:26
+msgid "Bottom"
+msgstr "Lent"
+
+#: Settings.ui.h:27
+msgid "Top"
+msgstr "Fent"
+
+#: Settings.ui.h:29
 msgid ""
 "Hide the dock when it obstructs a window of the the current application. "
 "More refined settings are available."
 msgstr ""
+"A dock elrejtése ha a futó alkalmazás ablakát akadályozza. További "
+"beállítások lehetségesek."
 
-#: Settings.ui.h:23
-#, fuzzy
+#: Settings.ui.h:30
 msgid "Intelligent autohide"
-msgstr "okos elrejtés"
+msgstr "Okos elrejtés"
 
-#: Settings.ui.h:24
+#: Settings.ui.h:31
 msgid "Dock size limit"
-msgstr ""
+msgstr "Dock maximális mérete"
 
-#: Settings.ui.h:25
+#: Settings.ui.h:32
 msgid "Panel mode: extend to the screen edge"
-msgstr ""
+msgstr "Panel mód: a képernyő sarkokig kiterjesztése"
 
-#: Settings.ui.h:26
+#: Settings.ui.h:33
 msgid "Icon size limit"
-msgstr ""
+msgstr "Maximális ikon méret"
 
-#: Settings.ui.h:27
+#: Settings.ui.h:34
 msgid "Fixed icon size: scroll to reveal other icons"
-msgstr ""
+msgstr "Fix ikon méret: görgetéssel láthatóvá válnak az ikonok"
 
-#: Settings.ui.h:28
+#: Settings.ui.h:35
 msgid "Position and size"
-msgstr ""
+msgstr "Elhelyezkedés és méret"
 
-#: Settings.ui.h:29
-#, fuzzy
+#: Settings.ui.h:36
 msgid "Show favorite applications"
 msgstr "Mutasd a kedvenc alkalmazások ikonjait"
 
-#: Settings.ui.h:30
-#, fuzzy
+#: Settings.ui.h:37
 msgid "Show running applications"
 msgstr "Mutasd a futtatott alkalmazások ikonjait"
 
-#: Settings.ui.h:31
+#: Settings.ui.h:38
 msgid "Isolate workspaces."
-msgstr ""
+msgstr "munkaterület izolálása."
 
-#: Settings.ui.h:32
+#: Settings.ui.h:39
+msgid "Show open windows previews."
+msgstr "Mutasd előnézetet megnyitott ablakokhoz."
+
+#: Settings.ui.h:40
 msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"If disabled, these settings are accessible from gnome-tweak-tool or the "
 "extension website."
 msgstr ""
+"Ha kikapcsolt, akkor ezek a beállítások elérhetők a gnome-tweak-tool vagy a "
+"honlap-ról."
 
-#: Settings.ui.h:33
-#, fuzzy
+#: Settings.ui.h:41
 msgid "Show <i>Applications</i> icon"
-msgstr "Mutasd a futtatott alkalmazások ikonjait"
+msgstr "Mutasd az <i>Alkalmazás</i> ikont"
 
-#: Settings.ui.h:34
+#: Settings.ui.h:42
 msgid "Move the applications button at the beginning of the dock."
-msgstr ""
+msgstr "Alkalmazás gombját a dock elejére tolása."
 
-#: Settings.ui.h:35
-#, fuzzy
+#: Settings.ui.h:43
 msgid "Animate <i>Show Applications</i>."
-msgstr "Mutasd a futtatott alkalmazások ikonjait"
+msgstr "Animáld a <i>Mutasd Alkalmazásokat</i>"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:44
+msgid "Launchers"
+msgstr "Indítok"
+
+#: Settings.ui.h:45
+msgid ""
+"Enable Super+(0-9) as shortcuts to activate apps. It can also be used "
+"together with Shift and Ctrl."
+msgstr ""
+"Aktiváld a Szuper+(0-9) mint billentyűparancsot. Shift és Ctrl is "
+"használható."
+
+#: Settings.ui.h:46
+msgid "Use keyboard shortcuts to activate apps"
+msgstr "Billentyűparancsok használata az alkalmazások aktiválásához."
+
+#: Settings.ui.h:47
 msgid "Behaviour when clicking on the icon of a running application."
-msgstr ""
+msgstr "Futó alkalmazások ikonjának megnyomása kori viselkedés."
 
-#: Settings.ui.h:37
+#: Settings.ui.h:48
 msgid "Click action"
-msgstr ""
+msgstr "Kattintás művelete"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:49
 msgid "Minimize"
 msgstr "Kicsinyítés"
 
-#: Settings.ui.h:39
-msgid ""
-"With fixed icon size, only the edge of the dock and the <i>Show "
-"Applications</i> icon are active."
-msgstr ""
+#: Settings.ui.h:50
+msgid "Behaviour when scrolling on the icon of an application."
+msgstr "Alkalmazás ikonja feletti görgetés kori viselkedés."
 
-#: Settings.ui.h:40
-#, fuzzy
-msgid "Switch workspace by scrolling on the dock"
-msgstr "Dock feletti görgetéskor válts munkahelyet"
+#: Settings.ui.h:51
+msgid "Scroll action"
+msgstr "Görgetési művelet"
 
-#: Settings.ui.h:41
+#: Settings.ui.h:52
+msgid "Do nothing"
+msgstr "Ne tegyen semmit"
+
+#: Settings.ui.h:53
+msgid "Switch workspace"
+msgstr "Válts munkahelyenként"
+
+#: Settings.ui.h:54
 msgid "Behavior"
-msgstr ""
+msgstr "Viselkedés"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:55
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
 msgstr ""
+"A GNOME témájához való alkalmazkodásért kevés testre szabások aktiváltak. "
+"Viszont lejjebb lehetőség nyílik a testra szabásra."
 
-#: Settings.ui.h:43
+#: Settings.ui.h:56
 msgid "Use built-in theme"
-msgstr ""
+msgstr "Használd a beépített témát."
 
-#: Settings.ui.h:44
+#: Settings.ui.h:57
 msgid "Save space reducing padding and border radius."
-msgstr ""
+msgstr "Helymegtakarítás a párnázás és szegély rádiusza csökkentésével"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:58
 msgid "Shrink the dash"
-msgstr ""
+msgstr "A dash zsugoritása"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:59
 msgid "Show a dot for each windows of the application."
-msgstr ""
+msgstr "Mutasd egy pontot minden egyes ablaknak."
 
-#: Settings.ui.h:47
+#: Settings.ui.h:60
 msgid "Show windows counter indicators"
-msgstr ""
+msgstr "Mutasd ablak számlálót"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:61
 msgid "Set the background color for the dash."
-msgstr ""
+msgstr "A dash hátterének beállítása."
 
-#: Settings.ui.h:49
+#: Settings.ui.h:62
 msgid "Customize the dash color"
-msgstr ""
+msgstr "A Dash színének testreszabása"
 
-#: Settings.ui.h:50
-#, fuzzy
+#: Settings.ui.h:63
 msgid "Tune the dash background opacity."
-msgstr "A Dock háttér átláthatósága testre szabható"
+msgstr "A dash háttérének átláthatóságának testreszabása."
 
-#: Settings.ui.h:51
-#, fuzzy
+#: Settings.ui.h:64
 msgid "Customize opacity"
-msgstr "A Dock háttér átláthatósága testre szabható"
+msgstr "Átláthatóságnak testreszabása"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:65
 msgid "Opacity"
 msgstr "Átláthatóság"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:66
+msgid "Force straight corner\n"
+msgstr "Egyenes sarkok kényszerítése\n"
+
+#: Settings.ui.h:68
 msgid "Appearance"
-msgstr ""
+msgstr "Megjelenés"
 
-#: Settings.ui.h:54
+#: Settings.ui.h:69
 msgid "version: "
-msgstr ""
+msgstr "verzió: "
 
-#: Settings.ui.h:55
+#: Settings.ui.h:70
 msgid "Moves the dash out of the overview transforming it in a dock"
-msgstr ""
+msgstr "A dash átformázása dock-ká"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:71
 msgid "Created by"
-msgstr ""
+msgstr "Létrehozta"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:72
 msgid "Webpage"
-msgstr ""
+msgstr "Honlap"
 
-#: Settings.ui.h:58
+#: Settings.ui.h:73
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
 "\">GNU General Public License, version 2 or later</a> for details.</span>"
 msgstr ""
+"<span size=\"small\">Ez a program GARANCIA NÉLKÜL-i.\n"
+"További részletekért lásd <a href=\"https://www.gnu.org/licenses/old-"
+"licenses/gpl-2.0.html\">GNU General Public License, version 2 or later</a></"
+"span>"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:75
 msgid "About"
-msgstr ""
+msgstr "Névjegy"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:76
 msgid "Show the dock by mouse hover on the screen edge."
-msgstr ""
+msgstr "Mutasd a dock-ot ha az egér mutató a képernyő sarkához ér."
 
-#: Settings.ui.h:62
+#: Settings.ui.h:77
 msgid "Autohide"
 msgstr "Automatikus elrejtés"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:78
 msgid "Push to show: require pressure to show the dock"
-msgstr ""
+msgstr "Nyomásra mutatkozás: a dock láthatóvá válik nyomás alkamazása után."
 
-#: Settings.ui.h:64
+#: Settings.ui.h:79
 msgid "Enable in fullscreen mode"
-msgstr ""
+msgstr "Teljes képernyő módban aktiv"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:80
 msgid "Show the dock when it doesn't obstruct application windows."
-msgstr ""
+msgstr "Mutasd a dock-ot ha nem akadályozz ablakokat."
 
-#: Settings.ui.h:66
+#: Settings.ui.h:81
 msgid "Dodge windows"
-msgstr ""
+msgstr "Ablakok kikerülése"
 
-#: Settings.ui.h:67
+#: Settings.ui.h:82
 msgid "All windows"
-msgstr ""
+msgstr "Összes ablak"
 
-#: Settings.ui.h:68
+#: Settings.ui.h:83
 msgid "Only focused application's windows"
-msgstr ""
+msgstr "Csak fókuszált alkalmazások ablakai"
 
-#: Settings.ui.h:69
-#, fuzzy
+#: Settings.ui.h:84
 msgid "Only maximized windows"
-msgstr "Kicsinyítés"
+msgstr "Csak maximalizált ablakok"
 
-#: Settings.ui.h:70
-#, fuzzy
+#: Settings.ui.h:85
 msgid "Animation duration (s)"
-msgstr "Animáció időtartalma [ezredmásodperc]"
+msgstr "Animáció időtartalma (mp)"
 
-#: Settings.ui.h:71
+#: Settings.ui.h:86
 msgid "0.000"
-msgstr ""
+msgstr "0.000"
 
-#: Settings.ui.h:72
-msgid "Hide timeout (s)"
-msgstr ""
-
-#: Settings.ui.h:73
+#: Settings.ui.h:87
 msgid "Show timeout (s)"
-msgstr ""
+msgstr "Láthatóság időkorlátja (mp)"
 
-#: Settings.ui.h:74
+#: Settings.ui.h:88
 msgid "Pressure threshold"
-msgstr ""
+msgstr "Nyomás küszöb"
 
 #, fuzzy
-#~ msgid "Do nothing"
-#~ msgstr "Ne tegyen semmit (előre beállított)"
+#~ msgid "Switch workspace by scrolling on the dock"
+#~ msgstr "Dock feletti görgetéskor válts munkahelyet"
 
 #~ msgid "Main Settings"
 #~ msgstr "Fő beállítások "
@@ -426,9 +487,6 @@ msgstr ""
 
 #~ msgid "Optional features"
 #~ msgstr "Tetszőleges beállítások"
-
-#~ msgid "Switch one workspace at a time"
-#~ msgstr "Válts munkahelyenként"
 
 #~ msgid "Only a 1px wide area close to the screen edge is active"
 #~ msgstr "A kijelző szélén csak egy 1px széles hely aktív "

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2012-12-22 22:04+0100\n"
 "Last-Translator: giroresh <giroresh@gmail.com>\n"
 "Language-Team: giroresh <giroresh@gmail.com>\n"
@@ -17,31 +17,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr ""
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr ""
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr ""
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr ""
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr ""
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr ""
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "A Dock háttér átláthatósága testre szabható"
+
+#: prefs.js:419
 #, fuzzy
 msgid "Customize running indicators"
 msgstr "Mutasd a futtatott alkalmazások ikonjait"
@@ -64,267 +69,303 @@ msgid "Border width"
 msgstr ""
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr ""
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr ""
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr ""
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr ""
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-
-#: Settings.ui.h:12
-#, fuzzy
-msgid "Intelligent autohide"
-msgstr "okos elrejtés"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr ""
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr ""
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr ""
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr ""
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr ""
-
-#: Settings.ui.h:18
-#, fuzzy
-msgid "Show favorite applications"
-msgstr "Mutasd a kedvenc alkalmazások ikonjait"
-
-#: Settings.ui.h:19
-#, fuzzy
-msgid "Show running applications"
-msgstr "Mutasd a futtatott alkalmazások ikonjait"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-
-#: Settings.ui.h:21
-#, fuzzy
-msgid "Show <i>Show Applications</i> icon"
-msgstr "Mutasd a futtatott alkalmazások ikonjait"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr ""
-
-#: Settings.ui.h:23
-#, fuzzy
-msgid "Animate <i>Show Applications</i>."
-msgstr "Mutasd a futtatott alkalmazások ikonjait"
-
-#: Settings.ui.h:24
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr ""
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr ""
-
-#: Settings.ui.h:26
-#, fuzzy
-msgid "Do nothing"
-msgstr "Ne tegyen semmit (előre beállított)"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "Kicsinyítés"
-
-#: Settings.ui.h:28
-#, fuzzy
-msgid "Launch new instance"
-msgstr "Új ablak nyitása"
-
-#: Settings.ui.h:29
-#, fuzzy
-msgid "Cycle through windows"
-msgstr "Körözzön az alkalmazások ablakai közt"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
 msgstr ""
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr ""
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Kicsinyítés"
+
+#: Settings.ui.h:8
 #, fuzzy
 msgid "Minimize window"
 msgstr "Kicsinyítés"
 
+#: Settings.ui.h:9
+#, fuzzy
+msgid "Launch new instance"
+msgstr "Új ablak nyitása"
+
+#: Settings.ui.h:10
+#, fuzzy
+msgid "Cycle through windows"
+msgstr "Körözzön az alkalmazások ablakai közt"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+msgid "Middle-Click action"
+msgstr ""
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+msgid "Shift+Middle-Click action"
+msgstr ""
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr ""
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr ""
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr ""
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr ""
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+
+#: Settings.ui.h:23
+#, fuzzy
+msgid "Intelligent autohide"
+msgstr "okos elrejtés"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr ""
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr ""
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr ""
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr ""
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr ""
+
+#: Settings.ui.h:29
+#, fuzzy
+msgid "Show favorite applications"
+msgstr "Mutasd a kedvenc alkalmazások ikonjait"
+
+#: Settings.ui.h:30
+#, fuzzy
+msgid "Show running applications"
+msgstr "Mutasd a futtatott alkalmazások ikonjait"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+
 #: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
+msgstr "Mutasd a futtatott alkalmazások ikonjait"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr ""
+
+#: Settings.ui.h:35
+#, fuzzy
+msgid "Animate <i>Show Applications</i>."
+msgstr "Mutasd a futtatott alkalmazások ikonjait"
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr ""
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr ""
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "Kicsinyítés"
+
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
 msgstr ""
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 #, fuzzy
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Dock feletti görgetéskor válts munkahelyet"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr ""
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
 msgstr ""
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr ""
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr ""
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr ""
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr ""
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr ""
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 #, fuzzy
 msgid "Tune the dash background opacity."
 msgstr "A Dock háttér átláthatósága testre szabható"
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 #, fuzzy
 msgid "Customize opacity"
 msgstr "A Dock háttér átláthatósága testre szabható"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Átláthatóság"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr ""
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr ""
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr ""
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr ""
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr ""
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
 "\">GNU General Public License, version 2 or later</a> for details.</span>"
 msgstr ""
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr ""
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr ""
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Automatikus elrejtés"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr ""
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr ""
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr ""
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr ""
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr ""
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr ""
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 #, fuzzy
 msgid "Only maximized windows"
 msgstr "Kicsinyítés"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 #, fuzzy
 msgid "Animation duration (s)"
 msgstr "Animáció időtartalma [ezredmásodperc]"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr ""
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr ""
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr ""
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Do nothing"
+#~ msgstr "Ne tegyen semmit (előre beállított)"
 
 #~ msgid "Main Settings"
 #~ msgstr "Fő beállítások "

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash-to-Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2015-05-16 15:22-0000\n"
 "Last-Translator: Michele G <micxgx@gmail.com>\n"
 "Language-Team: Italian <micxgx@gmail.com>\n"
@@ -18,31 +18,36 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.6.10\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "Monitor principale"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "Monitor secondatio"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "A destra"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "A sinistra"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "Opzioni Intelligent autohide "
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Predefiniti"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Opacità"
+
+#: prefs.js:419
 #, fuzzy
 msgid "Customize running indicators"
 msgstr "Mostra applicazioni aperte"
@@ -65,254 +70,286 @@ msgid "Border width"
 msgstr ""
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "Mostra dock sul"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "Posizione sullo schermo"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "In basso"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "In alto"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr "Nascondi la "
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "Autohide intelligente"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "Dimesione massima"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr ""
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr ""
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr ""
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "Posizione e dimensione"
-
-#: Settings.ui.h:18
-#, fuzzy
-msgid "Show favorite applications"
-msgstr "Mostra applicazioni aperte"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "Mostra applicazioni aperte"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-
-#: Settings.ui.h:21
-#, fuzzy
-msgid "Show <i>Show Applications</i> icon"
-msgstr "Mostra applicazioni aperte"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr ""
-
-#: Settings.ui.h:23
-#, fuzzy
-msgid "Animate <i>Show Applications</i>."
-msgstr "Mostra applicazioni aperte"
-
-#: Settings.ui.h:24
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr ""
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr ""
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr ""
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr ""
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr ""
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr ""
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
 msgstr ""
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr ""
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+msgid "Raise window"
+msgstr ""
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr ""
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr ""
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr ""
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+msgid "Middle-Click action"
+msgstr ""
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+msgid "Shift+Middle-Click action"
+msgstr ""
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "Mostra dock sul"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "Posizione sullo schermo"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "In basso"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "In alto"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr "Nascondi la "
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "Autohide intelligente"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "Dimesione massima"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr ""
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr ""
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr ""
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "Posizione e dimensione"
+
+#: Settings.ui.h:29
+#, fuzzy
+msgid "Show favorite applications"
+msgstr "Mostra applicazioni aperte"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "Mostra applicazioni aperte"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+
 #: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
+msgstr "Mostra applicazioni aperte"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr ""
+
+#: Settings.ui.h:35
+#, fuzzy
+msgid "Animate <i>Show Applications</i>."
+msgstr "Mostra applicazioni aperte"
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr ""
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr ""
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr ""
+
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
 msgstr ""
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr ""
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr ""
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
 msgstr ""
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr ""
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr ""
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr ""
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr ""
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr ""
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr ""
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 #, fuzzy
 msgid "Customize opacity"
 msgstr "Opacità"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Opacità"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr ""
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr ""
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr ""
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr ""
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr ""
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
 "\">GNU General Public License, version 2 or later</a> for details.</span>"
 msgstr ""
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr ""
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr ""
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Autohide"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr ""
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr ""
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr ""
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr ""
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr ""
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr ""
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 msgid "Only maximized windows"
 msgstr ""
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Durata aniazione (s)"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr ""
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Ritardo (s)"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Sensitiv"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dash-to-dock master\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-03 11:16+0900\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2016-04-03 17:02+0900\n"
 "Last-Translator: Debonne Hooties <debonne.hooties@gmail.com>\n"
 "Language-Team: Safranjoepe (an unofficial team of Japanese) <>\n"
@@ -18,31 +18,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "プライマリーモニター"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "セカンダリーモニター"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "右"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "左"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "インテリジェント表示の設定"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "既定値にリセット"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "表示スタイルの設定"
+
+#: prefs.js:419
 msgid "Customize running indicators"
 msgstr "インジケーターの表示設定"
 
@@ -63,241 +68,307 @@ msgid "Border width"
 msgstr "縁取り幅"
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "ドックを表示するモニター"
+msgid ""
+"When set to minimize, double clicking minimizes all the windows of the "
+"application."
+msgstr ""
+"[ウィンドウの最小化] に設定したときは、アイコンをダブルクリックするとそのアプ"
+"リケーションのウィンドウをすべて最小化します。"
 
 #: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "表示位置"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "下"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "上"
-
-#: Settings.ui.h:11
-msgid "Hide the dock when it obstructs a window of the the current application. More refined settings are available."
-msgstr "開いているウィンドウの邪魔にならないようドックの表示/非表示を自動的に切り替えます。より洗練された表示設定も可能です。"
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "インテリジェント表示"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "ドックサイズの上限"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "パネルモード（画面の端までドックを拡張）"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "アイコンサイズの上限"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr "アイコンサイズの固定（隠れたアイコンはスクロールで表示）"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "位置とサイズ"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "お気に入りアプリケーションの表示"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "実行中アプリケーションの表示"
-
-#: Settings.ui.h:20
-msgid "If disabled, these settings are acccessible from gnome-tweak-tool or the extension website."
-msgstr "オフにしたときは、gnome-tweak-tool または拡張機能ウェブサイトを経由してこの設定ダイアログにアクセスします。"
-
-#: Settings.ui.h:21
-msgid "Show <i>Show Applications</i> icon"
-msgstr "[アプリケーションを表示する] アイコンの表示"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr "ドックの先頭（最上段または左端）に表示"
-
-#: Settings.ui.h:23
-msgid "Animate <i>Show Applications</i>."
-msgstr "アニメーションしながらアプリケーション一覧を表示"
-
-#: Settings.ui.h:24
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "実行中アプリケーションのアイコンをクリックしたときの動作を指定します。"
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr "クリック時のアクション"
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "何もしない"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "ウィンドウの最小化"
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "新しいウィンドウを開く"
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "ウィンドウの切り替え"
-
-#: Settings.ui.h:30
-msgid "When set to minimize, double clicking minimizes all the windows of the application."
-msgstr "[ウィンドウの最小化] に設定したときは、アイコンをダブルクリックするとそのアプリケーションのウィンドウをすべて最小化します。"
-
-#: Settings.ui.h:31
 msgid "Shift+Click action"
 msgstr "Shift+クリック時のアクション"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "ウィンドウの最小化"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "ウィンドウの最小化"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "新しいウィンドウを開く"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "ウィンドウの切り替え"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "クリック時のアクション"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Shift+クリック時のアクション"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "ドックを表示するモニター"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "表示位置"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "下"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "上"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+"開いているウィンドウの邪魔にならないようドックの表示/非表示を自動的に切り替え"
+"ます。より洗練された表示設定も可能です。"
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "インテリジェント表示"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "ドックサイズの上限"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "パネルモード（画面の端までドックを拡張）"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "アイコンサイズの上限"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr "アイコンサイズの固定（隠れたアイコンはスクロールで表示）"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "位置とサイズ"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "お気に入りアプリケーションの表示"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "実行中アプリケーションの表示"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+"オフにしたときは、gnome-tweak-tool または拡張機能ウェブサイトを経由してこの設"
+"定ダイアログにアクセスします。"
+
 #: Settings.ui.h:33
-msgid "With fixed icon size, only the edge of the dock and the <i>Show Applications</i> icon are active."
-msgstr "アイコンサイズを固定しているときは、ドックの端または [アプリケーションを表示する] アイコン上でのスクロールのみが有効です。"
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
+msgstr "[アプリケーションを表示する] アイコンの表示"
 
 #: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr "ドックの先頭（最上段または左端）に表示"
+
+#: Settings.ui.h:35
+msgid "Animate <i>Show Applications</i>."
+msgstr "アニメーションしながらアプリケーション一覧を表示"
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "実行中アプリケーションのアイコンをクリックしたときの動作を指定します。"
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "クリック時のアクション"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "ウィンドウの最小化"
+
+#: Settings.ui.h:39
+msgid ""
+"With fixed icon size, only the edge of the dock and the <i>Show "
+"Applications</i> icon are active."
+msgstr ""
+"アイコンサイズを固定しているときは、ドックの端または [アプリケーションを表示"
+"する] アイコン上でのスクロールのみが有効です。"
+
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "ドック上でスクロールしたらワークスペースを切り替える"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "動作"
 
-#: Settings.ui.h:36
-msgid "Few customizations meant to integrate the dock with the default GNOME theme. Alternatively, specific options can be enabled below."
-msgstr "この設定がオンのときは、お使いのGNOMEテーマとの調和を図るためカスタマイズは無効になります。オフのときには以下のカスタマイズが可能です。"
+#: Settings.ui.h:42
+msgid ""
+"Few customizations meant to integrate the dock with the default GNOME theme. "
+"Alternatively, specific options can be enabled below."
+msgstr ""
+"この設定がオンのときは、お使いのGNOMEテーマとの調和を図るためカスタマイズは無"
+"効になります。オフのときには以下のカスタマイズが可能です。"
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "ビルトインテーマの使用"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "境界線の太さとパディングを減らして表示域を小さくします。"
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Dashの縮小表示"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "アプリケーションウィンドウの数をドットで表示します。"
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "ウィンドウ数インジケーターの表示"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Dash背景の不透明度を調整します。"
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "不透明度の調整"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "不透明度"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "外観"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "バージョン: "
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr "Dashをドック化してアクティビティ画面以外でもDash操作を可能にします。"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "作者:"
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "ウェブページ"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
-"See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html\">GNU General Public License, version 2 or later</a> for details.</span>"
+"See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
+"\">GNU General Public License, version 2 or later</a> for details.</span>"
 msgstr ""
 "<span size=\"small\">このプログラムに<b>保証は一切ありません</b>。\n"
-"詳しくは <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html\">GNU一般公衆ライセンス（GPL）バージョン2</a> またはそれ以降のバージョンをご覧ください。</span>"
+"詳しくは <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
+"\">GNU一般公衆ライセンス（GPL）バージョン2</a> またはそれ以降のバージョンをご"
+"覧ください。</span>"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr "情報"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
-msgstr "ドックを表示したいとき、ポインターを画面端に移動するとドックが表示されます。"
+msgstr ""
+"ドックを表示したいとき、ポインターを画面端に移動するとドックが表示されます。"
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "オンデマンド表示"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
-msgstr "押し込んで表示（画面外にポインターを移動するようにマウスを動かして表示）"
+msgstr ""
+"押し込んで表示（画面外にポインターを移動するようにマウスを動かして表示）"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr "フルスクリーンモード時でも表示"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
-msgstr "ドックを常に表示しますが、アプリケーションウィンドウと重なるときは表示しません。"
+msgstr ""
+"ドックを常に表示しますが、アプリケーションウィンドウと重なるときは表示しませ"
+"ん。"
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "ウィンドウ重なり防止"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr "すべてのウィンドウが対象"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr "フォーカスされたアプリケーションのウィンドウが対象"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 msgid "Only maximized windows"
 msgstr "最大化されたウィンドウが対象"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "アニメーション表示時間 (秒)"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "非表示までのタイムアウト (秒)"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "表示までのタイムアウト (秒)"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "押し込み量 (ピクセル)"
+
+#~ msgid "Do nothing"
+#~ msgstr "何もしない"

--- a/po/nl.po
+++ b/po/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2015-05-14 14:26+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: Nederlands <vistausss@outlook.com>\n"
@@ -21,31 +21,36 @@ msgstr ""
 "X-Generator: Gtranslator 2.91.7\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "Eerste beeldscherm"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "Tweede beeldscherm"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "Rechts"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "Links"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "Voorkeuren voor intelligente verbergmodus"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Herstellen naar standaardwaarden"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Doorzichtigheid aanpassen"
+
+#: prefs.js:419
 #, fuzzy
 msgid "Customize running indicators"
 msgstr "Geopende applicaties weergeven"
@@ -68,109 +73,6 @@ msgid "Border width"
 msgstr ""
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "Het dock weergeven op"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "Positie op het scherm"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "Onderaan"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "Bovenaan"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-"Het dock verbergen wanneer het een venster van de huidige applicatie in de "
-"weg zit. Er zijn gedetailleerde instellingen hiervoor beschikbaar."
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "Intelligente verbergmodus"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "Maximale dockgrootte"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "Paneelmodus: uitrekken tot aan de schermrand"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "Maximale pictogramgrootte"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr ""
-"Vastgezette pictogramgrootte: scroll om meer pictogrammen weer te geven"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "Positie en grootte"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "Favoriete applicaties weergeven"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "Geopende applicaties weergeven"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-
-#: Settings.ui.h:21
-#, fuzzy
-msgid "Show <i>Show Applications</i> icon"
-msgstr "<i>Applicaties weergeven</i>-pictogram aan het begin"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Verplaatst de applicaties-knop naar het begin van het dock."
-
-#: Settings.ui.h:23
-#, fuzzy
-msgid "Animate <i>Show Applications</i>."
-msgstr "<i>Applicaties weergeven</i>-pictogram aan het begin"
-
-#: Settings.ui.h:24
-#, fuzzy
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "Gedrag van het klikken op het pictogram van een geopende applicatie."
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr "Klikactie"
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "Niets doen"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "Minimaliseren"
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "Nieuw proces openen"
-
-#: Settings.ui.h:29
-#, fuzzy
-msgid "Cycle through windows"
-msgstr "Schakelen tussen vensters"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
@@ -178,15 +80,145 @@ msgstr ""
 "Indien gekozen voor minimaliseren zal dubbelklikken alle vensters van de "
 "huidige applicatie minimaliseren."
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr "Shift+Klik-actie"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Venster minimalisren"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "Venster minimalisren"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "Nieuw proces openen"
+
+#: Settings.ui.h:10
+#, fuzzy
+msgid "Cycle through windows"
+msgstr "Schakelen tussen vensters"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Klikactie"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Shift+Klik-actie"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "Het dock weergeven op"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "Positie op het scherm"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "Onderaan"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "Bovenaan"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+"Het dock verbergen wanneer het een venster van de huidige applicatie in de "
+"weg zit. Er zijn gedetailleerde instellingen hiervoor beschikbaar."
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "Intelligente verbergmodus"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "Maximale dockgrootte"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "Paneelmodus: uitrekken tot aan de schermrand"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "Maximale pictogramgrootte"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr ""
+"Vastgezette pictogramgrootte: scroll om meer pictogrammen weer te geven"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "Positie en grootte"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "Favoriete applicaties weergeven"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "Geopende applicaties weergeven"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+
 #: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
+msgstr "<i>Applicaties weergeven</i>-pictogram aan het begin"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr "Verplaatst de applicaties-knop naar het begin van het dock."
+
+#: Settings.ui.h:35
+#, fuzzy
+msgid "Animate <i>Show Applications</i>."
+msgstr "<i>Applicaties weergeven</i>-pictogram aan het begin"
+
+#: Settings.ui.h:36
+#, fuzzy
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "Gedrag van het klikken op het pictogram van een geopende applicatie."
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "Klikactie"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "Minimaliseren"
+
+#: Settings.ui.h:39
 #, fuzzy
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
@@ -195,15 +227,15 @@ msgstr ""
 "Het gebied nabij de schermrand en de <i>Applicaties weergeven</i>-knop zijn "
 "actief."
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Van werkblad wisselen door te scrollen op het dock"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Gedrag"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 #, fuzzy
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
@@ -213,61 +245,69 @@ msgstr ""
 "standaard GNOME-thema. In plaats daarvan kunt specifieke opties hieronder "
 "inschakelen."
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Ingebouwd thema gebruiken"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "Bespaar ruimte door de radius van de dikte en rand te verkleinen."
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "De dash verkleinen"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Een stip weergeven voor elk venster van de applicatie."
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Indicatoren van de vensterteller weergeven"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "De doorzichtigheid van de dash-achtergrond aanpassen."
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Doorzichtigheid aanpassen"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Doorzichtigheid"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Uiterlijk"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "versie:"
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr ""
 "Verplaatst de dash naar buiten het activiteitenoverzicht zodat het een dock "
 "wordt"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Gecreëerd door"
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr ""
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -277,67 +317,70 @@ msgstr ""
 "Bekijk de <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
 "\">GNU General Public License, versie 2 of nieuwer</a> voor details.</span>"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr "Over"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Het dock weergeven door de muiscursor op de schermrand te plaatsen"
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Automatisch verbergen"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "Weergeven middels druk: druk toepassen om het dock weer te geven"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr ""
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Het dock weergeven wanneer het geen applicatievensters in de weg zit."
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Vensters ontwijken"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 #, fuzzy
 msgid "All windows"
 msgstr "Vensters ontwijken"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr ""
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 #, fuzzy
 msgid "Only maximized windows"
 msgstr "Venster minimalisren"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Animatieduur (s)"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Verberginterval (s)"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Weergaveinterval (s)"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Drukwaarde (px)"
+
+#~ msgid "Do nothing"
+#~ msgstr "Niets doen"
 
 #~ msgid "Only consider windows of the focused application"
 #~ msgstr "Alleen vensters van de huidige gefocuste applicatie overwegen"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 53\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2016-03-22 17:25+0100\n"
 "Last-Translator: Piotr Sokół <psokol.l10n@gmail.com>\n"
 "Language-Team: polski <>\n"
@@ -20,31 +20,36 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2);\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "Podstawowy"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "Drugorzędny"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "Prawo"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "Lewo"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "Dostosowanie automatycznego ukrywania"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Przywróć domyślne"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Dostosowanie stylu wskaźników"
+
+#: prefs.js:419
 msgid "Customize running indicators"
 msgstr "Dostosowanie wskaźników okien"
 
@@ -65,106 +70,6 @@ msgid "Border width"
 msgstr "Szerokość obramowania"
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "Ekran wyświetlania doku"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "Położenie na ekranie"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "Dół"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "Góra"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-"Ukrywa dok jeśli zakrywa okno bieżącego programu. Dostępnych jest więcej "
-"szczegółowych opcji."
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "Inteligentne ukrywanie"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "Ograniczenie rozmiaru doku"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "Tryb panelu: rozciągnięcie do krawędzi ekranu"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "Ograniczenie rozmiaru ikon"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr "Ustalony rozmiar ikon: odsłanianie ikon przewijaniem"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "Położenie i rozmiar"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "Ulubione programy"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "Uruchomione programy"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-"Zmiana tego ustawienia możliwa jest również za pomocą narzędzia dostrajania "
-"lub innego rozszerzenia. "
-
-#: Settings.ui.h:21
-msgid "Show <i>Show Applications</i> icon"
-msgstr "Przycisk <i>Wyświetl programy</i>"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Przemieszczenie przycisku programów na początek doku"
-
-#: Settings.ui.h:23
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animowanie przycisku <i>Wyświetl programy</i>"
-
-#: Settings.ui.h:24
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "Określa działanie kliknięcia ikony uruchomionego programu"
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr "Działanie kliknięcia"
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "Brak"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "Zminimalizowanie okna"
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "Otwarcie nowego okna"
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "Przełączenie pomiędzy oknami"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
@@ -172,15 +77,143 @@ msgstr ""
 "Wybranie zminimalizowania okna, umożliwia zminimalizowanie wszystkich okien "
 "programu dwukrotnym kliknięciem"
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr "Działanie kliknięcia+Shift"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Zminimalizowanie okna"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "Zminimalizowanie okna"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "Otwarcie nowego okna"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "Przełączenie pomiędzy oknami"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Działanie kliknięcia"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Działanie kliknięcia+Shift"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "Ekran wyświetlania doku"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "Położenie na ekranie"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "Dół"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "Góra"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+"Ukrywa dok jeśli zakrywa okno bieżącego programu. Dostępnych jest więcej "
+"szczegółowych opcji."
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "Inteligentne ukrywanie"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "Ograniczenie rozmiaru doku"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "Tryb panelu: rozciągnięcie do krawędzi ekranu"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "Ograniczenie rozmiaru ikon"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr "Ustalony rozmiar ikon: odsłanianie ikon przewijaniem"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "Położenie i rozmiar"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "Ulubione programy"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "Uruchomione programy"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+"Zmiana tego ustawienia możliwa jest również za pomocą narzędzia dostrajania "
+"lub innego rozszerzenia. "
+
 #: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
+msgstr "Przycisk <i>Wyświetl programy</i>"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr "Przemieszczenie przycisku programów na początek doku"
+
+#: Settings.ui.h:35
+msgid "Animate <i>Show Applications</i>."
+msgstr "Animowanie przycisku <i>Wyświetl programy</i>"
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "Określa działanie kliknięcia ikony uruchomionego programu"
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "Działanie kliknięcia"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "Zminimalizowanie okna"
+
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
@@ -188,15 +221,15 @@ msgstr ""
 "W przypadku ustalonego rozmiaru ikon, używa jedynie obszaru krawędzi doku i "
 "przycisku <i>Wyświetl programy</i>."
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Przełączanie obszarów roboczych przewijaniem doku"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Zachowanie"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
@@ -204,61 +237,69 @@ msgstr ""
 "Integruje dok z domyślnym stylem GNOME przy użyciu kilku ustawień. "
 "Opcjonalnie ustawienia te można określić poniżej."
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Użycie zintegrowanego stylu"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr ""
 "Zmniejsza zajmowaną powierzchnię redukując\n"
 "odległość od krawędzi i jej zaokrąglenie"
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Zmniejszenie kokpitu"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Wyświetla kropkę dla każdego okna programu"
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Wskaźniki ilości okien"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Modyfikuje przezroczystość tła kokpitu"
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Dostosowanie przezroczystości tła"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Nieprzezroczystość"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Wygląd"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "wersja: "
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr "Przemieszcza kokpit z widoku podglądu do doku"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Autor:"
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "Strona internetowa"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -270,65 +311,68 @@ msgstr ""
 "gpl-2.0.html\">Powszechna licencja publiczna GNU, wersja 2 lub późniejsza</"
 "a>.</span>"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr "O programie"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Wyświetla dok po przemieszczeniu wskaźnika myszy do krawędzi ekranu"
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Automatyczne ukrywanie"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "Wymagany nacisk do wyświetlenia doku"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr "Wyświetlanie na pełnym ekranie"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Wyświetla dok jeśli nie zakrywa okien programu"
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Ukrywanie przed oknami"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr "Wszystkie okna"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr "Tylko aktywne okna programu"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 msgid "Only maximized windows"
 msgstr "Tylko zmaksymalizowane okna"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Czas animacji (s)"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Czas ukrywania (s)"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Czas wyświetlania (s)"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Próg nacisku"
+
+#~ msgid "Do nothing"
+#~ msgstr "Brak"
 
 #~ msgid "Main Settings"
 #~ msgstr "Ogólne"

--- a/po/pl.po
+++ b/po/pl.po
@@ -3,21 +3,21 @@
 # This file is distributed under the same license as the dash-to-dock package.
 # 
 # Piotr Sokół <psokol.l10n@gmail.com>, 2012, 2013, 2015, 2016.
-#
+# 
 msgid ""
 msgstr ""
-"Project-Id-Version: 53\n"
+"Project-Id-Version: 55\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-09 23:29+0100\n"
-"PO-Revision-Date: 2016-03-22 17:25+0100\n"
+"POT-Creation-Date: 2016-10-03 20:39+0100\n"
+"PO-Revision-Date: 2016-10-02 14:43+0200\n"
 "Last-Translator: Piotr Sokół <psokol.l10n@gmail.com>\n"
 "Language-Team: polski <>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bits\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
 #: prefs.js:98
@@ -45,9 +45,8 @@ msgid "Reset to defaults"
 msgstr "Przywróć domyślne"
 
 #: prefs.js:346
-#, fuzzy
 msgid "Customize middle-click behavior"
-msgstr "Dostosowanie stylu wskaźników"
+msgstr "Dostosowanie działania przycisków myszy"
 
 #: prefs.js:419
 msgid "Customize running indicators"
@@ -74,17 +73,16 @@ msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
 msgstr ""
-"Wybranie zminimalizowania okna, umożliwia zminimalizowanie wszystkich okien "
+"Wybranie zminimalizowania okna, umożliwia minimalizowanie wszystkich okien "
 "programu dwukrotnym kliknięciem"
 
 #: Settings.ui.h:6
 msgid "Shift+Click action"
-msgstr "Działanie kliknięcia+Shift"
+msgstr "Kliknięcia lewym przyciskiem + Shift"
 
 #: Settings.ui.h:7
-#, fuzzy
 msgid "Raise window"
-msgstr "Zminimalizowanie okna"
+msgstr "Przywrócenie okna"
 
 #: Settings.ui.h:8
 msgid "Minimize window"
@@ -100,25 +98,25 @@ msgstr "Przełączenie pomiędzy oknami"
 
 #: Settings.ui.h:11
 msgid "Quit"
-msgstr ""
+msgstr "Zakończenie działania"
 
 #: Settings.ui.h:12
 msgid "Behavior for Middle-Click."
-msgstr ""
+msgstr "Konfiguruje działanie kliknięcia środkowym przyciskiem myszy"
 
 #: Settings.ui.h:13
-#, fuzzy
 msgid "Middle-Click action"
-msgstr "Działanie kliknięcia"
+msgstr "Kliknięcie środkowym przyciskiem"
 
 #: Settings.ui.h:14
 msgid "Behavior for Shift+Middle-Click."
 msgstr ""
+"Konfiguruje działanie kliknięcia środkowym przyciskiem myszy z przytrzymanym "
+"klawiszem Shift"
 
 #: Settings.ui.h:15
-#, fuzzy
 msgid "Shift+Middle-Click action"
-msgstr "Działanie kliknięcia+Shift"
+msgstr "Kliknięcie środkowym przyciskiem + Shift"
 
 #: Settings.ui.h:16
 msgid "Show the dock on"
@@ -178,18 +176,17 @@ msgstr "Uruchomione programy"
 
 #: Settings.ui.h:31
 msgid "Isolate workspaces."
-msgstr ""
+msgstr "Izolowanie obszarów roboczych"
 
 #: Settings.ui.h:32
 msgid ""
 "If disabled, these settings are acccessible from gnome-tweak-tool or the "
 "extension website."
 msgstr ""
-"Zmiana tego ustawienia możliwa jest również za pomocą narzędzia dostrajania "
-"lub innego rozszerzenia. "
+"Przełącza widoczność przycisku programów. Można też skonfigurować za pomocą "
+"narzędzia dostrajania lub innego rozszerzenia."
 
 #: Settings.ui.h:33
-#, fuzzy
 msgid "Show <i>Applications</i> icon"
 msgstr "Przycisk <i>Wyświetl programy</i>"
 
@@ -261,11 +258,11 @@ msgstr "Wskaźniki ilości okien"
 
 #: Settings.ui.h:48
 msgid "Set the background color for the dash."
-msgstr ""
+msgstr "Ustala wybrany kolor tła kokpitu"
 
 #: Settings.ui.h:49
 msgid "Customize the dash color"
-msgstr ""
+msgstr "Kolor kokpitu"
 
 #: Settings.ui.h:50
 msgid "Tune the dash background opacity."

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2012-12-20 20:45+1100\n"
 "Last-Translator: Carlos Alberto Junior Spohr Poletto <carlos."
 "spohr@gmail>com>\n"
@@ -19,31 +19,36 @@ msgstr ""
 "X-Poedit-Language: Portuguese\n"
 "X-Poedit-Country: Portugal\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr ""
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr ""
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr ""
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr ""
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr ""
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr ""
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Alterar a opacidade do fundo do dock"
+
+#: prefs.js:419
 #, fuzzy
 msgid "Customize running indicators"
 msgstr "Mostrar aplicações em execução"
@@ -66,267 +71,303 @@ msgid "Border width"
 msgstr ""
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr ""
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr ""
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr ""
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr ""
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-
-#: Settings.ui.h:12
-#, fuzzy
-msgid "Intelligent autohide"
-msgstr "Ocultação inteligente"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr ""
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr ""
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr ""
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr ""
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr ""
-
-#: Settings.ui.h:18
-#, fuzzy
-msgid "Show favorite applications"
-msgstr "Mostrar ícones das aplicações favoritas"
-
-#: Settings.ui.h:19
-#, fuzzy
-msgid "Show running applications"
-msgstr "Mostrar aplicações em execução"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-
-#: Settings.ui.h:21
-#, fuzzy
-msgid "Show <i>Show Applications</i> icon"
-msgstr "Mostrar aplicações em execução"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr ""
-
-#: Settings.ui.h:23
-#, fuzzy
-msgid "Animate <i>Show Applications</i>."
-msgstr "Mostrar aplicações em execução"
-
-#: Settings.ui.h:24
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr ""
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr ""
-
-#: Settings.ui.h:26
-#, fuzzy
-msgid "Do nothing"
-msgstr "Não faça nada (padrão)"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "Minimizar"
-
-#: Settings.ui.h:28
-#, fuzzy
-msgid "Launch new instance"
-msgstr "Abrir uma nova janela"
-
-#: Settings.ui.h:29
-#, fuzzy
-msgid "Cycle through windows"
-msgstr "Percorrer janelas de aplicativos"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
 msgstr ""
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr ""
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Minimizar"
+
+#: Settings.ui.h:8
 #, fuzzy
 msgid "Minimize window"
 msgstr "Minimizar"
 
+#: Settings.ui.h:9
+#, fuzzy
+msgid "Launch new instance"
+msgstr "Abrir uma nova janela"
+
+#: Settings.ui.h:10
+#, fuzzy
+msgid "Cycle through windows"
+msgstr "Percorrer janelas de aplicativos"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+msgid "Middle-Click action"
+msgstr ""
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+msgid "Shift+Middle-Click action"
+msgstr ""
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr ""
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr ""
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr ""
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr ""
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+
+#: Settings.ui.h:23
+#, fuzzy
+msgid "Intelligent autohide"
+msgstr "Ocultação inteligente"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr ""
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr ""
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr ""
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr ""
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr ""
+
+#: Settings.ui.h:29
+#, fuzzy
+msgid "Show favorite applications"
+msgstr "Mostrar ícones das aplicações favoritas"
+
+#: Settings.ui.h:30
+#, fuzzy
+msgid "Show running applications"
+msgstr "Mostrar aplicações em execução"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+
 #: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
+msgstr "Mostrar aplicações em execução"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr ""
+
+#: Settings.ui.h:35
+#, fuzzy
+msgid "Animate <i>Show Applications</i>."
+msgstr "Mostrar aplicações em execução"
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr ""
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr ""
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "Minimizar"
+
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
 msgstr ""
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 #, fuzzy
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Trocar de espaço de trabalho quando scrolar o mouse sobre o dock"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr ""
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
 msgstr ""
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr ""
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr ""
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr ""
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr ""
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr ""
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 #, fuzzy
 msgid "Tune the dash background opacity."
 msgstr "Alterar a opacidade do fundo do dock"
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 #, fuzzy
 msgid "Customize opacity"
 msgstr "Alterar a opacidade do fundo do dock"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Opacidade"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr ""
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr ""
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr ""
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr ""
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr ""
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
 "\">GNU General Public License, version 2 or later</a> for details.</span>"
 msgstr ""
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr ""
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr ""
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Masquage automatique"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr ""
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr ""
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr ""
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr ""
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr ""
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr ""
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 #, fuzzy
 msgid "Only maximized windows"
 msgstr "Minimizar"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 #, fuzzy
 msgid "Animation duration (s)"
 msgstr "Tempo da animação [ms]"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr ""
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr ""
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr ""
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Do nothing"
+#~ msgstr "Não faça nada (padrão)"
 
 #~ msgid "Main Settings"
 #~ msgstr "Configurações principais"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2016-04-06 17:44-0300\n"
 "Last-Translator: Fábio Nogueira <fnogueira@gnome.org>\n"
 "Language-Team: Português do Brasil\n"
@@ -18,31 +18,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "Monitor primário"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "Monitor secundário"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "Direita"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "Esquerda"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "Configuração da ocultação inteligente"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Restaurar o padrão"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Customizar o estilo do indicador"
+
+#: prefs.js:419
 msgid "Customize running indicators"
 msgstr "Customizar os indicadores de execução"
 
@@ -63,22 +68,72 @@ msgid "Border width"
 msgstr "Tamanho da borda"
 
 #: Settings.ui.h:5
+msgid ""
+"When set to minimize, double clicking minimizes all the windows of the "
+"application."
+msgstr ""
+"Quando minimizar, o duplo clique minizará todas as janelas dos aplicativos"
+
+#: Settings.ui.h:6
+msgid "Shift+Click action"
+msgstr "Ação do Shift+Click"
+
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Minimizar janela"
+
+#: Settings.ui.h:8
+msgid "Minimize window"
+msgstr "Minimizar janela"
+
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "Iniciar nova instância"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "Percorrer através das janelas"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Ação do clique"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Ação do Shift+Click"
+
+#: Settings.ui.h:16
 msgid "Show the dock on"
 msgstr "Exibir o dock"
 
-#: Settings.ui.h:6
+#: Settings.ui.h:17
 msgid "Position on screen"
 msgstr "Posição na tela"
 
-#: Settings.ui.h:8
+#: Settings.ui.h:19
 msgid "Bottom"
 msgstr "Embaixo"
 
-#: Settings.ui.h:9
+#: Settings.ui.h:20
 msgid "Top"
 msgstr "Em cima"
 
-#: Settings.ui.h:11
+#: Settings.ui.h:22
 msgid ""
 "Hide the dock when it obstructs a window of the the current application. "
 "More refined settings are available."
@@ -86,39 +141,43 @@ msgstr ""
 "Ocultar o dock quando o mesmo sobrepor a janela do aplicativo em uso. "
 "Definições mais aperfeiçoadas estão disponíveis."
 
-#: Settings.ui.h:12
+#: Settings.ui.h:23
 msgid "Intelligent autohide"
 msgstr "Ocultação inteligente"
 
-#: Settings.ui.h:13
+#: Settings.ui.h:24
 msgid "Dock size limit"
 msgstr "Tamanho limite do dock"
 
-#: Settings.ui.h:14
+#: Settings.ui.h:25
 msgid "Panel mode: extend to the screen edge"
 msgstr "Modo do painel: estender até a borda da tela"
 
-#: Settings.ui.h:15
+#: Settings.ui.h:26
 msgid "Icon size limit"
 msgstr "Tamanho limite do ícone"
 
-#: Settings.ui.h:16
+#: Settings.ui.h:27
 msgid "Fixed icon size: scroll to reveal other icons"
 msgstr "Tamanho do ícone fixo: use o scroll do mouse para revelar outro ícone"
 
-#: Settings.ui.h:17
+#: Settings.ui.h:28
 msgid "Position and size"
 msgstr "Posição e tamanho"
 
-#: Settings.ui.h:18
+#: Settings.ui.h:29
 msgid "Show favorite applications"
 msgstr "Mostrar aplicativos favoritos"
 
-#: Settings.ui.h:19
+#: Settings.ui.h:30
 msgid "Show running applications"
 msgstr "Mostrar aplicativos em execução"
 
-#: Settings.ui.h:20
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
 msgid ""
 "If disabled, these settings are acccessible from gnome-tweak-tool or the "
 "extension website."
@@ -126,58 +185,32 @@ msgstr ""
 "Se desabilitado, essas configurações estão acessíveis através do gnome-tweak-"
 "tool ou no site da extensão."
 
-#: Settings.ui.h:21
-msgid "Show <i>Show Applications</i> icon"
+#: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
 msgstr "Exibir ícone de <i>Mostrar Aplicativos</i>"
 
-#: Settings.ui.h:22
+#: Settings.ui.h:34
 msgid "Move the applications button at the beginning of the dock."
 msgstr "Mover o botão de aplicativos para o íncio do dock."
 
-#: Settings.ui.h:23
+#: Settings.ui.h:35
 msgid "Animate <i>Show Applications</i>."
 msgstr "<i>Mostrar aplicativos</i> com efeitos."
 
-#: Settings.ui.h:24
+#: Settings.ui.h:36
 msgid "Behaviour when clicking on the icon of a running application."
 msgstr "Comportamento ao clicar sobre o ícone de um aplicativo em execução."
 
-#: Settings.ui.h:25
+#: Settings.ui.h:37
 msgid "Click action"
 msgstr "Ação do clique"
 
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "Não faça nada"
-
-#: Settings.ui.h:27
+#: Settings.ui.h:38
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "Iniciar nova instância"
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "Percorrer através das janelas"
-
-#: Settings.ui.h:30
-msgid ""
-"When set to minimize, double clicking minimizes all the windows of the "
-"application."
-msgstr ""
-"Quando minimizar, o duplo clique minizará todas as janelas dos aplicativos"
-
-#: Settings.ui.h:31
-msgid "Shift+Click action"
-msgstr "Ação do Shift+Click"
-
-#: Settings.ui.h:32
-msgid "Minimize window"
-msgstr "Minimizar janela"
-
-#: Settings.ui.h:33
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
@@ -185,15 +218,15 @@ msgstr ""
 "Com o tamanho do ícone fixo, somente a borda do dock e o ícone <i>Mostrar "
 "aplicativos</i> são ativados."
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Trocar de área de trabalho quando usar o scroll do mouse sobre o dock"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Comportamento"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
@@ -201,59 +234,67 @@ msgstr ""
 "Algumas personalizações se destinam a integrar o dock com o tema padrão do "
 "GNOME. Alternativamente, as opções específicas podem ser ativadas abaixo."
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Usar o tema do sistema"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "Economizar espaço reduzindo preenchimento e a borda arredondada"
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Encolher o dash"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Mostrar um ponto para cada janela do aplicativo"
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Mostrar indicadores de contador de janelas"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Ajustar a opacidade do fundo do dash."
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Customizar opacidade"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Opacidade"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Aparência"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "versão:"
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr "Mover o dash para fora da visão geral transformando-o em dock"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Criado por"
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "Página Web"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -264,65 +305,68 @@ msgstr ""
 "\">GNU General Public License, versão 2 ou posterior</a> para maiores "
 "detalhes.</span>"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr "Sobre"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Mostrar o dock quando o mouse pairar sobre a tela."
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Ocultação"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "Empurrar para mostrar: requer pressão para mostrar o dock"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr "Habilitar modo tela cheia"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Mostrar o dock quando nenhum aplicativo sobrepor o mesmo."
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Esconder janela"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr "Todas as janelas"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr "Apenas janelas de aplicativos em foco"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 msgid "Only maximized windows"
 msgstr "Somente janelas maximizadas"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Tempo da animação [s]"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Ocultar tempo limite [s]"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Mostrar tempo limite [s]"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Limite de pressão"
+
+#~ msgid "Do nothing"
+#~ msgstr "Não faça nada"
 
 #~ msgid "Only consider windows of the focused application"
 #~ msgstr "Considere apenas janelas de aplicativos em uso."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -9,14 +9,14 @@ msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-09 23:29+0100\n"
-"PO-Revision-Date: 2016-04-06 17:44-0300\n"
+"PO-Revision-Date: 2017-01-03 23:59-0300\n"
 "Last-Translator: Fábio Nogueira <fnogueira@gnome.org>\n"
 "Language-Team: Português do Brasil\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.7.1\n"
+"X-Generator: Poedit 1.8.11\n"
 
 #: prefs.js:98
 msgid "Primary monitor"
@@ -43,9 +43,8 @@ msgid "Reset to defaults"
 msgstr "Restaurar o padrão"
 
 #: prefs.js:346
-#, fuzzy
 msgid "Customize middle-click behavior"
-msgstr "Customizar o estilo do indicador"
+msgstr "Customizar o comportamento do clique do botão do meio"
 
 #: prefs.js:419
 msgid "Customize running indicators"
@@ -79,9 +78,8 @@ msgid "Shift+Click action"
 msgstr "Ação do Shift+Click"
 
 #: Settings.ui.h:7
-#, fuzzy
 msgid "Raise window"
-msgstr "Minimizar janela"
+msgstr "Aumentar janela"
 
 #: Settings.ui.h:8
 msgid "Minimize window"
@@ -97,25 +95,23 @@ msgstr "Percorrer através das janelas"
 
 #: Settings.ui.h:11
 msgid "Quit"
-msgstr ""
+msgstr "Sair"
 
 #: Settings.ui.h:12
 msgid "Behavior for Middle-Click."
-msgstr ""
+msgstr "Comportamento do Clique do botão do meio."
 
 #: Settings.ui.h:13
-#, fuzzy
 msgid "Middle-Click action"
-msgstr "Ação do clique"
+msgstr "Ação do clique do botão do meio"
 
 #: Settings.ui.h:14
 msgid "Behavior for Shift+Middle-Click."
-msgstr ""
+msgstr "Comportamento para Shift + Clique do botão do meio."
 
 #: Settings.ui.h:15
-#, fuzzy
 msgid "Shift+Middle-Click action"
-msgstr "Ação do Shift+Click"
+msgstr "Ação do Shift+Clique do botão do meio"
 
 #: Settings.ui.h:16
 msgid "Show the dock on"
@@ -175,7 +171,7 @@ msgstr "Mostrar aplicativos em execução"
 
 #: Settings.ui.h:31
 msgid "Isolate workspaces."
-msgstr ""
+msgstr "Isolar espaços de trabalho."
 
 #: Settings.ui.h:32
 msgid ""
@@ -186,9 +182,8 @@ msgstr ""
 "tool ou no site da extensão."
 
 #: Settings.ui.h:33
-#, fuzzy
 msgid "Show <i>Applications</i> icon"
-msgstr "Exibir ícone de <i>Mostrar Aplicativos</i>"
+msgstr "Exibir ícone dos <i>Aplicativos</i>"
 
 #: Settings.ui.h:34
 msgid "Move the applications button at the beginning of the dock."
@@ -256,11 +251,11 @@ msgstr "Mostrar indicadores de contador de janelas"
 
 #: Settings.ui.h:48
 msgid "Set the background color for the dash."
-msgstr ""
+msgstr "Define a cor de fundo para o dash."
 
 #: Settings.ui.h:49
 msgid "Customize the dash color"
-msgstr ""
+msgstr "Customizar a cor do dash"
 
 #: Settings.ui.h:50
 msgid "Tune the dash background opacity."

--- a/po/ru.po
+++ b/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dash-to-dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-20 15:36+0900\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2016-03-20 15:41+0900\n"
 "Last-Translator: Ivan Komaritsyn <vantu5z@mail.ru>\n"
 "Language-Team: \n"
@@ -17,31 +17,36 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "Основной монитор"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "Дополнительный монитор"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "Справа"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "Слева"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "Настройка автоскрытия"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Сбросить настройки"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Настроить стиль индикатора"
+
+#: prefs.js:419
 msgid "Customize running indicators"
 msgstr "Настройка индикаторов запуска"
 
@@ -62,108 +67,6 @@ msgid "Border width"
 msgstr "Ширина границы"
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "Показывать Док на"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "Расположение на экране"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "Снизу"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "Сверху"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-"Скрывать Док, если он перекрывается окном активного приложения. Доступны "
-"дополнительные настройки."
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "Интеллектуальное скрытие"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "Ограничение размера Дока"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "Режим панели: Док растянут по всей стороне экрана"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "Ограничение размера иконок"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr ""
-"Фиксированный размер иконок: используйте прокрутку для доступа к нужному "
-"приложению"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "Положение и размер"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "Показывать избранные приложения"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "Показывать запущенные приложения"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-"Если отключено, то эти настройки доступны в gnome-tweak-tool или через сайт "
-"дополнений."
-
-#: Settings.ui.h:21
-msgid "Show <i>Show Applications</i> icon"
-msgstr "Показывать иконку <i>«Приложения»</i>"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Расположить кнопку «Приложения» с другой стороны Дока."
-
-#: Settings.ui.h:23
-msgid "Animate <i>Show Applications</i>."
-msgstr "Анимация при показе <i>«Приложений»</i>"
-
-#: Settings.ui.h:24
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "Поведение при нажатии на иконку запущенного приложения."
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr "Действие по нажатию"
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "Ничего не делать"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "Минимизировать"
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "Открыть новое окно"
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "Переключить окно приложения"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
@@ -171,15 +74,145 @@ msgstr ""
 "Если установлено на «Минимизировать», то двойной клик минимизирует все окна "
 "данного приложения."
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr "Действие по Shift+Click"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Минимизировать окно"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "Минимизировать окно"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "Открыть новое окно"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "Переключить окно приложения"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Действие по нажатию"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Действие по Shift+Click"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "Показывать Док на"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "Расположение на экране"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "Снизу"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "Сверху"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+"Скрывать Док, если он перекрывается окном активного приложения. Доступны "
+"дополнительные настройки."
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "Интеллектуальное скрытие"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "Ограничение размера Дока"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "Режим панели: Док растянут по всей стороне экрана"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "Ограничение размера иконок"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr ""
+"Фиксированный размер иконок: используйте прокрутку для доступа к нужному "
+"приложению"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "Положение и размер"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "Показывать избранные приложения"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "Показывать запущенные приложения"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+"Если отключено, то эти настройки доступны в gnome-tweak-tool или через сайт "
+"дополнений."
+
 #: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
+msgstr "Показывать иконку <i>«Приложения»</i>"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr "Расположить кнопку «Приложения» с другой стороны Дока."
+
+#: Settings.ui.h:35
+msgid "Animate <i>Show Applications</i>."
+msgstr "Анимация при показе <i>«Приложений»</i>"
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "Поведение при нажатии на иконку запущенного приложения."
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "Действие по нажатию"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "Минимизировать"
+
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
@@ -187,15 +220,15 @@ msgstr ""
 "При фиксированном размере иконок приложений активна только область иконки "
 "<i>«Приложения»</i> и край дока."
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Переключать рабочие столы при прокрутке на Доке"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Поведение"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
@@ -203,61 +236,69 @@ msgstr ""
 "Сбалансированные настройки для интеграции Дока с темой Gnome по умолчанию. "
 "Ниже можно установить настройки вручную."
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Использовать встроенную тему"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr ""
 "Экономия рабочего пространства за счёт уменьшения промежутков и "
 "использования скругленных углов."
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Сжать Док"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Отображает точку для каждого окна приложения."
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Показывать индикаторы количества окон"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Настройка прозрачности фона Дока."
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Настроить прозрачность"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Непрозрачность"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Внешний вид"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "версия: "
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr "Показывает панель из режима «Обзор» в виде дока"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Автор"
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "Домашняя страница"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -269,65 +310,68 @@ msgstr ""
 "\">GNU General Public License, версия 2 или позднее</a> для информации.</"
 "span>"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr "О дополнении"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Показывать Док при подведении мыши к стороне экрана."
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Автоматическое скрытие"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "Давление для появления: требуется давление для открытия Дока"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr "Включить для полноэкранного режима"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Скрывать Док, когда он перекрыт окнами приложений"
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Перекрытие окнами"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr "Все окна"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr "Только активное окно приложения"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 msgid "Only maximized windows"
 msgstr "Только развёрнутые окна"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Время анимации (сек.)"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Задержка скрытия (сек.)"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Задержка открытия (сек.)"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Порог давления"
+
+#~ msgid "Do nothing"
+#~ msgstr "Ничего не делать"
 
 #~ msgid "Only consider windows of the focused application"
 #~ msgstr "Применить только к активным окнам приложений"

--- a/po/ru.po
+++ b/po/ru.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: dash-to-dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-09 23:29+0100\n"
-"PO-Revision-Date: 2016-03-20 15:41+0900\n"
+"PO-Revision-Date: 2016-09-23 09:30+0300\n"
 "Last-Translator: Ivan Komaritsyn <vantu5z@mail.ru>\n"
 "Language-Team: \n"
 "Language: ru\n"
@@ -42,9 +42,8 @@ msgid "Reset to defaults"
 msgstr "Сбросить настройки"
 
 #: prefs.js:346
-#, fuzzy
 msgid "Customize middle-click behavior"
-msgstr "Настроить стиль индикатора"
+msgstr "Настройка действий для средней кнопки мыши"
 
 #: prefs.js:419
 msgid "Customize running indicators"
@@ -79,9 +78,8 @@ msgid "Shift+Click action"
 msgstr "Действие по Shift+Click"
 
 #: Settings.ui.h:7
-#, fuzzy
 msgid "Raise window"
-msgstr "Минимизировать окно"
+msgstr "Показать окно"
 
 #: Settings.ui.h:8
 msgid "Minimize window"
@@ -97,25 +95,23 @@ msgstr "Переключить окно приложения"
 
 #: Settings.ui.h:11
 msgid "Quit"
-msgstr ""
+msgstr "Выйти"
 
 #: Settings.ui.h:12
 msgid "Behavior for Middle-Click."
-msgstr ""
+msgstr "Действие по нажатию средней кнопки мыши."
 
 #: Settings.ui.h:13
-#, fuzzy
 msgid "Middle-Click action"
-msgstr "Действие по нажатию"
+msgstr "Действие по Middle-Click"
 
 #: Settings.ui.h:14
 msgid "Behavior for Shift+Middle-Click."
-msgstr ""
+msgstr "Действие по нажатию Shift + средняя кнопка мыши."
 
 #: Settings.ui.h:15
-#, fuzzy
 msgid "Shift+Middle-Click action"
-msgstr "Действие по Shift+Click"
+msgstr "Действие по Shift+Middle-Click"
 
 #: Settings.ui.h:16
 msgid "Show the dock on"
@@ -177,7 +173,7 @@ msgstr "Показывать запущенные приложения"
 
 #: Settings.ui.h:31
 msgid "Isolate workspaces."
-msgstr ""
+msgstr "Для текущего рабочего стола."
 
 #: Settings.ui.h:32
 msgid ""
@@ -188,7 +184,6 @@ msgstr ""
 "дополнений."
 
 #: Settings.ui.h:33
-#, fuzzy
 msgid "Show <i>Applications</i> icon"
 msgstr "Показывать иконку <i>«Приложения»</i>"
 
@@ -260,11 +255,11 @@ msgstr "Показывать индикаторы количества окон"
 
 #: Settings.ui.h:48
 msgid "Set the background color for the dash."
-msgstr ""
+msgstr "Вобор цвета фона для панели."
 
 #: Settings.ui.h:49
 msgid "Customize the dash color"
-msgstr ""
+msgstr "Настроить цвет Дока"
 
 #: Settings.ui.h:50
 msgid "Tune the dash background opacity."

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-15 11:30+0200\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2016-07-15 12:48+0200\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
 "Language-Team: \n"
@@ -26,11 +26,11 @@ msgstr "Hlavnom monitore"
 msgid "Secondary monitor "
 msgstr "Vedľajšom monitore"
 
-#: prefs.js:139 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "Vpravo"
 
-#: prefs.js:140 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "Vľavo"
 
@@ -38,11 +38,16 @@ msgstr "Vľavo"
 msgid "Intelligent autohide customization"
 msgstr "Prispôsobenie inteligentného automatického skrývania"
 
-#: prefs.js:197
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Obnoviť pôvodné"
 
-#: prefs.js:358
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Prispôsobenie štýlu indikátorov"
+
+#: prefs.js:419
 msgid "Customize running indicators"
 msgstr "Prispôsobenie "
 
@@ -63,110 +68,6 @@ msgid "Border width"
 msgstr "Šírka okraja"
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "Zobraziť dok na"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "Pozícia na obrazovke"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "Na spodku"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "Na vrchu"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-"Skryť dok, keď zasahuje do okna aktuálnej aplikácie. Sú dostupné "
-"podrobnejšie nastavenia."
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "Inteligentné automatické skrývanie"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "Limit veľkosti doku"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "Režim panelu: roztiahnutie k hranám obrazovky"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "Limit veľkosti ikôn"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr "Pevná veľkosť ikôn: rolovaním odhalíte ostatné ikony"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "Pozícia a veľkosť"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "Zobraziť obľúbené aplikácie"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "Zobraziť spustené aplikácie"
-
-#: Settings.ui.h:20
-msgid "Isolate workspaces."
-msgstr "Oddelené pracovné priestory."
-
-#: Settings.ui.h:21
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-"Ak je voľba zakázaná, nastavenia sú dostupné z nástroja na vyladenie "
-"nastavení prostredia Gnome alebo webovej stránky rozšírenia."
-
-#: Settings.ui.h:22
-msgid "Show <i>Applications</i> icon"
-msgstr "Zobraziť ikonu <i>Aplikácie</i>"
-
-#: Settings.ui.h:23
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Premiestni tlačidlo aplikácií na začiatok doku."
-
-#: Settings.ui.h:24
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animovať položku <i>Zobraziť aplikácie</i>."
-
-#: Settings.ui.h:25
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "Správanie pri kliknutí na ikonu spustenej aplikácie."
-
-#: Settings.ui.h:26
-msgid "Click action"
-msgstr "Akcia po kliknutí"
-
-#: Settings.ui.h:27
-msgid "Do nothing"
-msgstr "Nevykonať nič"
-
-#: Settings.ui.h:28
-msgid "Minimize"
-msgstr "Minimalizovať"
-
-#: Settings.ui.h:29
-msgid "Launch new instance"
-msgstr "Spustiť novú inštanciu"
-
-#: Settings.ui.h:30
-msgid "Cycle through windows"
-msgstr "Striedať okná"
-
-#: Settings.ui.h:31
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
@@ -174,15 +75,142 @@ msgstr ""
 "Keď je nastavené na minimalizovanie, dvojklik minimalizuje všetky okná "
 "aplikácie."
 
-#: Settings.ui.h:32
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr "Akcia Shift+Kliknutie"
 
-#: Settings.ui.h:33
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Minimalizovať okno"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "Minimalizovať okno"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "Spustiť novú inštanciu"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "Striedať okná"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Akcia po kliknutí"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Akcia Shift+Kliknutie"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "Zobraziť dok na"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "Pozícia na obrazovke"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "Na spodku"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "Na vrchu"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+"Skryť dok, keď zasahuje do okna aktuálnej aplikácie. Sú dostupné "
+"podrobnejšie nastavenia."
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "Inteligentné automatické skrývanie"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "Limit veľkosti doku"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "Režim panelu: roztiahnutie k hranám obrazovky"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "Limit veľkosti ikôn"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr "Pevná veľkosť ikôn: rolovaním odhalíte ostatné ikony"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "Pozícia a veľkosť"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "Zobraziť obľúbené aplikácie"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "Zobraziť spustené aplikácie"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr "Oddelené pracovné priestory."
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+"Ak je voľba zakázaná, nastavenia sú dostupné z nástroja na vyladenie "
+"nastavení prostredia Gnome alebo webovej stránky rozšírenia."
+
+#: Settings.ui.h:33
+msgid "Show <i>Applications</i> icon"
+msgstr "Zobraziť ikonu <i>Aplikácie</i>"
+
 #: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr "Premiestni tlačidlo aplikácií na začiatok doku."
+
+#: Settings.ui.h:35
+msgid "Animate <i>Show Applications</i>."
+msgstr "Animovať položku <i>Zobraziť aplikácie</i>."
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "Správanie pri kliknutí na ikonu spustenej aplikácie."
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "Akcia po kliknutí"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "Minimalizovať"
+
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
@@ -190,15 +218,15 @@ msgstr ""
 "S pevnou veľkosťou ikon je aktívna iba hrana doku a ikona <i>Zobraziť "
 "aplikácie</i>."
 
-#: Settings.ui.h:35
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Prepínať pracovné priestory rolovaním na doku"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Správanie"
 
-#: Settings.ui.h:37
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
@@ -206,67 +234,67 @@ msgstr ""
 "Niekoľko úprav na integrovanie doku s predvolenou témou prostredia GNOME. "
 "Alternatívne môžu byť povolené špecifické voľby nižšie."
 
-#: Settings.ui.h:38
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Použiť zabudovanú tému"
 
-#: Settings.ui.h:39
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "Ušetrí miesto zmenšením rádiusu odsadenia a okrajov."
 
-#: Settings.ui.h:40
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Zmenšiť panel"
 
-#: Settings.ui.h:41
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Zobrazí bodku za každé okno aplikácie."
 
-#: Settings.ui.h:42
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Zobraziť indikátory počítadiel okien"
 
-#: Settings.ui.h:43
+#: Settings.ui.h:48
 msgid "Set the background color for the dash."
 msgstr "Nastaví farbu pozadia panelu."
 
-#: Settings.ui.h:44
+#: Settings.ui.h:49
 msgid "Customize the dash color"
 msgstr "Prispôsobenie farby panelu"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Vyladí krytie pozadia panelu."
 
-#: Settings.ui.h:46
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Prispôsobenie krytia"
 
-#: Settings.ui.h:47
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Krytie"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Vzhľad"
 
-#: Settings.ui.h:49
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "Verzia: c"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr "Presunie panel z prehľadu transformovaním do doku"
 
-#: Settings.ui.h:51
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Vytvoril"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "Webová stránka"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -277,62 +305,65 @@ msgstr ""
 "licenses/gpl-2.0.html\">Licenciu GNU General Public, verzie 2 alebo novšiu</"
 "a>.</span>"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:60
 msgid "About"
 msgstr "O rozšírení"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Zobrazí dok prejdením myši na hranu obrazovky."
 
-#: Settings.ui.h:57
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Automatické skrytie"
 
-#: Settings.ui.h:58
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "Zobraziť stlačením: vyžaduje tlak na zobrazenie doku"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr "Povoliť v režime na celú obrazovku"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Zobrazí dok, keď nebude zasahovať do okien aplikácií."
 
-#: Settings.ui.h:61
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Vyhýbať sa oknám"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr "Všetky okná"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr "Iba zamerané okná aplikácií"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:69
 msgid "Only maximized windows"
 msgstr "Iba maximalizované okná"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Trvanie animácie (s)"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:67
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Časový limit na skrytie (s)"
 
-#: Settings.ui.h:68
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Zobraziť časový limit (s)"
 
-#: Settings.ui.h:69
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Medza tlaku"
+
+#~ msgid "Do nothing"
+#~ msgstr "Nevykonať nič"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2015-07-29 18:11+0200\n"
 "Last-Translator: Слободан Терзић <Xabre@archlinux.info>\n"
 "Language-Team: \n"
@@ -19,31 +19,36 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "примарном монитору"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "секундарном монитору"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "десно"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "лево"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "Поставке интелигентног самосакривања"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Поврати основно"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Прилагоћавање прозирности"
+
+#: prefs.js:419
 #, fuzzy
 msgid "Customize running indicators"
 msgstr "Приказ покренутих програма"
@@ -66,107 +71,6 @@ msgid "Border width"
 msgstr ""
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "Прикажи док на"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "Позиција на екрану"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "дно"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "врх"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-"Сакриј док када је на путу прозора тренутног програма. Доступне су финије "
-"поставке."
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "Интелигентно самосакривање"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "Ограничење величине дока"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "Режим панела: проширен до ивица екрана"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "Ограничење величине икона"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr "Устаљена величина икона: клизајте за друге иконе"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "Позиција и величина"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "Приказ омиљених програма"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "Приказ покренутих програма"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-"Уколико је онемогућено, ове поставке су доступне кроз алатку за лицкање или "
-"веб сајт проширења."
-
-#: Settings.ui.h:21
-msgid "Show <i>Show Applications</i> icon"
-msgstr "Приказ иконе <i>Прикажи програме</i>"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Помери дугме програма на почетак дока"
-
-#: Settings.ui.h:23
-#, fuzzy
-msgid "Animate <i>Show Applications</i>."
-msgstr "Приказ иконе <i>Прикажи програме</i>"
-
-#: Settings.ui.h:24
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "Понашање при клику на покренути програм."
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr "Радња клика"
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "ништа"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "минимизуј"
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "покрени нови примерак"
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "кружење кроз прозоре"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
@@ -174,15 +78,144 @@ msgstr ""
 "Кад је постављено на минимизовање, дупли клик минимизује све прозоре "
 "програма."
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr "Радња шифт+клика"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "минимиуј прозор"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "минимиуј прозор"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "покрени нови примерак"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "кружење кроз прозоре"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Радња клика"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Радња шифт+клика"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "Прикажи док на"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "Позиција на екрану"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "дно"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "врх"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+"Сакриј док када је на путу прозора тренутног програма. Доступне су финије "
+"поставке."
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "Интелигентно самосакривање"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "Ограничење величине дока"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "Режим панела: проширен до ивица екрана"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "Ограничење величине икона"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr "Устаљена величина икона: клизајте за друге иконе"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "Позиција и величина"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "Приказ омиљених програма"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "Приказ покренутих програма"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+"Уколико је онемогућено, ове поставке су доступне кроз алатку за лицкање или "
+"веб сајт проширења."
+
 #: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
+msgstr "Приказ иконе <i>Прикажи програме</i>"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr "Помери дугме програма на почетак дока"
+
+#: Settings.ui.h:35
+#, fuzzy
+msgid "Animate <i>Show Applications</i>."
+msgstr "Приказ иконе <i>Прикажи програме</i>"
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "Понашање при клику на покренути програм."
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "Радња клика"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "минимизуј"
+
+#: Settings.ui.h:39
 #, fuzzy
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
@@ -191,15 +224,15 @@ msgstr ""
 "Ако се иконе преклапају на доку, приказује се само икона <i>Прикажи "
 "програме</i>."
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Промена радног простора клизањем по доку"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Понашање"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 #, fuzzy
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
@@ -208,59 +241,67 @@ msgstr ""
 "Неколико поставки је намењено уграђивању дока у основну тему Гнома. "
 "Алтернативно, посебне поставке се могу уредити испод."
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Користи уграђену тему"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "Чува простор сужавањем попуне и опсега ивица."
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Скупи плочу"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Приказује тачку за сваки прозор програма."
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Приказ индикаторa бројача прозора."
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Прилагоди прозирност позадине плоче."
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Прилагоћавање прозирности"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Прозирност"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Изглед"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "верзија:"
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr "Помера плочу из глобалног приказа, претварајући је у док"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Направи"
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "Веб страница"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -270,67 +311,70 @@ msgstr ""
 "Погледајте <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
 "\">ГНУову Општу Јавну лиценцу, верзија 2 или каснија</a>, за детаље.</span>"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr "О програму"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Прикажи док прелазом миша пеко ивице екрана."
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Самоскривање"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "Приказ притиском: захтева притисак за приказ дока"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr ""
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Приказује док када није на путу прозорима програма."
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Избегавање розора"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 #, fuzzy
 msgid "All windows"
 msgstr "Избегавање розора"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr ""
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 #, fuzzy
 msgid "Only maximized windows"
 msgstr "минимиуј прозор"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Трајање(а) анимације"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0,000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Застој скривања"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Застој приказивања"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Праг притиска"
+
+#~ msgid "Do nothing"
+#~ msgstr "ништа"
 
 #~ msgid "Only consider windows of the focused application"
 #~ msgstr "Разматрај само прозор фокусираног програма"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2015-07-29 18:11+0200\n"
 "Last-Translator: Slobodan Terzić <Xabre@archlinux.info>\n"
 "Language-Team: \n"
@@ -19,31 +19,36 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "primarnom monitoru"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "sekundarnom monitoru"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "desno"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "levo"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "Postavke inteligentnog samosakrivanja"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Povrati osnovno"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Prilagoćavanje prozirnosti"
+
+#: prefs.js:419
 #, fuzzy
 msgid "Customize running indicators"
 msgstr "Prikaz pokrenutih programa"
@@ -66,107 +71,6 @@ msgid "Border width"
 msgstr ""
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "Prikaži dok na"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "Pozicija na ekranu"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "dno"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "vrh"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-"Sakrij dok kada je na putu prozora trenutnog programa. Dostupne su finije "
-"postavke."
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "Inteligentno samosakrivanje"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "Ograničenje veličine doka"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "Režim panela: proširen do ivica ekrana"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "Ograničenje veličine ikona"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr "Ustaljena veličina ikona: klizajte za druge ikone"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "Pozicija i veličina"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "Prikaz omiljenih programa"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "Prikaz pokrenutih programa"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-"Ukoliko je onemogućeno, ove postavke su dostupne kroz alatku za lickanje ili "
-"veb sajt proširenja."
-
-#: Settings.ui.h:21
-msgid "Show <i>Show Applications</i> icon"
-msgstr "Prikaz ikone <i>Prikaži programe</i>"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Pomeri dugme programa na početak doka"
-
-#: Settings.ui.h:23
-#, fuzzy
-msgid "Animate <i>Show Applications</i>."
-msgstr "Prikaz ikone <i>Prikaži programe</i>"
-
-#: Settings.ui.h:24
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "Ponašanje pri kliku na pokrenuti program."
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr "Radnja klika"
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "ništa"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "minimizuj"
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "pokreni novi primerak"
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "kruženje kroz prozore"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
@@ -174,15 +78,144 @@ msgstr ""
 "Kad je postavljeno na minimizovanje, dupli klik minimizuje sve prozore "
 "programa."
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr "Radnja šift+klika"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "minimiuj prozor"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "minimiuj prozor"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "pokreni novi primerak"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "kruženje kroz prozore"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Radnja klika"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Radnja šift+klika"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "Prikaži dok na"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "Pozicija na ekranu"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "dno"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "vrh"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+"Sakrij dok kada je na putu prozora trenutnog programa. Dostupne su finije "
+"postavke."
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "Inteligentno samosakrivanje"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "Ograničenje veličine doka"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "Režim panela: proširen do ivica ekrana"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "Ograničenje veličine ikona"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr "Ustaljena veličina ikona: klizajte za druge ikone"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "Pozicija i veličina"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "Prikaz omiljenih programa"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "Prikaz pokrenutih programa"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+"Ukoliko je onemogućeno, ove postavke su dostupne kroz alatku za lickanje ili "
+"veb sajt proširenja."
+
 #: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
+msgstr "Prikaz ikone <i>Prikaži programe</i>"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr "Pomeri dugme programa na početak doka"
+
+#: Settings.ui.h:35
+#, fuzzy
+msgid "Animate <i>Show Applications</i>."
+msgstr "Prikaz ikone <i>Prikaži programe</i>"
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "Ponašanje pri kliku na pokrenuti program."
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "Radnja klika"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "minimizuj"
+
+#: Settings.ui.h:39
 #, fuzzy
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
@@ -191,15 +224,15 @@ msgstr ""
 "Ako se ikone preklapaju na doku, prikazuje se samo ikona <i>Prikaži "
 "programe</i>."
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Promena radnog prostora klizanjem po doku"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Ponašanje"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 #, fuzzy
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
@@ -208,59 +241,67 @@ msgstr ""
 "Nekoliko postavki je namenjeno ugrađivanju doka u osnovnu temu Gnoma. "
 "Alternativno, posebne postavke se mogu urediti ispod."
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Koristi ugrađenu temu"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "Čuva prostor sužavanjem popune i opsega ivica."
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Skupi ploču"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Prikazuje tačku za svaki prozor programa."
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Prikaz indikatora brojača prozora."
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Prilagodi prozirnost pozadine ploče."
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Prilagoćavanje prozirnosti"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Prozirnost"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Izgled"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "verzija:"
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr "Pomera ploču iz globalnog prikaza, pretvarajući je u dok"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Napravi"
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "Veb stranica"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -270,67 +311,70 @@ msgstr ""
 "Pogledajte <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
 "\">GNUovu Opštu Javnu licencu, verzija 2 ili kasnija</a>, za detalje.</span>"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr "O programu"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Prikaži dok prelazom miša peko ivice ekrana."
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Samoskrivanje"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "Prikaz pritiskom: zahteva pritisak za prikaz doka"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr ""
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Prikazuje dok kada nije na putu prozorima programa."
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Izbegavanje rozora"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 #, fuzzy
 msgid "All windows"
 msgstr "Izbegavanje rozora"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr ""
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 #, fuzzy
 msgid "Only maximized windows"
 msgstr "minimiuj prozor"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Trajanje(a) animacije"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0,000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Zastoj skrivanja"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Zastoj prikazivanja"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Prag pritiska"
+
+#~ msgid "Do nothing"
+#~ msgstr "ništa"
 
 #~ msgid "Only consider windows of the focused application"
 #~ msgstr "Razmatraj samo prozor fokusiranog programa"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-01 13:17+0200\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2016-07-01 18:37+0200\n"
+"Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
+"Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
-"Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "X-Generator: Poedit 1.8.8\n"
 
 #: prefs.js:98
@@ -25,11 +25,11 @@ msgstr "Primär skärm"
 msgid "Secondary monitor "
 msgstr "Sekundär skärm "
 
-#: prefs.js:139 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "Höger"
 
-#: prefs.js:140 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "Vänster"
 
@@ -37,11 +37,16 @@ msgstr "Vänster"
 msgid "Intelligent autohide customization"
 msgstr "Anpassning av intelligent automatiskt döljande"
 
-#: prefs.js:197
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Återställ till standardvärden"
 
-#: prefs.js:354
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Anpassa indikatorstil"
+
+#: prefs.js:419
 msgid "Customize running indicators"
 msgstr "Anpassa körningsindikatorer"
 
@@ -62,106 +67,6 @@ msgid "Border width"
 msgstr "Kantbredd"
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "Visa dockan på"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "Position på skärmen"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "Nederkant"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "Överkant"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-"Dölj dockan då den är i vägen för ett fönster för det aktuella programmet. "
-"Mer förfinade inställningar finns tillgängliga."
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "Intelligent automatiskt döljande"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "Storleksgräns för docka"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "Panelläge: sträck ut till skärmkanten"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "Storleksgräns för ikoner"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr "Fast ikonstorlek: rulla för att avslöja andra ikoner"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "Position och storlek"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "Visa favoritprogram"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "Visa körande program"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-"Om inaktiverad är dessa inställningar tillgängliga från gnome-tweak-tool "
-"eller webbplatsen för utökningar."
-
-#: Settings.ui.h:21
-msgid "Show <i>Applications</i> icon"
-msgstr "Visa <i>Program</i>-ikon"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Flytta programknappen till början på dockan."
-
-#: Settings.ui.h:23
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animera <i>Visa program</i>."
-
-#: Settings.ui.h:24
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "Beteende då ikonen för ett körande program klickas på."
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr "Klickåtgärd"
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "Gör ingenting"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "Minimera"
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "Starta ny instans"
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "Växla mellan fönster"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
@@ -169,15 +74,142 @@ msgstr ""
 "Då inställd till minimera så minimerar dubbelklick alla fönster för "
 "programmet."
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr "Skift+klick-åtgärd"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Minimera fönster"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "Minimera fönster"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "Starta ny instans"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "Växla mellan fönster"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Klickåtgärd"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Skift+klick-åtgärd"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "Visa dockan på"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "Position på skärmen"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "Nederkant"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "Överkant"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+"Dölj dockan då den är i vägen för ett fönster för det aktuella programmet. "
+"Mer förfinade inställningar finns tillgängliga."
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "Intelligent automatiskt döljande"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "Storleksgräns för docka"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "Panelläge: sträck ut till skärmkanten"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "Storleksgräns för ikoner"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr "Fast ikonstorlek: rulla för att avslöja andra ikoner"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "Position och storlek"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "Visa favoritprogram"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "Visa körande program"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+"Om inaktiverad är dessa inställningar tillgängliga från gnome-tweak-tool "
+"eller webbplatsen för utökningar."
+
 #: Settings.ui.h:33
+msgid "Show <i>Applications</i> icon"
+msgstr "Visa <i>Program</i>-ikon"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr "Flytta programknappen till början på dockan."
+
+#: Settings.ui.h:35
+msgid "Animate <i>Show Applications</i>."
+msgstr "Animera <i>Visa program</i>."
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "Beteende då ikonen för ett körande program klickas på."
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "Klickåtgärd"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "Minimera"
+
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
@@ -185,15 +217,15 @@ msgstr ""
 "Med fast ikonstorlek är endast kanten på dockan och <i>Visa program</i>-"
 "ikonen aktiva."
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Växla arbetsyta genom att rulla på dockan"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Beteende"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
@@ -201,68 +233,68 @@ msgstr ""
 "Några anpassningar för att integrera dockan med GNOME:s standardtema. "
 "Alternativt kan specifika alternativ aktiveras nedan."
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Använd inbyggt tema"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "Spara utrymme genom att minska utfyllnad och kantradie."
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Krymp snabbstartspanelen"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Visa en punkt för varje fönster för programmet."
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Visa fönsterräknarindikatorer"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
 msgid "Set the background color for the dash."
 msgstr "Ställ in bakgrundsfärg för snabbstartspanelen."
 
-#: Settings.ui.h:43
+#: Settings.ui.h:49
 msgid "Customize the dash color"
 msgstr "Anpassa färgen för snabbstartspanelen"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Justera opacitet för bakgrunden till snabbstartspanelen."
 
-#: Settings.ui.h:45
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Anpassa opacitet"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Opacitet"
 
-#: Settings.ui.h:47
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Utseende"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "version: "
 
-#: Settings.ui.h:49
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr ""
 "Flyttar snabbstartspanelen från översiktsvyn och förvandlar den till en docka"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Skapat av"
 
-#: Settings.ui.h:51
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "Webbsida"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -272,62 +304,65 @@ msgstr ""
 "Se <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html\">GNU "
 "General Public License, version 2 eller senare</a> för detaljer.</span>"
 
-#: Settings.ui.h:54
+#: Settings.ui.h:60
 msgid "About"
 msgstr "Om"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Visa dockan genom att hovra musen över skärmkanten."
 
-#: Settings.ui.h:56
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Dölj automatiskt"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "Tryck för att visa: kräv tryck för att visa dockan"
 
-#: Settings.ui.h:58
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr "Aktivera i helskärmsläge"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Visa dockan då den inte är i vägen för programfönster."
 
-#: Settings.ui.h:60
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Undvik fönster"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr "Alla fönster"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr "Endast fokuserade programs fönster"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:69
 msgid "Only maximized windows"
 msgstr "Endast maximerade fönster"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Längd på animering (s)"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Tidsgräns för att dölja (s)"
 
-#: Settings.ui.h:67
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Tidsgräns för att visa (s)"
 
-#: Settings.ui.h:68
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Tröskelvärde för tryck"
+
+#~ msgid "Do nothing"
+#~ msgstr "Gör ingenting"

--- a/po/tr.po
+++ b/po/tr.po
@@ -2,20 +2,20 @@
 # Copyright (C) 2015
 # This file is distributed under the same license with main package.
 # Mustafa Akgün <mustafa.akgun@gmail.com>, 2015.
+# Çağatay Yiğit Şahin <cyigitsahin@outlook.com>, 2016.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-03-19 13:09+0000\n"
-"PO-Revision-Date: 2015-12-24 12:08+0200\n"
-"Last-Translator: Mustafa Akgün <mustafa.akgun@gmail.com>\n"
-"Language-Team: Mustafa Akgün <mustafa.akgun@gmail.com>\n"
+"PO-Revision-Date: 2016-09-04 21:25+0300\n"
+"Last-Translator: Çağatay Yiğit Şahin <cyigitsahin@outlook.com>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.6\n"
+"X-Generator: Gtranslator 2.91.7\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: prefs.js:102
@@ -43,26 +43,24 @@ msgid "Reset to defaults"
 msgstr "Öntanımlı ayarlara geri dön"
 
 #: prefs.js:359
-#, fuzzy
 msgid "Customize running indicators"
 msgstr "Çalışan uygulamaları göster"
 
 #: Settings.ui.h:1
-#, fuzzy
 msgid "Customize indicator style"
-msgstr "Parlaklığı ayarla"
+msgstr "Panel biçemini ayarla"
 
 #: Settings.ui.h:2
 msgid "Color"
-msgstr ""
+msgstr "Renk"
 
 #: Settings.ui.h:3
 msgid "Border color"
-msgstr ""
+msgstr "Çerçeve rengi"
 
 #: Settings.ui.h:4
 msgid "Border width"
-msgstr ""
+msgstr "Çerçeve genişliği"
 
 #: Settings.ui.h:5
 msgid "Show the dock on"
@@ -137,7 +135,6 @@ msgid "Move the applications button at the beginning of the dock."
 msgstr "Uygulamalar düğmesini panelin başlangıcına taşı "
 
 #: Settings.ui.h:23
-#, fuzzy
 msgid "Animate <i>Show Applications</i>."
 msgstr "<i>Uygulamaları Göster</i> simgesini göster"
 
@@ -151,7 +148,7 @@ msgstr "Hareket için tıkla"
 
 #: Settings.ui.h:26
 msgid "Do nothing"
-msgstr "Hiç birşey yapma"
+msgstr "Hiçbir şey yapma"
 
 #: Settings.ui.h:27
 msgid "Minimize"
@@ -182,28 +179,28 @@ msgid "Minimize window"
 msgstr "Pencereyi küçült"
 
 #: Settings.ui.h:33
-#, fuzzy
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
-msgstr "Eğer simgeler taşmışsa, sadece kullanılan <i>Uygulamayı göster</i> "
+msgstr ""
+"Simge boyutu sabitlenmişse, sadece panelin kenarları ve <i>Uygulamaları "
+"Göster</i> simgesi etkindir."
 
 #: Settings.ui.h:34
 msgid "Switch workspace by scrolling on the dock"
-msgstr "Panel üzerinde kaydırma çalışma alanını değiştirme"
+msgstr "Panel üzerinde kaydırarak çalışma alanını değiştir"
 
 #: Settings.ui.h:35
 msgid "Behavior"
 msgstr "Davranış"
 
 #: Settings.ui.h:36
-#, fuzzy
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
 msgstr ""
-"Gnome varsayılan tema ile birkaç özelleştirme gelmektedir . Ek olarak diğer "
-"seçenekleri, aşağıda bazı ayarlar ile özelleştirebilirsiniz."
+"Varsayılan GNOME temasıyla bütünleşme için birkaç kişiselleştirme. Tercihen, "
+"belirli ayarlar aşağıdan etkinleştirilebilir"
 
 #: Settings.ui.h:37
 msgid "Use built-in theme"
@@ -227,15 +224,15 @@ msgstr "Pencere sayacını göster"
 
 #: Settings.ui.h:42
 msgid "Tune the dash background opacity."
-msgstr "Panel arkaplanının parlaklığını ayarla"
+msgstr "Panel arkaplanının saydamlığını ayarla"
 
 #: Settings.ui.h:43
 msgid "Customize opacity"
-msgstr "Parlaklığı ayarla"
+msgstr "Saydamlığı ayarla"
 
 #: Settings.ui.h:44
 msgid "Opacity"
-msgstr "Parlaklık"
+msgstr "Saydamlık"
 
 #: Settings.ui.h:45
 msgid "Appearance"
@@ -247,7 +244,7 @@ msgstr "Sürüm: "
 
 #: Settings.ui.h:47
 msgid "Moves the dash out of the overview transforming it in a dock"
-msgstr "Panele genel dönüşümünü taşır"
+msgstr "Paneli genel görünümden ana ekrana taşır"
 
 #: Settings.ui.h:48
 msgid "Created by"
@@ -255,7 +252,7 @@ msgstr "Tarafından oluşturulmuştur:"
 
 #: Settings.ui.h:49
 msgid "Webpage"
-msgstr "Web sitesi"
+msgstr "Web sayfası"
 
 #: Settings.ui.h:50
 msgid ""
@@ -286,7 +283,7 @@ msgstr "Göstermek için it: Panelin gösterilmesi icin etki gerektirir."
 
 #: Settings.ui.h:56
 msgid "Enable in fullscreen mode"
-msgstr ""
+msgstr "Tam ekran modunda etkinleştir"
 
 #: Settings.ui.h:57
 msgid "Show the dock when it doesn't obstruct application windows."
@@ -309,9 +306,8 @@ msgid "Only maximized windows"
 msgstr "Sadece büyütülen pencereler"
 
 #: Settings.ui.h:62
-#, fuzzy
 msgid "Animation duration (s)"
-msgstr "Canlandırma süresi(s)"
+msgstr "Animasyon süresi(s)"
 
 #: Settings.ui.h:63
 msgid "0.000"

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2016-09-04 21:25+0300\n"
 "Last-Translator: Çağatay Yiğit Şahin <cyigitsahin@outlook.com>\n"
 "Language: tr\n"
@@ -18,31 +18,36 @@ msgstr ""
 "X-Generator: Gtranslator 2.91.7\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "Ana Ekran"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "İkincil Ekran"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "Sağ"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "Sol"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "Akıllı otomatik saklama ayarları"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "Öntanımlı ayarlara geri dön"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "Panel biçemini ayarla"
+
+#: prefs.js:419
 msgid "Customize running indicators"
 msgstr "Çalışan uygulamaları göster"
 
@@ -63,106 +68,6 @@ msgid "Border width"
 msgstr "Çerçeve genişliği"
 
 #: Settings.ui.h:5
-msgid "Show the dock on"
-msgstr "Panelde göster"
-
-#: Settings.ui.h:6
-msgid "Position on screen"
-msgstr "Ekrandaki konumu"
-
-#: Settings.ui.h:8
-msgid "Bottom"
-msgstr "Alt"
-
-#: Settings.ui.h:9
-msgid "Top"
-msgstr "Üst"
-
-#: Settings.ui.h:11
-msgid ""
-"Hide the dock when it obstructs a window of the the current application. "
-"More refined settings are available."
-msgstr ""
-"Etkin uygulamanın penceresini engellediğinde paneli gizle. Daha ileri "
-"ayarlar mevcuttur."
-
-#: Settings.ui.h:12
-msgid "Intelligent autohide"
-msgstr "Akıllı otogizleme"
-
-#: Settings.ui.h:13
-msgid "Dock size limit"
-msgstr "Panel ölçü sınırı"
-
-#: Settings.ui.h:14
-msgid "Panel mode: extend to the screen edge"
-msgstr "Panel modu: Ekran köşelerine genişlet"
-
-#: Settings.ui.h:15
-msgid "Icon size limit"
-msgstr "Simge ölçü sınırı"
-
-#: Settings.ui.h:16
-msgid "Fixed icon size: scroll to reveal other icons"
-msgstr "Sabit simge ölçüsü: Diğer simgeleri görmek için kaydır"
-
-#: Settings.ui.h:17
-msgid "Position and size"
-msgstr "Konum ve ölçü"
-
-#: Settings.ui.h:18
-msgid "Show favorite applications"
-msgstr "Kullanılan uygulamaları göster"
-
-#: Settings.ui.h:19
-msgid "Show running applications"
-msgstr "Çalışan uygulamaları göster"
-
-#: Settings.ui.h:20
-msgid ""
-"If disabled, these settings are acccessible from gnome-tweak-tool or the "
-"extension website."
-msgstr ""
-"Eğer engellenmiş ise, bu ayarlara Gnome-tweak-tool ile  veya Gnome extension "
-"sitesinden ulaşılabilir."
-
-#: Settings.ui.h:21
-msgid "Show <i>Show Applications</i> icon"
-msgstr "<i>Uygulamaları Göster</i> simgesini göster"
-
-#: Settings.ui.h:22
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Uygulamalar düğmesini panelin başlangıcına taşı "
-
-#: Settings.ui.h:23
-msgid "Animate <i>Show Applications</i>."
-msgstr "<i>Uygulamaları Göster</i> simgesini göster"
-
-#: Settings.ui.h:24
-msgid "Behaviour when clicking on the icon of a running application."
-msgstr "Çalışan uygulama simgesine tıkladığındaki davranış"
-
-#: Settings.ui.h:25
-msgid "Click action"
-msgstr "Hareket için tıkla"
-
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "Hiçbir şey yapma"
-
-#: Settings.ui.h:27
-msgid "Minimize"
-msgstr "Küçült"
-
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "Yeni durumu başlat"
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "Penceler döngüsü"
-
-#: Settings.ui.h:30
 msgid ""
 "When set to minimize, double clicking minimizes all the windows of the "
 "application."
@@ -170,15 +75,143 @@ msgstr ""
 "En küçüğe ayarlandığında, tüm uygulama pencerelerini küçültmek için çift "
 "tıklayın."
 
-#: Settings.ui.h:31
+#: Settings.ui.h:6
 msgid "Shift+Click action"
 msgstr "Shift+Tıkla hareketi"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "Pencereyi küçült"
+
+#: Settings.ui.h:8
 msgid "Minimize window"
 msgstr "Pencereyi küçült"
 
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "Yeni durumu başlat"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "Penceler döngüsü"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "Hareket için tıkla"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Shift+Tıkla hareketi"
+
+#: Settings.ui.h:16
+msgid "Show the dock on"
+msgstr "Panelde göster"
+
+#: Settings.ui.h:17
+msgid "Position on screen"
+msgstr "Ekrandaki konumu"
+
+#: Settings.ui.h:19
+msgid "Bottom"
+msgstr "Alt"
+
+#: Settings.ui.h:20
+msgid "Top"
+msgstr "Üst"
+
+#: Settings.ui.h:22
+msgid ""
+"Hide the dock when it obstructs a window of the the current application. "
+"More refined settings are available."
+msgstr ""
+"Etkin uygulamanın penceresini engellediğinde paneli gizle. Daha ileri "
+"ayarlar mevcuttur."
+
+#: Settings.ui.h:23
+msgid "Intelligent autohide"
+msgstr "Akıllı otogizleme"
+
+#: Settings.ui.h:24
+msgid "Dock size limit"
+msgstr "Panel ölçü sınırı"
+
+#: Settings.ui.h:25
+msgid "Panel mode: extend to the screen edge"
+msgstr "Panel modu: Ekran köşelerine genişlet"
+
+#: Settings.ui.h:26
+msgid "Icon size limit"
+msgstr "Simge ölçü sınırı"
+
+#: Settings.ui.h:27
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr "Sabit simge ölçüsü: Diğer simgeleri görmek için kaydır"
+
+#: Settings.ui.h:28
+msgid "Position and size"
+msgstr "Konum ve ölçü"
+
+#: Settings.ui.h:29
+msgid "Show favorite applications"
+msgstr "Kullanılan uygulamaları göster"
+
+#: Settings.ui.h:30
+msgid "Show running applications"
+msgstr "Çalışan uygulamaları göster"
+
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
+msgid ""
+"If disabled, these settings are acccessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+"Eğer engellenmiş ise, bu ayarlara Gnome-tweak-tool ile  veya Gnome extension "
+"sitesinden ulaşılabilir."
+
 #: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
+msgstr "<i>Uygulamaları Göster</i> simgesini göster"
+
+#: Settings.ui.h:34
+msgid "Move the applications button at the beginning of the dock."
+msgstr "Uygulamalar düğmesini panelin başlangıcına taşı "
+
+#: Settings.ui.h:35
+msgid "Animate <i>Show Applications</i>."
+msgstr "<i>Uygulamaları Göster</i> simgesini göster"
+
+#: Settings.ui.h:36
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "Çalışan uygulama simgesine tıkladığındaki davranış"
+
+#: Settings.ui.h:37
+msgid "Click action"
+msgstr "Hareket için tıkla"
+
+#: Settings.ui.h:38
+msgid "Minimize"
+msgstr "Küçült"
+
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
@@ -186,15 +219,15 @@ msgstr ""
 "Simge boyutu sabitlenmişse, sadece panelin kenarları ve <i>Uygulamaları "
 "Göster</i> simgesi etkindir."
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "Panel üzerinde kaydırarak çalışma alanını değiştir"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "Davranış"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
@@ -202,59 +235,67 @@ msgstr ""
 "Varsayılan GNOME temasıyla bütünleşme için birkaç kişiselleştirme. Tercihen, "
 "belirli ayarlar aşağıdan etkinleştirilebilir"
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "Varsayılan temayı kullan"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "Yer kazanmak için dolguyu ve kenar çevresini azalt."
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "Paneli daralt"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "Uygulamanın her penceresi için bir nokta göster"
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "Pencere sayacını göster"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "Panel arkaplanının saydamlığını ayarla"
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "Saydamlığı ayarla"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "Saydamlık"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "Görünüm"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "Sürüm: "
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr "Paneli genel görünümden ana ekrana taşır"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "Tarafından oluşturulmuştur:"
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "Web sayfası"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -265,65 +306,68 @@ msgstr ""
 "licenses/gpl-2.0.html\">GNU Genel Halk Lisansı, sürüm 2 veya üstü</a> "
 "tıklayın</span>"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr "Hakkında"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Fare Ekran köşeleri üzerinde iken paneli göster. "
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "Otogizleme"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "Göstermek için it: Panelin gösterilmesi icin etki gerektirir."
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr "Tam ekran modunda etkinleştir"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Uygulama penceresini engellemediğinde paneli göster."
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "Pencereleri atlat"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr "Bütün pencereler"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr "Sadece odaklanan uygulamanın pencereleri"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 msgid "Only maximized windows"
 msgstr "Sadece büyütülen pencereler"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "Animasyon süresi(s)"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "Gecikme zaman aşımı(s)"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "Zaman aşımını göster(s)"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "Etki eşiği"
+
+#~ msgid "Do nothing"
+#~ msgstr "Hiçbir şey yapma"
 
 #~ msgid "Only consider windows of the focused application"
 #~ msgstr "Sadece açık olan uygulama penceresini dikkate al"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-09 23:29+0100\n"
-"PO-Revision-Date: 2016-05-25 22:35+0800\n"
+"PO-Revision-Date: 2016-10-02 23:45+0800\n"
 "Last-Translator: 绿色圣光 <lishaohui.qd@163.com>\n"
 "Language-Team: Chinese (Simplified) <>\n"
 "Language: zh_CN\n"
@@ -44,9 +44,8 @@ msgid "Reset to defaults"
 msgstr "重置为默认值"
 
 #: prefs.js:346
-#, fuzzy
 msgid "Customize middle-click behavior"
-msgstr "自定义指示器样式"
+msgstr "自定义中键点击行为"
 
 #: prefs.js:419
 msgid "Customize running indicators"
@@ -79,9 +78,8 @@ msgid "Shift+Click action"
 msgstr "Shift+点击动作"
 
 #: Settings.ui.h:7
-#, fuzzy
 msgid "Raise window"
-msgstr "最小化窗口"
+msgstr "提升窗口"
 
 #: Settings.ui.h:8
 msgid "Minimize window"
@@ -97,25 +95,23 @@ msgstr "在窗口间循环"
 
 #: Settings.ui.h:11
 msgid "Quit"
-msgstr ""
+msgstr "退出"
 
 #: Settings.ui.h:12
 msgid "Behavior for Middle-Click."
-msgstr ""
+msgstr "中键点击的行为。"
 
 #: Settings.ui.h:13
-#, fuzzy
 msgid "Middle-Click action"
-msgstr "点击动作"
+msgstr "中键点击动作"
 
 #: Settings.ui.h:14
 msgid "Behavior for Shift+Middle-Click."
-msgstr ""
+msgstr "Shift+中键点击的行为"
 
 #: Settings.ui.h:15
-#, fuzzy
 msgid "Shift+Middle-Click action"
-msgstr "Shift+点击动作"
+msgstr "Shift+中键点击动作"
 
 #: Settings.ui.h:16
 msgid "Show the dock on"
@@ -175,7 +171,7 @@ msgstr "显示正在运行的应用程序"
 
 #: Settings.ui.h:31
 msgid "Isolate workspaces."
-msgstr ""
+msgstr "隔离工作区。"
 
 #: Settings.ui.h:32
 msgid ""
@@ -184,9 +180,8 @@ msgid ""
 msgstr "禁用之后，可以通过 gnome-tweak-tool 或者扩展网站来访问设置。"
 
 #: Settings.ui.h:33
-#, fuzzy
 msgid "Show <i>Applications</i> icon"
-msgstr "显示“<i>显示应用程序</i>”图标"
+msgstr "显示“<i>应用程序</i>”图标"
 
 #: Settings.ui.h:34
 msgid "Move the applications button at the beginning of the dock."
@@ -253,11 +248,11 @@ msgstr "显示窗口个数指示器"
 
 #: Settings.ui.h:48
 msgid "Set the background color for the dash."
-msgstr ""
+msgstr "设置 dash 的背景颜色。"
 
 #: Settings.ui.h:49
 msgid "Customize the dash color"
-msgstr ""
+msgstr "自定义 dash 颜色"
 
 #: Settings.ui.h:50
 msgid "Tune the dash background opacity."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-19 13:09+0000\n"
+"POT-Creation-Date: 2016-09-09 23:29+0100\n"
 "PO-Revision-Date: 2016-05-25 22:35+0800\n"
 "Last-Translator: 绿色圣光 <lishaohui.qd@163.com>\n"
 "Language-Team: Chinese (Simplified) <>\n"
@@ -19,31 +19,36 @@ msgstr ""
 "X-Generator: Gtranslator 2.91.7\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: prefs.js:102
+#: prefs.js:98
 msgid "Primary monitor"
 msgstr "主显示器"
 
-#: prefs.js:111 prefs.js:118
+#: prefs.js:107 prefs.js:114
 msgid "Secondary monitor "
 msgstr "副显示器"
 
-#: prefs.js:143 Settings.ui.h:10
+#: prefs.js:139 Settings.ui.h:21
 msgid "Right"
 msgstr "右侧"
 
-#: prefs.js:144 Settings.ui.h:7
+#: prefs.js:140 Settings.ui.h:18
 msgid "Left"
 msgstr "左侧"
 
-#: prefs.js:194
+#: prefs.js:190
 msgid "Intelligent autohide customization"
 msgstr "智能自动隐藏自定义"
 
-#: prefs.js:201
+#: prefs.js:197 prefs.js:353
 msgid "Reset to defaults"
 msgstr "重置为默认值"
 
-#: prefs.js:359
+#: prefs.js:346
+#, fuzzy
+msgid "Customize middle-click behavior"
+msgstr "自定义指示器样式"
+
+#: prefs.js:419
 msgid "Customize running indicators"
 msgstr "自定义“运行中”指示器"
 
@@ -64,22 +69,71 @@ msgid "Border width"
 msgstr "边框宽度"
 
 #: Settings.ui.h:5
+msgid ""
+"When set to minimize, double clicking minimizes all the windows of the "
+"application."
+msgstr "当设置为最小化时，双击会最小化应用程序的所有窗口。"
+
+#: Settings.ui.h:6
+msgid "Shift+Click action"
+msgstr "Shift+点击动作"
+
+#: Settings.ui.h:7
+#, fuzzy
+msgid "Raise window"
+msgstr "最小化窗口"
+
+#: Settings.ui.h:8
+msgid "Minimize window"
+msgstr "最小化窗口"
+
+#: Settings.ui.h:9
+msgid "Launch new instance"
+msgstr "启动新实例"
+
+#: Settings.ui.h:10
+msgid "Cycle through windows"
+msgstr "在窗口间循环"
+
+#: Settings.ui.h:11
+msgid "Quit"
+msgstr ""
+
+#: Settings.ui.h:12
+msgid "Behavior for Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:13
+#, fuzzy
+msgid "Middle-Click action"
+msgstr "点击动作"
+
+#: Settings.ui.h:14
+msgid "Behavior for Shift+Middle-Click."
+msgstr ""
+
+#: Settings.ui.h:15
+#, fuzzy
+msgid "Shift+Middle-Click action"
+msgstr "Shift+点击动作"
+
+#: Settings.ui.h:16
 msgid "Show the dock on"
 msgstr "显示 dock 于"
 
-#: Settings.ui.h:6
+#: Settings.ui.h:17
 msgid "Position on screen"
 msgstr "屏幕中的位置"
 
-#: Settings.ui.h:8
+#: Settings.ui.h:19
 msgid "Bottom"
 msgstr "底部"
 
-#: Settings.ui.h:9
+#: Settings.ui.h:20
 msgid "Top"
 msgstr "顶部"
 
-#: Settings.ui.h:11
+#: Settings.ui.h:22
 msgid ""
 "Hide the dock when it obstructs a window of the the current application. "
 "More refined settings are available."
@@ -87,110 +141,89 @@ msgstr ""
 "当 dock 会挡住当前应用程序的某个窗口时，将其隐藏。点击右侧设置按钮可以设置更"
 "多细节。"
 
-#: Settings.ui.h:12
+#: Settings.ui.h:23
 msgid "Intelligent autohide"
 msgstr "智能隐藏"
 
-#: Settings.ui.h:13
+#: Settings.ui.h:24
 msgid "Dock size limit"
 msgstr "Dock 大小限制"
 
-#: Settings.ui.h:14
+#: Settings.ui.h:25
 msgid "Panel mode: extend to the screen edge"
 msgstr "面板模式：延伸到屏幕边缘"
 
-#: Settings.ui.h:15
+#: Settings.ui.h:26
 msgid "Icon size limit"
 msgstr "图标大小限制"
 
-#: Settings.ui.h:16
+#: Settings.ui.h:27
 msgid "Fixed icon size: scroll to reveal other icons"
 msgstr "固定图标大小：滚动显示其它图标"
 
-#: Settings.ui.h:17
+#: Settings.ui.h:28
 msgid "Position and size"
 msgstr "位置和大小"
 
-#: Settings.ui.h:18
+#: Settings.ui.h:29
 msgid "Show favorite applications"
 msgstr "显示收藏的应用程序"
 
-#: Settings.ui.h:19
+#: Settings.ui.h:30
 msgid "Show running applications"
 msgstr "显示正在运行的应用程序"
 
-#: Settings.ui.h:20
+#: Settings.ui.h:31
+msgid "Isolate workspaces."
+msgstr ""
+
+#: Settings.ui.h:32
 msgid ""
 "If disabled, these settings are acccessible from gnome-tweak-tool or the "
 "extension website."
 msgstr "禁用之后，可以通过 gnome-tweak-tool 或者扩展网站来访问设置。"
 
-#: Settings.ui.h:21
-msgid "Show <i>Show Applications</i> icon"
+#: Settings.ui.h:33
+#, fuzzy
+msgid "Show <i>Applications</i> icon"
 msgstr "显示“<i>显示应用程序</i>”图标"
 
-#: Settings.ui.h:22
+#: Settings.ui.h:34
 msgid "Move the applications button at the beginning of the dock."
 msgstr "将应用程序按钮移至 dock 的起始位置。"
 
-#: Settings.ui.h:23
+#: Settings.ui.h:35
 msgid "Animate <i>Show Applications</i>."
 msgstr "动画“<i>显示应用程序</i>”。"
 
-#: Settings.ui.h:24
+#: Settings.ui.h:36
 msgid "Behaviour when clicking on the icon of a running application."
 msgstr "点击一个正在运行的应用程序图标时的行为。"
 
-#: Settings.ui.h:25
+#: Settings.ui.h:37
 msgid "Click action"
 msgstr "点击动作"
 
-#: Settings.ui.h:26
-msgid "Do nothing"
-msgstr "无动作"
-
-#: Settings.ui.h:27
+#: Settings.ui.h:38
 msgid "Minimize"
 msgstr "最小化"
 
-#: Settings.ui.h:28
-msgid "Launch new instance"
-msgstr "启动新实例"
-
-#: Settings.ui.h:29
-msgid "Cycle through windows"
-msgstr "在窗口间循环"
-
-#: Settings.ui.h:30
-msgid ""
-"When set to minimize, double clicking minimizes all the windows of the "
-"application."
-msgstr "当设置为最小化时，双击会最小化应用程序的所有窗口。"
-
-#: Settings.ui.h:31
-msgid "Shift+Click action"
-msgstr "Shift+点击动作"
-
-#: Settings.ui.h:32
-msgid "Minimize window"
-msgstr "最小化窗口"
-
-#: Settings.ui.h:33
+#: Settings.ui.h:39
 msgid ""
 "With fixed icon size, only the edge of the dock and the <i>Show "
 "Applications</i> icon are active."
 msgstr ""
 "如果固定了图标大小，只有 dock 边缘和“<i>显示应用程序</i>”图标会激活该功能。"
 
-#: Settings.ui.h:34
+#: Settings.ui.h:40
 msgid "Switch workspace by scrolling on the dock"
 msgstr "通过滚动 dock 来切换工作区"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:41
 msgid "Behavior"
 msgstr "行为"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:42
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
@@ -198,59 +231,67 @@ msgstr ""
 "几个自定义项可以将 dock 整合到默认 GNOME 主题中。或者，也可以启动下面的几个特"
 "殊选项。"
 
-#: Settings.ui.h:37
+#: Settings.ui.h:43
 msgid "Use built-in theme"
 msgstr "使用内置主题"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:44
 msgid "Save space reducing padding and border radius."
 msgstr "减小填充和边框半径以节省空间。"
 
-#: Settings.ui.h:39
+#: Settings.ui.h:45
 msgid "Shrink the dash"
 msgstr "收缩 dash"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:46
 msgid "Show a dot for each windows of the application."
 msgstr "为应用程序的每个窗口显示一个点。"
 
-#: Settings.ui.h:41
+#: Settings.ui.h:47
 msgid "Show windows counter indicators"
 msgstr "显示窗口个数指示器"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:48
+msgid "Set the background color for the dash."
+msgstr ""
+
+#: Settings.ui.h:49
+msgid "Customize the dash color"
+msgstr ""
+
+#: Settings.ui.h:50
 msgid "Tune the dash background opacity."
 msgstr "调整 dash 的背景透明度。"
 
-#: Settings.ui.h:43
+#: Settings.ui.h:51
 msgid "Customize opacity"
 msgstr "自定义透明度"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:52
 msgid "Opacity"
 msgstr "不透明度"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:53
 msgid "Appearance"
 msgstr "外观"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:54
 msgid "version: "
 msgstr "版本："
 
-#: Settings.ui.h:47
+#: Settings.ui.h:55
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr "让 dash 跳出概览之外，转化为一个 dock"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:56
 msgid "Created by"
 msgstr "作者："
 
-#: Settings.ui.h:49
+#: Settings.ui.h:57
 msgid "Webpage"
 msgstr "网站主页"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:58
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -260,65 +301,68 @@ msgstr ""
 "参见 <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html\">GNU "
 "通用公共许可证，第二版或更高版本</a>以了解更多细节。</span>"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:60
 msgid "About"
 msgstr "关于"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:61
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "鼠标移至屏幕边缘时显示 dock"
 
-#: Settings.ui.h:54
+#: Settings.ui.h:62
 msgid "Autohide"
 msgstr "自动隐藏"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:63
 msgid "Push to show: require pressure to show the dock"
 msgstr "推压以显示：需要一定压力来显示 dock"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:64
 msgid "Enable in fullscreen mode"
 msgstr "在全屏模式下启用"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:65
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "在不妨碍应用程序窗口时，显示 dock。"
 
-#: Settings.ui.h:58
+#: Settings.ui.h:66
 msgid "Dodge windows"
 msgstr "避开窗口"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:67
 msgid "All windows"
 msgstr "所有窗口"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:68
 msgid "Only focused application's windows"
 msgstr "仅焦点程序窗口"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:69
 msgid "Only maximized windows"
 msgstr "仅最大化窗口"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:70
 msgid "Animation duration (s)"
 msgstr "动画持续时间（秒）"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:71
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:72
 msgid "Hide timeout (s)"
 msgstr "隐藏超时时间（秒）"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:73
 msgid "Show timeout (s)"
 msgstr "显示超时时间（秒）"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:74
 msgid "Pressure threshold"
 msgstr "压力阈值"
+
+#~ msgid "Do nothing"
+#~ msgstr "无动作"
 
 #~ msgid "Main Settings"
 #~ msgstr "主设置"

--- a/prefs.js
+++ b/prefs.js
@@ -299,6 +299,10 @@ const Settings = new Lang.Class({
                             this._builder.get_object('application_button_isolation_button'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-windows-preview',
+                            this._builder.get_object('windows_preview_button'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-favorites',
                             this._builder.get_object('show_favorite_switch'),
                             'active',

--- a/prefs.js
+++ b/prefs.js
@@ -266,7 +266,7 @@ const Settings = new Lang.Class({
         this._builder.get_object('dock_size_scale').set_value(this._settings.get_double('height-fraction'));
         this._builder.get_object('dock_size_scale').add_mark(0.9, Gtk.PositionType.TOP, null);
         let icon_size_scale = this._builder.get_object('icon_size_scale');
-        icon_size_scale.set_range(DEFAULT_ICONS_SIZES[DEFAULT_ICONS_SIZES.length -1], DEFAULT_ICONS_SIZES[0]);
+        icon_size_scale.set_range(8, DEFAULT_ICONS_SIZES[0]);
         icon_size_scale.set_value(this._settings.get_int('dash-max-icon-size'));
         DEFAULT_ICONS_SIZES.forEach(function(val) {
              icon_size_scale.add_mark(val, Gtk.PositionType.TOP, val.toString());

--- a/prefs.js
+++ b/prefs.js
@@ -337,6 +337,11 @@ const Settings = new Lang.Class({
             this._settings.set_enum('click-action', widget.get_active());
         }));
 
+        this._builder.get_object('scroll_action_combo').set_active(this._settings.get_enum('scroll-action'));
+        this._builder.get_object('scroll_action_combo').connect('changed', Lang.bind (this, function(widget) {
+            this._settings.set_enum('scroll-action', widget.get_active());
+        }));
+
         this._builder.get_object('shift_click_action_combo').connect('changed', Lang.bind (this, function(widget) {
             this._settings.set_enum('shift-click-action', widget.get_active());
         }));
@@ -403,8 +408,6 @@ const Settings = new Lang.Class({
             dialog.show_all();
 
         }));
-
-        this._settings.bind('scroll-switch-workspace', this._builder.get_object('switch_workspace_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
 
         // Appearance Panel
 

--- a/prefs.js
+++ b/prefs.js
@@ -303,6 +303,10 @@ const Settings = new Lang.Class({
                             this._builder.get_object('windows_preview_button'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('hot-keys',
+                            this._builder.get_object('hot_keys_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-favorites',
                             this._builder.get_object('show_favorite_switch'),
                             'active',

--- a/prefs.js
+++ b/prefs.js
@@ -307,6 +307,14 @@ const Settings = new Lang.Class({
                             this._builder.get_object('hot_keys_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('hotkeys-show-dock',
+                            this._builder.get_object('hotkeys_show_dock'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('hot-keys',
+                            this._builder.get_object('hotkeys_show_dock'),
+                            'sensitive',
+                            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-favorites',
                             this._builder.get_object('show_favorite_switch'),
                             'active',

--- a/prefs.js
+++ b/prefs.js
@@ -289,7 +289,7 @@ const Settings = new Lang.Class({
         this._settings.bind('extend-height', this._builder.get_object('dock_size_scale'), 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN);
 
 
-        // Behavior panel
+        // Apps panel
 
         this._settings.bind('show-running',
                             this._builder.get_object('show_running_switch'),
@@ -302,18 +302,6 @@ const Settings = new Lang.Class({
         this._settings.bind('show-windows-preview',
                             this._builder.get_object('windows_preview_button'),
                             'active',
-                            Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('hot-keys',
-                            this._builder.get_object('hot_keys_switch'),
-                            'active',
-                            Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('hotkeys-show-dock',
-                            this._builder.get_object('hotkeys_show_dock'),
-                            'active',
-                            Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('hot-keys',
-                            this._builder.get_object('hotkeys_show_dock'),
-                            'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-favorites',
                             this._builder.get_object('show_favorite_switch'),
@@ -337,6 +325,22 @@ const Settings = new Lang.Class({
                             Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-show-apps-button',
                             this._builder.get_object('application_button_animation_button'),
+                            'sensitive',
+                            Gio.SettingsBindFlags.DEFAULT);
+
+
+        // Behavior panel
+
+        this._settings.bind('hot-keys',
+                            this._builder.get_object('hot_keys_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('hotkeys-show-dock',
+                            this._builder.get_object('hotkeys_show_dock'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('hot-keys',
+                            this._builder.get_object('hotkeys_show_dock'),
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
 

--- a/prefs.js
+++ b/prefs.js
@@ -335,12 +335,8 @@ const Settings = new Lang.Class({
                             this._builder.get_object('hot_keys_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('hotkeys-show-dock',
-                            this._builder.get_object('hotkeys_show_dock'),
-                            'active',
-                            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('hot-keys',
-                            this._builder.get_object('hotkeys_show_dock'),
+                            this._builder.get_object('overlay_button'),
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
 
@@ -363,6 +359,60 @@ const Settings = new Lang.Class({
         }));
         this._builder.get_object('shift_middle_click_action_combo').connect('changed', Lang.bind (this, function(widget) {
             this._settings.set_enum('shift-middle-click-action', widget.get_active());
+        }));
+
+        // Create dialog for number overlay options
+        this._builder.get_object('overlay_button').connect('clicked', Lang.bind(this, function() {
+
+            let dialog = new Gtk.Dialog({ title: _('Show dock and application numbers'),
+                                          transient_for: this.widget.get_toplevel(),
+                                          use_header_bar: true,
+                                          modal: true });
+
+            // GTK+ leaves positive values for application-defined response ids.
+            // Use +1 for the reset action
+            dialog.add_button(_('Reset to defaults'), 1);
+
+            let box = this._builder.get_object('box_overlay_shortcut');
+            dialog.get_content_area().add(box);
+
+            this._builder.get_object('overlay_switch').set_active(this._settings.get_boolean('hotkeys-overlay'));
+            this._builder.get_object('show_dock_switch').set_active(this._settings.get_boolean('hotkeys-show-dock'));
+
+            this._settings.bind('shortcut-text',
+                                this._builder.get_object('shortcut_entry'),
+                                'text',
+                                Gio.SettingsBindFlags.DEFAULT);
+            this._settings.bind('hotkeys-overlay',
+                                this._builder.get_object('overlay_switch'),
+                                'active',
+                                Gio.SettingsBindFlags.DEFAULT);
+            this._settings.bind('hotkeys-show-dock',
+                                this._builder.get_object('show_dock_switch'),
+                                'active',
+                                Gio.SettingsBindFlags.DEFAULT);
+            this._settings.bind('shortcut-timeout',
+                                this._builder.get_object('timeout_spinbutton'),
+                                'value',
+                                Gio.SettingsBindFlags.DEFAULT);
+
+            dialog.connect('response', Lang.bind(this, function(dialog, id) {
+                if (id == 1) {
+                    // restore default settings for the relevant keys
+                    let keys = ['shortcut-text', 'hotkeys-overlay', 'hotkeys-show-dock', 'shortcut-timeout'];
+                    keys.forEach(function(val) {
+                        this._settings.set_value(val, this._settings.get_default_value(val));
+                    }, this);
+                } else {
+                    // remove the settings box so it doesn't get destroyed;
+                    dialog.get_content_area().remove(box);
+                    dialog.destroy();
+                }
+                return;
+            }));
+
+            dialog.show_all();
+
         }));
 
         // Create dialog for middle-click options

--- a/prefs.js
+++ b/prefs.js
@@ -496,6 +496,10 @@ const Settings = new Lang.Class({
         this._builder.get_object('custom_opacity_scale').set_value(this._settings.get_double('background-opacity'));
         this._settings.bind('opaque-background', this._builder.get_object('custom_opacity'), 'sensitive', Gio.SettingsBindFlags.DEFAULT);
 
+        this._settings.bind('force-straight-corner',
+            this._builder.get_object('force_straight_corner_switch'),
+            'active', Gio.SettingsBindFlags.DEFAULT);
+
         // About Panel
 
         this._builder.get_object('extension_version').set_label(Me.metadata.version.toString());

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -247,6 +247,18 @@
       <summary>Super Hot-Keys</summary>
       <description>Launch and switch between dash items using Super+(0-9)</description>
     </key>
+    <key type="b" name="hotkeys-show-dock">
+      <default>true</default>
+      <summary>Show the dock when using the hotkeys</summary>
+      <description>The dock will be quickly shown so that the number-overlay is visible and app activation is easier</description>
+    </key>
+    <key name="number-overlay-key" type="as">
+      <default><![CDATA[['<Super>z']]]></default>
+      <summary>Keybinding to launch 1st dash app</summary>
+      <description>
+        Keybinding to launch 1st app.
+      </description>
+    </key>
     <key name="app-ctrl-hotkey-1" type="as">
       <default><![CDATA[['<Ctrl><Super>1']]]></default>
       <summary>Keybinding to launch 1st dash app</summary>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -5,6 +5,7 @@
     <value value='1' nick='minimize'/>
     <value value='2' nick='launch'/>
     <value value='3' nick='cycle-windows'/>
+    <value value='4' nick='quit'/>
   </enum>
   <!-- this is mean to Match StSide. LEFT and RIGHT actual position in reversed in
        rtl languages -->
@@ -210,6 +211,21 @@
       <default>'cycle-windows'</default>
       <summary>Action when clicking on a running app</summary>
       <description>Set the action that is executed when clicking on the icon of a running application</description>
+    </key>
+    <key name="shift-click-action" enum="org.gnome.shell.extensions.dash-to-dock.clickAction">
+      <default>'minimize'</default>
+      <summary>Action when shit+clicking on a running app</summary>
+      <description>Set the action that is executed when shift+clicking on the icon of a running application</description>
+    </key>
+    <key name="middle-click-action" enum="org.gnome.shell.extensions.dash-to-dock.clickAction">
+      <default>'launch'</default>
+      <summary>Action when clicking on a running app</summary>
+      <description>Set the action that is executed when middle-clicking on the icon of a running application</description>
+    </key>
+    <key name="shift-middle-click-action" enum="org.gnome.shell.extensions.dash-to-dock.clickAction">
+      <default>'launch'</default>
+      <summary>Action when clicking on a running app</summary>
+      <description>Set the action that is executed when shift+middle-clicking on the icon of a running application</description>
     </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -657,5 +657,10 @@
         Keybinding to either show or launch the 10th application in the dash.
       </description>
     </key>
+    <key name="force-straight-corner" type="b">
+      <default>false</default>
+      <summary>Force straight corners in dash</summary>
+      <description>Make the borders in the dash non rounded</description>
+    </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -156,6 +156,11 @@
       <summary>Provide workspace isolation</summary>
       <description>Dash shows only windows from the currentworkspace</description>
     </key>
+    <key type="b" name="show-windows-preview">
+      <default>true</default>
+      <summary>Show preview of the open windows</summary>
+      <description>Replace open windows list with windows previews</description>
+    </key>
     <key type="b" name="show-favorites">
       <default>true</default>
       <summary>Show favorites apps</summary>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -7,6 +7,11 @@
     <value value='3' nick='cycle-windows'/>
     <value value='4' nick='quit'/>
   </enum>
+  <enum id='org.gnome.shell.extensions.dash-to-dock.scrollAction'>
+    <value value='0' nick='do-nothing'/>
+    <value value='1' nick='cycle-windows'/>
+    <value value='2' nick='switch-workspace'/>
+  </enum>
   <!-- this is mean to Match StSide. LEFT and RIGHT actual position in reversed in
        rtl languages -->
   <enum id='org.gnome.shell.extensions.dash-to-dock.position'>
@@ -216,6 +221,11 @@
       <default>'cycle-windows'</default>
       <summary>Action when clicking on a running app</summary>
       <description>Set the action that is executed when clicking on the icon of a running application</description>
+    </key>
+    <key name="scroll-action" enum="org.gnome.shell.extensions.dash-to-dock.scrollAction">
+      <default>'do-nothing'</default>
+      <summary>Action when scrolling app</summary>
+      <description>Set the action that is executed when scrolling on the application icon</description>
     </key>
     <key name="shift-click-action" enum="org.gnome.shell.extensions.dash-to-dock.clickAction">
       <default>'minimize'</default>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -232,5 +232,430 @@
       <summary>Action when clicking on a running app</summary>
       <description>Set the action that is executed when shift+middle-clicking on the icon of a running application</description>
     </key>
+    <key type="b" name="hot-keys">
+      <default>true</default>
+      <summary>Super Hot-Keys</summary>
+      <description>Launch and switch between dash items using Super+(0-9)</description>
+    </key>
+    <key name="app-ctrl-hotkey-1" type="as">
+      <default><![CDATA[['<Ctrl><Super>1']]]></default>
+      <summary>Keybinding to launch 1st dash app</summary>
+      <description>
+        Keybinding to launch 1st app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-2" type="as">
+      <default><![CDATA[['<Ctrl><Super>2']]]></default>
+      <summary>Keybinding to launch 2nd dash app</summary>
+      <description>
+        Keybinding to launch 2nd app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-3" type="as">
+      <default><![CDATA[['<Ctrl><Super>3']]]></default>
+      <summary>Keybinding to launch 3rd dash app</summary>
+      <description>
+        Keybinding to launch 3rd app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-4" type="as">
+      <default><![CDATA[['<Ctrl><Super>4']]]></default>
+      <summary>Keybinding to launch 4th dash app</summary>
+      <description>
+        Keybinding to launch 4th app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-5" type="as">
+      <default><![CDATA[['<Ctrl><Super>5']]]></default>
+      <summary>Keybinding to launch 5th dash app</summary>
+      <description>
+        Keybinding to launch 5th app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-6" type="as">
+      <default><![CDATA[['<Ctrl><Super>6']]]></default>
+      <summary>Keybinding to launch 6th dash app</summary>
+      <description>
+        Keybinding to launch 6th app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-7" type="as">
+      <default><![CDATA[['<Ctrl><Super>7']]]></default>
+      <summary>Keybinding to launch 7th dash app</summary>
+      <description>
+        Keybinding to launch 7th app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-8" type="as">
+      <default><![CDATA[['<Ctrl><Super>8']]]></default>
+      <summary>Keybinding to launch 8th dash app</summary>
+      <description>
+        Keybinding to launch 8th app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-9" type="as">
+      <default><![CDATA[['<Ctrl><Super>9']]]></default>
+      <summary>Keybinding to launch 9th dash app</summary>
+      <description>
+        Keybinding to launch 9th app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-10" type="as">
+      <default><![CDATA[['<Ctrl><Super>0']]]></default>
+      <summary>Keybinding to launch 10th dash app</summary>
+      <description>
+        Keybinding to launch 10th app.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-1" type="as">
+      <default><![CDATA[['<Shift><Super>1']]]></default>
+      <summary>Keybinding to trigger 1st dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 1st app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-2" type="as">
+      <default><![CDATA[['<Shift><Super>2']]]></default>
+      <summary>Keybinding to trigger 2nd dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 2nd app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-3" type="as">
+      <default><![CDATA[['<Shift><Super>3']]]></default>
+      <summary>Keybinding to trigger 3rd dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 3rd app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-4" type="as">
+      <default><![CDATA[['<Shift><Super>4']]]></default>
+      <summary>Keybinding to trigger 4th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 4th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-5" type="as">
+      <default><![CDATA[['<Shift><Super>5']]]></default>
+      <summary>Keybinding to trigger 5th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 5th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-6" type="as">
+      <default><![CDATA[['<Shift><Super>6']]]></default>
+      <summary>Keybinding to trigger 6th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 6th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-7" type="as">
+      <default><![CDATA[['<Shift><Super>7']]]></default>
+      <summary>Keybinding to trigger 7th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 7th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-8" type="as">
+      <default><![CDATA[['<Shift><Super>8']]]></default>
+      <summary>Keybinding to trigger 8th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 8th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-9" type="as">
+      <default><![CDATA[['<Shift><Super>9']]]></default>
+      <summary>Keybinding to trigger 9th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 9th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-10" type="as">
+      <default><![CDATA[['<Shift><Super>0']]]></default>
+      <summary>Keybinding to trigger 10th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 10th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-hotkey-1" type="as">
+      <default><![CDATA[['<Super>1']]]></default>
+      <summary>Keybinding to trigger 1st dash app</summary>
+      <description>
+        Keybinding to either show or launch the 1st application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-2" type="as">
+      <default><![CDATA[['<Super>2']]]></default>
+      <summary>Keybinding to trigger 2nd dash app</summary>
+      <description>
+        Keybinding to either show or launch the 2nd application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-3" type="as">
+      <default><![CDATA[['<Super>3']]]></default>
+      <summary>Keybinding to trigger 3rd dash app</summary>
+      <description>
+        Keybinding to either show or launch the 3rd application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-4" type="as">
+      <default><![CDATA[['<Super>4']]]></default>
+      <summary>Keybinding to trigger 4th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 4th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-5" type="as">
+      <default><![CDATA[['<Super>5']]]></default>
+      <summary>Keybinding to trigger 5th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 5th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-6" type="as">
+      <default><![CDATA[['<Super>6']]]></default>
+      <summary>Keybinding to trigger 6th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 6th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-7" type="as">
+      <default><![CDATA[['<Super>7']]]></default>
+      <summary>Keybinding to trigger 7th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 7th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-8" type="as">
+      <default><![CDATA[['<Super>8']]]></default>
+      <summary>Keybinding to trigger 8th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 8th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-9" type="as">
+      <default><![CDATA[['<Super>9']]]></default>
+      <summary>Keybinding to trigger 9th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 9th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-10" type="as">
+      <default><![CDATA[['<Super>0']]]></default>
+      <summary>Keybinding to trigger 10th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 10th application in the dash.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-kp-1" type="as">
+      <default><![CDATA[['<Ctrl><Super>KP_1']]]></default>
+      <summary>Keybinding to launch 1st dash app</summary>
+      <description>
+        Keybinding to launch 1st app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-kp-2" type="as">
+      <default><![CDATA[['<Ctrl><Super>KP_2']]]></default>
+      <summary>Keybinding to launch 2nd dash app</summary>
+      <description>
+        Keybinding to launch 2nd app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-kp-3" type="as">
+      <default><![CDATA[['<Ctrl><Super>KP_3']]]></default>
+      <summary>Keybinding to launch 3rd dash app</summary>
+      <description>
+        Keybinding to launch 3rd app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-kp-4" type="as">
+      <default><![CDATA[['<Ctrl><Super>KP_4']]]></default>
+      <summary>Keybinding to launch 4th dash app</summary>
+      <description>
+        Keybinding to launch 4th app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-kp-5" type="as">
+      <default><![CDATA[['<Ctrl><Super>KP_5']]]></default>
+      <summary>Keybinding to launch 5th dash app</summary>
+      <description>
+        Keybinding to launch 5th app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-kp-6" type="as">
+      <default><![CDATA[['<Ctrl><Super>KP_6']]]></default>
+      <summary>Keybinding to launch 6th dash app</summary>
+      <description>
+        Keybinding to launch 6th app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-kp-7" type="as">
+      <default><![CDATA[['<Ctrl><Super>KP_7']]]></default>
+      <summary>Keybinding to launch 7th dash app</summary>
+      <description>
+        Keybinding to launch 7th app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-kp-8" type="as">
+      <default><![CDATA[['<Ctrl><Super>KP_8']]]></default>
+      <summary>Keybinding to launch 8th dash app</summary>
+      <description>
+        Keybinding to launch 8th app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-kp-9" type="as">
+      <default><![CDATA[['<Ctrl><Super>KP_9']]]></default>
+      <summary>Keybinding to launch 9th dash app</summary>
+      <description>
+        Keybinding to launch 9th app.
+      </description>
+    </key>
+    <key name="app-ctrl-hotkey-kp-10" type="as">
+      <default><![CDATA[['<Ctrl><Super>KP_0']]]></default>
+      <summary>Keybinding to launch 10th dash app</summary>
+      <description>
+        Keybinding to launch 10th app.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-kp-1" type="as">
+      <default><![CDATA[['<Shift><Super>KP_1']]]></default>
+      <summary>Keybinding to trigger 1st dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 1st app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-kp-2" type="as">
+      <default><![CDATA[['<Shift><Super>KP_2']]]></default>
+      <summary>Keybinding to trigger 2nd dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 2nd app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-kp-3" type="as">
+      <default><![CDATA[['<Shift><Super>KP_3']]]></default>
+      <summary>Keybinding to trigger 3rd dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 3rd app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-kp-4" type="as">
+      <default><![CDATA[['<Shift><Super>KP_4']]]></default>
+      <summary>Keybinding to trigger 4th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 4th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-kp-5" type="as">
+      <default><![CDATA[['<Shift><Super>KP_5']]]></default>
+      <summary>Keybinding to trigger 5th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 5th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-kp-6" type="as">
+      <default><![CDATA[['<Shift><Super>KP_6']]]></default>
+      <summary>Keybinding to trigger 6th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 6th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-kp-7" type="as">
+      <default><![CDATA[['<Shift><Super>KP_7']]]></default>
+      <summary>Keybinding to trigger 7th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 7th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-kp-8" type="as">
+      <default><![CDATA[['<Shift><Super>KP_8']]]></default>
+      <summary>Keybinding to trigger 8th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 8th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-kp-9" type="as">
+      <default><![CDATA[['<Shift><Super>KP_9']]]></default>
+      <summary>Keybinding to trigger 9th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 9th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-shift-hotkey-kp-10" type="as">
+      <default><![CDATA[['<Shift><Super>KP_0']]]></default>
+      <summary>Keybinding to trigger 10th dash app with shift behavior</summary>
+      <description>
+        Keybinding to trigger 10th app with shift behavior.
+      </description>
+    </key>
+    <key name="app-hotkey-kp-1" type="as">
+      <default><![CDATA[['<Super>KP_1']]]></default>
+      <summary>Keybinding to trigger 1st dash app</summary>
+      <description>
+        Keybinding to either show or launch the 1st application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-kp-2" type="as">
+      <default><![CDATA[['<Super>KP_2']]]></default>
+      <summary>Keybinding to trigger 2nd dash app</summary>
+      <description>
+        Keybinding to either show or launch the 2nd application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-kp-3" type="as">
+      <default><![CDATA[['<Super>KP_3']]]></default>
+      <summary>Keybinding to trigger 3rd dash app</summary>
+      <description>
+        Keybinding to either show or launch the 3rd application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-kp-4" type="as">
+      <default><![CDATA[['<Super>KP_4']]]></default>
+      <summary>Keybinding to trigger 4th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 4th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-kp-5" type="as">
+      <default><![CDATA[['<Super>KP_5']]]></default>
+      <summary>Keybinding to trigger 5th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 5th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-kp-6" type="as">
+      <default><![CDATA[['<Super>KP_6']]]></default>
+      <summary>Keybinding to trigger 6th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 6th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-kp-7" type="as">
+      <default><![CDATA[['<Super>KP_7']]]></default>
+      <summary>Keybinding to trigger 7th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 7th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-kp-8" type="as">
+      <default><![CDATA[['<Super>KP_8']]]></default>
+      <summary>Keybinding to trigger 8th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 8th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-kp-9" type="as">
+      <default><![CDATA[['<Super>KP_9']]]></default>
+      <summary>Keybinding to trigger 9th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 9th application in the dash.
+      </description>
+    </key>
+    <key name="app-hotkey-kp-10" type="as">
+      <default><![CDATA[['<Super>KP_0']]]></default>
+      <summary>Keybinding to trigger 10th dash app</summary>
+      <description>
+        Keybinding to either show or launch the 10th application in the dash.
+      </description>
+    </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -252,12 +252,25 @@
       <summary>Show the dock when using the hotkeys</summary>
       <description>The dock will be quickly shown so that the number-overlay is visible and app activation is easier</description>
     </key>
-    <key name="number-overlay-key" type="as">
-      <default><![CDATA[['<Super>z']]]></default>
-      <summary>Keybinding to launch 1st dash app</summary>
-      <description>
-        Keybinding to launch 1st app.
-      </description>
+    <key type="s" name="shortcut-text">
+      <default>"&lt;Super&gt;q"</default>
+      <summary>Keybinding to show the dock and the number overlay.</summary>
+      <description>Behavior depends on hotkeys-show-dock and hotkeys-overlay.</description>
+    </key>
+    <key type="as" name="shortcut">
+      <default><![CDATA[['<Super>q']]]></default>
+      <summary>Keybinding to show the dock and the number overlay.</summary>
+      <description>Behavior depends on hotkeys-show-dock and hotkeys-overlay.</description>
+    </key>
+    <key type="d" name="shortcut-timeout">
+      <default>2</default>
+      <summary>Timeout to hide the dock</summary>
+      <description>Sets the time duration before the dock is hidden again.</description>
+    </key>
+    <key type="b" name="hotkeys-overlay">
+      <default>true</default>
+      <summary>Show the dock when using the hotkeys</summary>
+      <description>The dock will be quickly shown so that the number-overlay is visible and app activation is easier</description>
     </key>
     <key name="app-ctrl-hotkey-1" type="as">
       <default><![CDATA[['<Ctrl><Super>1']]]></default>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -11,11 +11,13 @@
     border-radius: 0px 9px 9px 0px;
 }
 
+
 #dashtodockContainer.shrink.right #dash,
 #dashtodockContainer.dashtodock.right #dash {
     border-right: 0px;
     border-radius: 9px 0px 0px 9px;
 }
+
 
 #dashtodockContainer.shrink.top #dash,
 #dashtodockContainer.dashtodock.top #dash {
@@ -27,6 +29,11 @@
 #dashtodockContainer.dashtodock.bottom #dash {
     border-bottom: 0px;
     border-radius: 9px 9px 0px 0px;
+}
+
+#dashtodockContainer.straight-corner #dash,
+#dashtodockContainer.shrink.straight-corner #dash {
+    border-radius: 0px;
 }
 
 /* Scrollview style */

--- a/theming.js
+++ b/theming.js
@@ -60,6 +60,10 @@ const ThemeManager = new Lang.Class({
 
         this._updateCustomStyleClasses();
 
+        // destroy themeManager when the managed actor is destroyed (e.g. extension unload)
+        // in order to disconnect signals
+        this._actor.connect('destroy', Lang.bind(this, this.destroy));
+
     },
 
     destroy: function() {

--- a/theming.js
+++ b/theming.js
@@ -171,6 +171,16 @@ const ThemeManager = new Lang.Class({
             this._actor.add_style_class_name('running-dots');
         else
             this._actor.remove_style_class_name('running-dots');
+
+        // If not the built-in theme option is not selected
+        if (!this._settings.get_boolean('apply-custom-theme')) {
+            if (this._settings.get_boolean('force-straight-corner'))
+                this._actor.add_style_class_name('straight-corner');
+            else 
+                this._actor.remove_style_class_name('straight-corner');
+        } else {
+            this._actor.remove_style_class_name('straight-corner');
+        }
     },
 
     updateCustomTheme: function() {
@@ -265,7 +275,8 @@ const ThemeManager = new Lang.Class({
                     'apply-custom-theme',
                     'custom-theme-shrink',
                     'custom-theme-running-dots',
-                    'extend-height'];
+                    'extend-height',
+                    'force-straight-corner'];
 
         keys.forEach(function(key) {
             this._settings.connect('changed::' + key, Lang.bind(this, this.updateCustomTheme));

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -1,10 +1,13 @@
 const Clutter = imports.gi.Clutter;
+const GLib = imports.gi.GLib;
 const Lang = imports.lang;
 const St = imports.gi.St;
+const Mainloop = imports.mainloop;
 
 const Params = imports.misc.params;
 const PopupMenu = imports.ui.popupMenu;
 const Tweener = imports.ui.tweener;
+const Workspace = imports.ui.workspace;
 
 const PREVIEW_MAX_WIDTH = 250;
 const PREVIEW_MAX_HEIGHT = 150;
@@ -15,11 +18,31 @@ const WindowPreviewMenuItem = new Lang.Class({
     _init: function(window, params) {
         this._window = window;
         this._destroyId = 0;
+        this._windowAddedId = 0;
         params = Params.parse(params, { style_class: 'app-well-preview-menu-item' });
         this.parent(params);
 
         this._cloneBin = new St.Bin();
         this._cloneBin.set_size(PREVIEW_MAX_WIDTH, PREVIEW_MAX_HEIGHT);
+
+        // TODO: improve the way the closebutton is layout. Just use some padding
+        // for the moment.
+        this._cloneBin.set_style('padding: 5px');
+
+        this.closeButton = new St.Button({ style_class: 'window-close',
+                                          x_expand: true,
+                                          y_expand: true});
+        this.closeButton.set_x_align(Clutter.ActorAlign.END);
+        this.closeButton.set_y_align(Clutter.ActorAlign.START);
+
+
+        this.closeButton.opacity = 0;
+        this.closeButton.connect('clicked', Lang.bind(this, this._closeWindow));
+
+        let overlayGroup = new Clutter.Actor({layout_manager: new Clutter.BinLayout() });
+
+        overlayGroup.add_actor(this._cloneBin);
+        overlayGroup.add_actor(this.closeButton);
 
         let label = new St.Label({ text: window.get_title()});
         label.set_style('max-width: '+PREVIEW_MAX_WIDTH +'px');
@@ -29,9 +52,18 @@ const WindowPreviewMenuItem = new Lang.Class({
         let box = new St.BoxLayout({ vertical: true,
                                      reactive:true,
                                      x_expand:true });
-        box.add(this._cloneBin);
+        box.add(overlayGroup);
         box.add(labelBin);
         this.actor.add_actor(box);
+
+        this.actor.connect('enter-event',
+                                  Lang.bind(this, this._onEnter));
+        this.actor.connect('leave-event',
+                                  Lang.bind(this, this._onLeave));
+        this.actor.connect('key-focus-in',
+                                  Lang.bind(this, this._onEnter));
+        this.actor.connect('key-focus-out',
+                                  Lang.bind(this, this._onLeave));
 
         this._cloneTexture(window);
 
@@ -65,6 +97,105 @@ const WindowPreviewMenuItem = new Lang.Class({
         this._cloneBin.set_child(this._clone);
     },
 
+    _windowCanClose: function() {
+        return this._window.can_close() &&
+               !this._hasAttachedDialogs();
+    },
+
+    _closeWindow: function(actor) {
+        this._workspace = this._window.get_workspace();
+
+        // This mechanism is copied from the workspace.js upstream code
+        // It forces window activation if the windows don't get closed,
+        // for instance because asking user confirmation, by monitoring the opening of
+        // such additional confirmation window
+        this._windowAddedId = this._workspace.connect('window-added',
+                                                      Lang.bind(this,
+                                                                this._onWindowAdded));
+
+        this.deleteAllWindows();
+    },
+
+    deleteAllWindows: function() {
+        // Delete all windows, starting from the bottom-most (most-modal) one
+        //let windows = this._window.get_compositor_private().get_children();
+        let windows = this._clone.get_children();
+        for (let i = windows.length - 1; i >= 1; i--) {
+            let realWindow = windows[i].source;
+            let metaWindow = realWindow.meta_window;
+
+            metaWindow.delete(global.get_current_time());
+        }
+
+        this._window.delete(global.get_current_time());
+    },
+
+    _onWindowAdded: function(workspace, win) {
+        let metaWindow = this._window;
+
+        if (win.get_transient_for() == metaWindow) {
+            workspace.disconnect(this._windowAddedId);
+            this._windowAddedId = 0;
+
+            // use an idle handler to avoid mapping problems -
+            // see comment in Workspace._windowAdded
+            let id = Mainloop.idle_add(Lang.bind(this,
+                                            function() {
+                                                this.emit('activate');
+                                                return GLib.SOURCE_REMOVE;
+                                            }));
+            GLib.Source.set_name_by_id(id, '[dash-to-dock] this.emit');
+        }
+    },
+
+    _hasAttachedDialogs: function() {
+        // count trasient windows
+        let n=0;
+        this._window.foreach_transient(function(){n++;});
+        return n>0;
+    },
+
+    _onEnter: function() {
+        this._showCloseButton();
+        return Clutter.EVENT_PROPAGATE;
+    },
+
+    _onLeave: function() {
+        if (!this._cloneBin.has_pointer &&
+            !this.closeButton.has_pointer)
+            this._hideCloseButton();
+
+        return Clutter.EVENT_PROPAGATE;
+    },
+
+    _idleToggleCloseButton: function() {
+        this._idleToggleCloseId = 0;
+
+        if (!this._cloneBin.has_pointer &&
+            !this.closeButton.has_pointer)
+            this._hideCloseButton();
+
+        return GLib.SOURCE_REMOVE;
+    },
+
+    _showCloseButton: function() {
+
+        if (this._windowCanClose()) {
+            this.closeButton.show();
+            Tweener.addTween(this.closeButton,
+                             { opacity: 255,
+                               time: Workspace.CLOSE_BUTTON_FADE_TIME,
+                               transition: 'easeOutQuad' });
+        }
+    },
+
+    _hideCloseButton: function() {
+        Tweener.addTween(this.closeButton,
+                         { opacity: 0,
+                           time: Workspace.CLOSE_BUTTON_FADE_TIME,
+                           transition: 'easeInQuad' });
+    },
+
     _animateOutAndDestroy: function() {
         Tweener.addTween(this.actor,
                          { opacity: 0,
@@ -85,6 +216,11 @@ const WindowPreviewMenuItem = new Lang.Class({
     _onDestroy: function() {
 
         this.parent();
+
+        if (this._windowAddedId > 0) {
+            this._workspace.disconnect(this._windowAddedId);
+            this._windowAddedId = 0;
+        }
 
         if (this._destroyId > 0)
             this._mutterWindow.disconnect(this._destroyId);

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -1,0 +1,59 @@
+const Clutter = imports.gi.Clutter;
+const Lang = imports.lang;
+const St = imports.gi.St;
+
+const Params = imports.misc.params;
+const PopupMenu = imports.ui.popupMenu;
+const Tweener = imports.ui.tweener;
+
+const PREVIEW_MAX_WIDTH = 250;
+const PREVIEW_MAX_HEIGHT = 150;
+const WindowPreviewMenuItem = new Lang.Class({
+    Name: 'WindowPreviewMenuItem',
+    Extends: PopupMenu.PopupBaseMenuItem,
+
+    _init: function(window, params) {
+        this._window = window;
+        params = Params.parse(params, { style_class: 'app-well-preview-menu-item' });
+        this.parent(params);
+
+        this._cloneBin = new St.Bin();
+        this._cloneBin.set_size(PREVIEW_MAX_WIDTH, PREVIEW_MAX_HEIGHT);
+
+        let label = new St.Label({ text: window.get_title()});
+        label.set_style('max-width: '+PREVIEW_MAX_WIDTH +'px');
+        let labelBin = new St.Bin({ child: label,
+                                    x_align: St.Align.MIDDLE});
+
+        let box = new St.BoxLayout({ vertical: true,
+                                     reactive:true,
+                                     x_expand:true });
+        box.add(this._cloneBin);
+        box.add(labelBin);
+        this.actor.add_actor(box);
+
+        this._cloneTexture(window);
+
+    },
+
+    _cloneTexture: function(metaWin){
+
+        let mutterWindow = metaWin.get_compositor_private();
+
+        let windowTexture = mutterWindow.get_texture();
+        let [width, height] = windowTexture.get_size();
+
+        let scale = Math.min(1.0, PREVIEW_MAX_WIDTH/width, PREVIEW_MAX_HEIGHT/height);
+
+        let clone = new Clutter.Clone ({ source: windowTexture,
+                                         reactive: true,
+                                         width: width * scale,
+                                         height: height * scale });
+
+        this._clone = clone;
+        this._mutterWindow = mutterWindow;
+        this._cloneBin.set_child(this._clone);
+    }
+
+});
+

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -73,6 +73,22 @@ const WindowPreviewMenuItem = new Lang.Class({
 
         let mutterWindow = metaWin.get_compositor_private();
 
+        // Newly-created windows are added to a workspace before
+        // the compositor finds out about them...
+        // Moreover sometimes they return an empty texture, thus as a workarounf also check for it size
+        if (!mutterWindow || !mutterWindow.get_texture() || !mutterWindow.get_texture().get_size()[0]) {
+            let id = Mainloop.idle_add(Lang.bind(this,
+                                            function () {
+                                                // Check if there's still a point in getting the texture,
+                                                // otherwise this could go on indefinitely
+                                                if (this.actor && metaWin.get_workspace())
+                                                    this._cloneTexture(metaWin);
+                                                return GLib.SOURCE_REMOVE;
+                                            }));
+            GLib.Source.set_name_by_id(id, '[dash-to-dock] this._cloneTexture');
+            return;
+        }
+
         let windowTexture = mutterWindow.get_texture();
         let [width, height] = windowTexture.get_size();
 


### PR DESCRIPTION
Hi, 
Is there any possibility to add an option like in "Workspaces-to-Dock" extension, which requires, if enabled, to click over the area where the Dock should appear if a window is maximized?

I imagine that it shouldn't be so hard to implement, but I have no skills in programming to do it or suggest some code to do it.

Regards.