### PR TITLE
Show Apps button at top by default

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -177,7 +177,7 @@
       <description>Show appplications button in the dash</description>
     </key>
     <key type="b" name="show-apps-at-top">
-      <default>false</default>
+      <default>true</default>
       <summary>Show application button at top</summary>
       <description>Show appplication button at top of the dash</description>
     </key>


### PR DESCRIPTION
Reasons for this change
--------------------------
1. Since the Activities button (or Applications button if you enabled *that* extension) is at the top left, it makes sense for the Apps button to be at the top left closest to it.
2. Since Unity is being discontinued (or at least no longer Ubuntu's flagship desktop), maybe it's a good idea to provide a default that's more similar to what Unity had.

Reasons against this change
------------------------------------
1. The current default has been here a long time.
2. The current default is more similar to Windows.

Other Info
-------------
Similar reasoning for extend-height to be enabled by default?
These are 2 of the 4 changes suggested by the Debian maintainer @highvoltage in https://github.com/micheleg/dash-to-dock/issues/385