### PR TITLE
Make the drag placeholder smaller than other icons

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -1016,8 +1016,8 @@ const MyDash = new Lang.Class({
                 fadeIn = true;
 
             this._dragPlaceholder = new Dash.DragPlaceholderItem();
-            this._dragPlaceholder.child.set_width (this.iconSize);
-            this._dragPlaceholder.child.set_height (this.iconSize / 2);
+            this._dragPlaceholder.child.set_width (this.iconSize / 2);
+            this._dragPlaceholder.child.set_height (this.iconSize / 4);
             this._box.insert_child_at_index(this._dragPlaceholder,
                                             this._dragPlaceholderPos);
             this._dragPlaceholder.show(fadeIn);


### PR DESCRIPTION
This matches the native shell more closely, and also reduces the
chances that the drag placeholder will look blurry or pixelated. I'm
not sure if there's a better factor to divide by, in order to more closely
match the native shell, but it seemed to look fine to me.