### PR TITLE
Move some functions and classes from convenience.js to utils.js.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 UUID = dash-to-dock@micxgx.gmail.com
 BASE_MODULES = extension.js stylesheet.css metadata.json COPYING README.md
-EXTRA_MODULES = convenience.js dash.js docking.js appIcons.js windowPreview.js intellihide.js prefs.js theming.js Settings.ui
+EXTRA_MODULES = convenience.js dash.js docking.js appIcons.js windowPreview.js intellihide.js prefs.js theming.js utils.js Settings.ui
 EXTRA_MEDIA = logo.svg
 TOLOCALIZE =  prefs.js
 MSGSRC = $(wildcard po/*.po)

--- a/appIcons.js
+++ b/appIcons.js
@@ -23,7 +23,7 @@ const Util = imports.misc.util;
 const Workspace = imports.ui.workspace;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
+const Utils = Me.imports.utils;
 const WindowPreview = Me.imports.windowPreview;
 
 let tracker = Shell.WindowTracker.get_default();
@@ -72,7 +72,7 @@ const MyAppIcon = new Lang.Class({
         // a prefix is required to avoid conflicting with the parent class variable
         this._dtdSettings = settings;
         this._monitorIndex = monitorIndex;
-        this._signalsHandler = new Convenience.GlobalSignalsHandler();
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._nWindows = 0;
 
         this.parent(app, iconParams);
@@ -264,7 +264,7 @@ const MyAppIcon = new Lang.Class({
 
         this._dots = new St.DrawingArea({x_expand: true, y_expand: true});
         this._dots.connect('repaint', Lang.bind(this, function() {
-            this._drawCircles(this._dots, Convenience.getPosition(this._dtdSettings));
+            this._drawCircles(this._dots, Utils.getPosition(this._dtdSettings));
         }));
         this._iconContainer.add_child(this._dots);
         this._updateCounterClass();
@@ -311,7 +311,7 @@ const MyAppIcon = new Lang.Class({
                     // scrollable so the minimum height is smaller than the natural height.
                     let monitor_index = Main.layoutManager.findIndexForActor(this.actor);
                     let workArea = Main.layoutManager.getWorkAreaForMonitor(monitor_index);
-                    let position = Convenience.getPosition(this._dtdSettings);
+                    let position = Utils.getPosition(this._dtdSettings);
                     this._isHorizontal = ( position == St.Side.TOP ||
                                            position == St.Side.BOTTOM);
                     // If horizontal also remove the height of the dash
@@ -773,7 +773,7 @@ const MyAppIconMenu = new Lang.Class({
     Extends: AppDisplay.AppIconMenu,
 
     _init: function(source, settings) {
-        let side = Convenience.getPosition(settings);
+        let side = Utils.getPosition(settings);
 
         // Damm it, there has to be a proper way of doing this...
         // As I can't call the parent parent constructor (?) passing the side
@@ -1116,7 +1116,7 @@ function itemShowLabel()  {
 
     let x, y, xOffset, yOffset;
 
-    let position = Convenience.getPosition(this._dtdSettings);
+    let position = Utils.getPosition(this._dtdSettings);
     this._isHorizontal = ((position == St.Side.TOP) || (position == St.Side.BOTTOM));
     let labelOffset = node.get_length('-x-offset');
 

--- a/convenience.js
+++ b/convenience.js
@@ -5,11 +5,8 @@
  * http://git.gnome.org/browse/gnome-shell-extensions/
  */
 
-const Clutter = imports.gi.Clutter;
 const Gettext = imports.gettext;
 const Gio = imports.gi.Gio;
-const Lang = imports.lang;
-const St = imports.gi.St;
 
 const Config = imports.misc.config;
 const ExtensionUtils = imports.misc.extensionUtils;
@@ -74,124 +71,4 @@ function getSettings(schema) {
     return new Gio.Settings({
         settings_schema: schemaObj
     });
-}
-
-/**
- * Simplify global signals and function injections handling
- * abstract class
- */
-const BasicHandler = new Lang.Class({
-    Name: 'DashToDock.BasicHandler',
-
-    _init: function() {
-        this._storage = new Object();
-    },
-
-    add: function(/* unlimited 3-long array arguments */) {
-        // Convert arguments object to array, concatenate with generic
-        let args = Array.concat('generic', Array.slice(arguments));
-        // Call addWithLabel with ags as if they were passed arguments
-        this.addWithLabel.apply(this, args);
-    },
-
-    destroy: function() {
-        for( let label in this._storage )
-            this.removeWithLabel(label);
-    },
-
-    addWithLabel: function(label /* plus unlimited 3-long array arguments*/) {
-        if (this._storage[label] == undefined)
-            this._storage[label] = new Array();
-
-        // Skip first element of the arguments
-        for (let i = 1; i < arguments.length; i++) {
-            this._storage[label].push( this._create(arguments[i]));
-        }
-    },
-
-    removeWithLabel: function(label) {
-        if (this._storage[label]) {
-            for (let i = 0; i < this._storage[label].length; i++)
-                this._remove(this._storage[label][i]);
-
-            delete this._storage[label];
-        }
-    },
-
-    // Virtual methods to be implemented by subclass
-
-    /**
-     * Create single element to be stored in the storage structure
-     */
-    _create: function(item) {
-        throw new Error('no implementation of _create in ' + this);
-    },
-
-    /**
-     * Correctly delete single element
-     */
-    _remove: function(item) {
-        throw new Error('no implementation of _remove in ' + this);
-    }
-});
-
-/**
- * Manage global signals
- */
-const GlobalSignalsHandler = new Lang.Class({
-    Name: 'DashToDock.GlobalSignalHandler',
-    Extends: BasicHandler,
-
-    _create: function(item) {
-        let object = item[0];
-        let event = item[1];
-        let callback = item[2]
-        let id = object.connect(event, callback);
-
-        return [object, id];
-    },
-
-    _remove: function(item) {
-         item[0].disconnect(item[1]);
-    }
-});
-
-/**
- * Manage function injection: both instances and prototype can be overridden
- * and restored
- */
-const InjectionsHandler = new Lang.Class({
-    Name: 'DashToDock.InjectionsHandler',
-    Extends: BasicHandler,
-
-    _create: function(item) {
-        let object = item[0];
-        let name = item[1];
-        let injectedFunction = item[2];
-        let original = object[name];
-
-        object[name] = injectedFunction;
-        return [object, name, injectedFunction, original];
-    },
-
-    _remove: function(item) {
-        let object = item[0];
-        let name = item[1];
-        let original = item[3];
-        object[name] = original;
-    }
-});
-
-/**
- * Return the actual position reverseing left and right in rtl
- */
-function getPosition(settings) {
-    let position = settings.get_enum('dock-position');
-    if (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL) {
-        if (position == St.Side.LEFT)
-            position = St.Side.RIGHT;
-        else if (position == St.Side.RIGHT)
-            position = St.Side.LEFT;
-    }
-    return position;
 }

--- a/dash.js
+++ b/dash.js
@@ -23,7 +23,7 @@ const Util = imports.misc.util;
 const Workspace = imports.ui.workspace;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
+const Utils = Me.imports.utils;
 const AppIcons = Me.imports.appIcons;
 
 let DASH_ANIMATION_TIME = Dash.DASH_ANIMATION_TIME;
@@ -60,7 +60,7 @@ const MyDashActor = new Lang.Class({
         this._dtdSettings = settings;
         this._rtl = (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL);
 
-        this._position = Convenience.getPosition(settings);
+        this._position = Utils.getPosition(settings);
         this._isHorizontal = ((this._position == St.Side.TOP) ||
                                (this._position == St.Side.BOTTOM));
 
@@ -186,10 +186,10 @@ const MyDash = new Lang.Class({
 
         this._dtdSettings = settings;
         this._monitorIndex = monitorIndex;
-        this._position = Convenience.getPosition(settings);
+        this._position = Utils.getPosition(settings);
         this._isHorizontal = ((this._position == St.Side.TOP) ||
                                (this._position == St.Side.BOTTOM));
-        this._signalsHandler = new Convenience.GlobalSignalsHandler();
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
 
         this._dragPlaceholder = null;
         this._dragPlaceholderPos = -1;

--- a/docking.js
+++ b/docking.js
@@ -25,6 +25,7 @@ const LayoutManager = imports.ui.main.layoutManager;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
+const Utils = Me.imports.utils;
 const Intellihide = Me.imports.intellihide;
 const Theming = Me.imports.theming;
 const MyDash = Me.imports.dash;
@@ -197,11 +198,11 @@ const DockedDash = new Lang.Class({
         this._settings = settings;
         this._monitorIndex = monitorIndex;
         // Connect global signals
-        this._signalsHandler = new Convenience.GlobalSignalsHandler();
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
 
         this._bindSettingsChanges();
 
-        this._position = Convenience.getPosition(settings);
+        this._position = Utils.getPosition(settings);
         this._isHorizontal = ((this._position == St.Side.TOP) || (this._position == St.Side.BOTTOM));
 
         // Temporary ignore hover events linked to autohide for whatever reason
@@ -344,7 +345,7 @@ const DockedDash = new Lang.Class({
             })
         ]);
 
-        this._injectionsHandler = new Convenience.InjectionsHandler();
+        this._injectionsHandler = new Utils.InjectionsHandler();
         this._themeManager = new Theming.ThemeManager(this._settings, this.actor, this.dash);
 
         // Since the actor is not a topLevel child and its parent is now not added to the Chrome,
@@ -1353,7 +1354,7 @@ const KeyboardShortcuts = new Lang.Class({
 
         this._settings = settings;
         this._allDocks = allDocks;
-        this._signalsHandler = new Convenience.GlobalSignalsHandler();
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
 
         this._hotKeysEnabled = false;
         if (this._settings.get_boolean('hot-keys'))
@@ -1510,8 +1511,8 @@ const WorkspaceIsolation = new Lang.Class({
         this._settings = settings;
         this._allDocks = allDocks;
 
-        this._signalsHandler = new Convenience.GlobalSignalsHandler();
-        this._injectionsHandler = new Convenience.InjectionsHandler();
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
+        this._injectionsHandler = new Utils.InjectionsHandler();
 
         this._signalsHandler.add([
             this._settings,
@@ -1610,7 +1611,7 @@ const DockManager = new Lang.Class({
 
     _bindSettingsChanges: function() {
         // Connect relevant signals to the toggling function
-        this._signalsHandler = new Convenience.GlobalSignalsHandler();
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._signalsHandler.add([
             global.screen,
             'monitors-changed',
@@ -1845,7 +1846,7 @@ const DockManager = new Lang.Class({
      * Adjust Panel corners
      */
     _adjustPanelCorners: function() {
-        let position = Convenience.getPosition(this._settings);
+        let position = Utils.getPosition(this._settings);
         let isHorizontal = ((position == St.Side.TOP) || (position == St.Side.BOTTOM));
         let extendHeight   = this._settings.get_boolean('extend-height');
         let fixedIsEnabled = this._settings.get_boolean('dock-fixed');

--- a/intellihide.js
+++ b/intellihide.js
@@ -10,7 +10,7 @@ const Main = imports.ui.main;
 const Signals = imports.signals;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
+const Utils = Me.imports.utils;
 
 // A good compromise between reactivity and efficiency; to be tuned.
 const INTELLIHIDE_CHECK_INTERVAL = 100;
@@ -53,7 +53,7 @@ const Intellihide = new Lang.Class({
         this._settings = settings;
         this._monitorIndex = monitorIndex;
 
-        this._signalsHandler = new Convenience.GlobalSignalsHandler();
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._tracker = Shell.WindowTracker.get_default();
         this._focusApp = null; // The application whose window is focused.
         this._topApp = null; // The application whose window is on top on the monitor with the dock.

--- a/theming.js
+++ b/theming.js
@@ -23,7 +23,7 @@ const Util = imports.misc.util;
 const Workspace = imports.ui.workspace;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
+const Utils = Me.imports.utils;
 
 /**
  * Manage theme customization and custom theme support
@@ -33,7 +33,7 @@ const ThemeManager = new Lang.Class({
 
     _init: function(settings, actor, dash) {
         this._settings = settings;
-        this._signalsHandler = new Convenience.GlobalSignalsHandler();
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._bindSettingsChanges();
         this._actor = actor;
         this._dash = dash;
@@ -128,7 +128,7 @@ const ThemeManager = new Lang.Class({
         // We want to find the inside border-color of the dock because it is
         // the side most visible to the user. We do this by finding the side
         // opposite the position
-        let position = Convenience.getPosition(this._settings);
+        let position = Utils.getPosition(this._settings);
         let side = position + 2;
         if (side > 3)
             side = Math.abs(side - 4);
@@ -212,7 +212,7 @@ const ThemeManager = new Lang.Class({
             return;
 
         let newStyle = '';
-        let position = Convenience.getPosition(this._settings);
+        let position = Utils.getPosition(this._settings);
 
         if (!this._settings.get_boolean('custom-theme-shrink')) {
             // obtain theme border settings

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,123 @@
+const Clutter = imports.gi.Clutter;
+const Lang = imports.lang;
+const St = imports.gi.St;
+
+/**
+ * Simplify global signals and function injections handling
+ * abstract class
+ */
+const BasicHandler = new Lang.Class({
+    Name: 'DashToDock.BasicHandler',
+
+    _init: function() {
+        this._storage = new Object();
+    },
+
+    add: function(/* unlimited 3-long array arguments */) {
+        // Convert arguments object to array, concatenate with generic
+        let args = Array.concat('generic', Array.slice(arguments));
+        // Call addWithLabel with ags as if they were passed arguments
+        this.addWithLabel.apply(this, args);
+    },
+
+    destroy: function() {
+        for( let label in this._storage )
+            this.removeWithLabel(label);
+    },
+
+    addWithLabel: function(label /* plus unlimited 3-long array arguments*/) {
+        if (this._storage[label] == undefined)
+            this._storage[label] = new Array();
+
+        // Skip first element of the arguments
+        for (let i = 1; i < arguments.length; i++) {
+            this._storage[label].push( this._create(arguments[i]));
+        }
+    },
+
+    removeWithLabel: function(label) {
+        if (this._storage[label]) {
+            for (let i = 0; i < this._storage[label].length; i++)
+                this._remove(this._storage[label][i]);
+
+            delete this._storage[label];
+        }
+    },
+
+    // Virtual methods to be implemented by subclass
+
+    /**
+     * Create single element to be stored in the storage structure
+     */
+    _create: function(item) {
+        throw new Error('no implementation of _create in ' + this);
+    },
+
+    /**
+     * Correctly delete single element
+     */
+    _remove: function(item) {
+        throw new Error('no implementation of _remove in ' + this);
+    }
+});
+
+/**
+ * Manage global signals
+ */
+const GlobalSignalsHandler = new Lang.Class({
+    Name: 'DashToDock.GlobalSignalHandler',
+    Extends: BasicHandler,
+
+    _create: function(item) {
+        let object = item[0];
+        let event = item[1];
+        let callback = item[2]
+        let id = object.connect(event, callback);
+
+        return [object, id];
+    },
+
+    _remove: function(item) {
+         item[0].disconnect(item[1]);
+    }
+});
+
+/**
+ * Manage function injection: both instances and prototype can be overridden
+ * and restored
+ */
+const InjectionsHandler = new Lang.Class({
+    Name: 'DashToDock.InjectionsHandler',
+    Extends: BasicHandler,
+
+    _create: function(item) {
+        let object = item[0];
+        let name = item[1];
+        let injectedFunction = item[2];
+        let original = object[name];
+
+        object[name] = injectedFunction;
+        return [object, name, injectedFunction, original];
+    },
+
+    _remove: function(item) {
+        let object = item[0];
+        let name = item[1];
+        let original = item[3];
+        object[name] = original;
+    }
+});
+
+/**
+ * Return the actual position reverseing left and right in rtl
+ */
+function getPosition(settings) {
+    let position = settings.get_enum('dock-position');
+    if (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL) {
+        if (position == St.Side.LEFT)
+            position = St.Side.RIGHT;
+        else if (position == St.Side.RIGHT)
+            position = St.Side.LEFT;
+    }
+    return position;
+}


### PR DESCRIPTION
Perhaps we can also reference the issues it fixes to the changelog.

I tested this on Gnome 3.22 and Gnome 3.24

Also, on 3.24, I purged:
```
gir1.2-clutter-1.0
gir1.2-clutter-gst-3.0
gir1.2-gtkclutter-1.0
```
and the settings dialog loaded fine. So, as you mentioned, it seems that the gir dependencies are no longer a problem. This is a nice plus!