### PR TITLE
Offer minimize or overview click action

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1721,6 +1721,7 @@
                                   <item translatable="yes">Minimize</item>
                                   <item translatable="yes">Launch new instance</item>
                                   <item translatable="yes">Cycle through windows</item>
+                                  <item translatable="yes">Minimize or overview</item>
                                 </items>
                               </object>
                             </child>

--- a/appIcons.js
+++ b/appIcons.js
@@ -35,7 +35,8 @@ const clickAction = {
     MINIMIZE: 1,
     LAUNCH: 2,
     CYCLE_WINDOWS: 3,
-    QUIT: 4
+    MINIMIZE_OR_OVERVIEW: 4,
+    QUIT: 5
 };
 
 const scrollAction = {
@@ -399,6 +400,29 @@ const MyAppIcon = new Lang.Class({
                 }
                 else
                     this.app.activate();
+                break;
+
+            case clickAction.MINIMIZE_OR_OVERVIEW:
+                let windows = getInterestingWindows(this.app, this._dtdSettings);
+                let nbWindows = windows.length;
+                // When a single window is present, toggle minimization
+                if (windows && nbWindows && nbWindows <= 1) {
+                  let w = windows[0];
+                  if (this.app == focusedApp) {
+                    // Window is raised, minimize it
+                    minimizeWindow(this.app, w, this._dtdSettings);
+                  } else {
+                    // Window is minimized, raise it
+                    Main.activateWindow(w);
+                  }
+                // Launch overview when multiple windows are present
+                // TODO: only show current app windows when gnome shell API will allow it
+                } else {
+                  Main.overview.toggle();
+                  // calling toggle() without another function afterwards fails for me
+                  // adding a log entry as a workaround
+                  console.log('toggled overview');
+                }
                 break;
 
             case clickAction.CYCLE_WINDOWS:

--- a/appIcons.js
+++ b/appIcons.js
@@ -377,6 +377,10 @@ const MyAppIcon = new Lang.Class({
         let appIsRunning = this.app.state == Shell.AppState.RUNNING
             && getInterestingWindows(this.app, this._dtdSettings).length > 0
 
+        // Some action modes (e.g. MINIMIZE_OR_OVERVIEW) require overview to remain open
+        // This variable keeps track of this
+        let shouldHideOverview = true;
+
         // We customize the action only when the application is already running
         if (appIsRunning) {
             switch (buttonAction) {
@@ -418,10 +422,8 @@ const MyAppIcon = new Lang.Class({
                 // Launch overview when multiple windows are present
                 // TODO: only show current app windows when gnome shell API will allow it
                 } else {
+                  shouldHideOverview = false;
                   Main.overview.toggle();
-                  // calling toggle() without another function afterwards fails for me
-                  // adding a log entry as a workaround
-                  console.log('toggled overview');
                 }
                 break;
 
@@ -457,7 +459,10 @@ const MyAppIcon = new Lang.Class({
             this.launchNewWindow();
         }
 
-        Main.overview.hide();
+        // Hide overview except when action mode requires it
+        if(shouldHideOverview) {
+          Main.overview.hide();
+        }
     },
 
     // Try to do the right thing when attempting to launch a new window of an app. In

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,15 +7,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Dash to Dock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-28 13:30-0400\n"
-"PO-Revision-Date: 2015-09-10 19:41+0100\n"
+"POT-Creation-Date: 2017-04-17 10:07+0200\n"
+"PO-Revision-Date: 2017-04-17 10:31+0200\n"
 "Last-Translator: Thomas GONET <th.gonet@gmail.com>\n"
 "Language-Team: Jean-Baptiste Le Cz <jb.lecoz@gmail.com>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.6.10\n"
+"X-Generator: Poedit 1.8.7.1\n"
 
 #: prefs.js:98
 msgid "Primary monitor"
@@ -78,8 +78,8 @@ msgid ""
 "Temporarily show the application numbers over the icons, corresponding to "
 "the shortcut."
 msgstr ""
-"Afficher temporairement les numéros d'application sur les icônes, correspondant"
-"au raccourci clavier."
+"Afficher temporairement les numéros d'application sur les icônes, "
+"correspondantau raccourci clavier."
 
 #: Settings.ui.h:7
 msgid "Show the dock if it is hidden"
@@ -90,8 +90,8 @@ msgid ""
 "If using autohide, the dock will appear for a short time when triggering the "
 "shortcut."
 msgstr ""
-"Si le masquage automatique est actif, le dock apparaîtra temporairement "
-"lors de l'utilisation du raccourci."
+"Si le masquage automatique est actif, le dock apparaîtra temporairement lors "
+"de l'utilisation du raccourci."
 
 #: Settings.ui.h:9
 msgid "Shortcut for the options above"
@@ -247,8 +247,8 @@ msgid ""
 "Enable Super+(0-9) as shortcuts to activate apps. It can also be used "
 "together with Shift and Ctrl."
 msgstr ""
-"Activer Super+(0-9) comme raccourcis pour activer les applications. On "
-"peut l'utiliser aussi avec Shift et Ctrl."
+"Activer Super+(0-9) comme raccourcis pour activer les applications. On peut "
+"l'utiliser aussi avec Shift et Ctrl."
 
 #: Settings.ui.h:46
 msgid "Use keyboard shortcuts to activate apps"
@@ -267,26 +267,30 @@ msgid "Minimize"
 msgstr "Minimiser la fenêtre"
 
 #: Settings.ui.h:50
+msgid "Minimize or overview"
+msgstr "Minimiser ou lancer l'exposé"
+
+#: Settings.ui.h:51
 msgid "Behaviour when scrolling on the icon of an application."
 msgstr "Comportement lors du défilement sur l'icône d'une application."
 
-#: Settings.ui.h:51
+#: Settings.ui.h:52
 msgid "Scroll action"
 msgstr "Action du défilement"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:53
 msgid "Do nothing"
 msgstr "Ne rien faire"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:54
 msgid "Switch workspace"
 msgstr "Changer d'espace de travail"
 
-#: Settings.ui.h:54
+#: Settings.ui.h:55
 msgid "Behavior"
 msgstr "Comportement"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:56
 msgid ""
 "Few customizations meant to integrate the dock with the default GNOME theme. "
 "Alternatively, specific options can be enabled below."
@@ -294,71 +298,71 @@ msgstr ""
 "Assortir le dock avec le thème par défaut. Sinon, vous pouvez personnaliser "
 "quelques paramètres ci-dessous."
 
-#: Settings.ui.h:56
+#: Settings.ui.h:57
 msgid "Use built-in theme"
 msgstr "Utiliser le thème par défaut"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:58
 msgid "Save space reducing padding and border radius."
 msgstr "Réduire la taille des marges pour gagner de la place."
 
-#: Settings.ui.h:58
+#: Settings.ui.h:59
 msgid "Shrink the dash"
 msgstr "Réduire les marges"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:60
 msgid "Show a dot for each windows of the application."
 msgstr "Afficher un point pour chaque fenêtre ouverte de l'application."
 
-#: Settings.ui.h:60
+#: Settings.ui.h:61
 msgid "Show windows counter indicators"
 msgstr "Afficher un compteur de fenêtres"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:62
 msgid "Set the background color for the dash."
 msgstr "Choisir la couleur de fond du dock."
 
-#: Settings.ui.h:62
+#: Settings.ui.h:63
 msgid "Customize the dash color"
 msgstr "Changer la couleur du dock"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:64
 msgid "Tune the dash background opacity."
 msgstr "Régler l'opacité en fond du dock."
 
-#: Settings.ui.h:64
+#: Settings.ui.h:65
 msgid "Customize opacity"
 msgstr "Régler l'opacité du dock"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:66
 msgid "Opacity"
 msgstr "Opacité"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:67
 msgid "Force straight corner\n"
 msgstr "Forcer des coins droits\n"
 
-#: Settings.ui.h:68
+#: Settings.ui.h:69
 msgid "Appearance"
 msgstr "Apparence"
 
-#: Settings.ui.h:69
+#: Settings.ui.h:70
 msgid "version: "
 msgstr "Version: "
 
-#: Settings.ui.h:70
+#: Settings.ui.h:71
 msgid "Moves the dash out of the overview transforming it in a dock"
 msgstr "Place le dash hors de l'aperçu des fenêtres, le transformant en dock"
 
-#: Settings.ui.h:71
+#: Settings.ui.h:72
 msgid "Created by"
 msgstr "Conçu par"
 
-#: Settings.ui.h:72
+#: Settings.ui.h:73
 msgid "Webpage"
 msgstr "Site web"
 
-#: Settings.ui.h:73
+#: Settings.ui.h:74
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -369,59 +373,58 @@ msgstr ""
 "\">Licence Générale Publique GNU version 2 ou plus récente</a> pour plus "
 "d'informations.</span>"
 
-#: Settings.ui.h:75
+#: Settings.ui.h:76
 msgid "About"
 msgstr "À propos"
 
-#: Settings.ui.h:76
+#: Settings.ui.h:77
 msgid "Show the dock by mouse hover on the screen edge."
 msgstr "Afficher le dock en survolant le bord de l'écran."
 
-#: Settings.ui.h:77
+#: Settings.ui.h:78
 msgid "Autohide"
 msgstr "Masquage automatique"
 
-#: Settings.ui.h:78
+#: Settings.ui.h:79
 msgid "Push to show: require pressure to show the dock"
 msgstr "Pousser pour Afficher: requiert une pression pour afficher le dock"
 
-#: Settings.ui.h:79
+#: Settings.ui.h:80
 msgid "Enable in fullscreen mode"
 msgstr "Activer en mode plein-écran"
 
-#: Settings.ui.h:80
+#: Settings.ui.h:81
 msgid "Show the dock when it doesn't obstruct application windows."
 msgstr "Afficher le dock quand il ne gêne pas les fenêtres."
 
-#: Settings.ui.h:81
+#: Settings.ui.h:82
 msgid "Dodge windows"
 msgstr "Masquage automatique intelligent"
 
-#: Settings.ui.h:82
+#: Settings.ui.h:83
 msgid "All windows"
 msgstr "Toutes les fenêtres"
 
-#: Settings.ui.h:83
+#: Settings.ui.h:84
 msgid "Only focused application's windows"
 msgstr "Seulement la fenêtre de l'application active"
 
-#: Settings.ui.h:84
+#: Settings.ui.h:85
 msgid "Only maximized windows"
 msgstr "Seulement les fenêtres maximisées"
 
-#: Settings.ui.h:85
+#: Settings.ui.h:86
 msgid "Animation duration (s)"
 msgstr "Durée de l'animation (s)"
 
-#: Settings.ui.h:86
+#: Settings.ui.h:87
 msgid "0.000"
 msgstr "0.000"
 
-#: Settings.ui.h:87
+#: Settings.ui.h:88
 msgid "Show timeout (s)"
 msgstr "Délai d'apparition (s)"
 
-#: Settings.ui.h:88
+#: Settings.ui.h:89
 msgid "Pressure threshold"
 msgstr "Seuil de pression"
-

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -5,7 +5,8 @@
     <value value='1' nick='minimize'/>
     <value value='2' nick='launch'/>
     <value value='3' nick='cycle-windows'/>
-    <value value='4' nick='quit'/>
+    <value value='4' nick='minimize-or-overview'/>
+    <value value='5' nick='quit'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-dock.scrollAction'>
     <value value='0' nick='do-nothing'/>


### PR DESCRIPTION
**Goal**
Offer a new click action option that will allow a more Unity-like behavior:
- when there is a single window, either minimize it or restore it
- when there are multiple windows, launch overview to select window. 

**Notes**

_This is my first attempt at contributing to a GNOME shell extension, please bare with my lack of knowledge ;-)_

- I could not find an option in the gnome shell API in order to filter out windows for a specific application in the overview, it could be a cool improvement as it would give a better consistency. If you have any information on this aspect I'd love to know more.
- Tried to follow your formatting. I did not launch a beautify on the source files as I'm not familiar with the conventions you use yet.
- I can translate my contribution in french if you guide me on how to do it.