### PR TITLE
Unity7-esk backlight items support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 UUID = dash-to-dock@micxgx.gmail.com
 BASE_MODULES = extension.js stylesheet.css metadata.json COPYING README.md
 EXTRA_MODULES = convenience.js dash.js docking.js appIcons.js windowPreview.js intellihide.js prefs.js theming.js utils.js Settings.ui
-EXTRA_MEDIA = logo.svg
+EXTRA_MEDIA = logo.svg glossy.svg
 TOLOCALIZE =  prefs.js appIcons.js
 MSGSRC = $(wildcard po/*.po)
 ifeq ($(strip $(DESTDIR)),)

--- a/Settings.ui
+++ b/Settings.ui
@@ -2350,6 +2350,49 @@
                   </object>
                 </child>
                 <child>
+                  <object class="GtkListBoxRow" id="unity_backlit_items">
+                    <property name="width_request">100</property>
+                    <property name="height_request">80</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="unity_backlit_items_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="valign">center</property>
+                            <property name="xpad">12</property>
+                            <property name="label" translatable="yes">Enable Unity7 like glossy backlit items</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="unity_backlit_items_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">12</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
                   <object class="GtkListBoxRow" id="listboxrow_rnd_border">
                     <property name="width_request">100</property>
                     <property name="height_request">80</property>

--- a/appIcons.js
+++ b/appIcons.js
@@ -62,6 +62,9 @@ let recentlyClickedAppIndex = 0;
 // pixel buffers that can be used for calculating the backlight color
 let themeLoader = null;
 
+// Global icon cache. Used for Unity7 styling.
+let iconCacheMap = new Map();
+
 /**
  * Extend AppIcon
  *
@@ -87,7 +90,6 @@ const MyAppIcon = new Lang.Class({
         this._monitorIndex = monitorIndex;
         this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._nWindows = 0;
-        this._backgroundColor = null;
 
         this.parent(app, iconParams);
 
@@ -712,9 +714,9 @@ const MyAppIcon = new Lang.Class({
      * Unity7 to javascript, so it more or less works the same way.
      */
     _calculateColorPalette: function (pixBuf) {
-        if (this._backgroundColor !== null) {
+        if (iconCacheMap.get(this.app.get_id())) {
             // We already know the answer
-            return this._backgroundColor;
+            return iconCacheMap.get(this.app.get_id());
         }
     
         let colorUtils = new Utils.ColorUtils();       
@@ -761,13 +763,15 @@ const MyAppIcon = new Lang.Class({
         let rgb = colorUtils.HSVtoRGB(hsv.h, hsv.s, hsv.v);
 
         // Cache the result.
-        this._backgroundColors = {
+        let backgroundColor = {
             lighter: colorUtils.ColorLuminance(rgb.r, rgb.g, rgb.b, 0.2),
             original: colorUtils.ColorLuminance(rgb.r, rgb.g, rgb.b, 0),
             darker: colorUtils.ColorLuminance(rgb.r, rgb.g, rgb.b, -0.5)
         };
 
-        return this._backgroundColors
+        iconCacheMap.set(this.app.get_id(), backgroundColor);
+
+        return backgroundColor;
     },
 
     _drawCircles: function(area, side) {

--- a/appIcons.js
+++ b/appIcons.js
@@ -626,10 +626,10 @@ const MyAppIcon = new Lang.Class({
     },
 
     _enableBacklight: function() {
-        let pixBuf = this._getIconPixBuf();
+        let colorPallete = this._calculateColorPalette();
 
         // Fallback
-        if (pixBuf === null) {
+        if (colorPallete === null) {
             this._iconContainer.set_style(
                 'border-radius: 5px;' +
                 'background-gradient-direction: vertical;' +
@@ -645,8 +645,6 @@ const MyAppIcon = new Lang.Class({
 
             return;
         }
-        
-        let colorPallete = this._calculateColorPalette(pixBuf);
 
         this._iconContainer.set_style(
             'border-radius: 5px;' +
@@ -713,11 +711,15 @@ const MyAppIcon = new Lang.Class({
      * The backlight color choosing algorithm was mostly ported from the C++ source of Canonicals
      * Unity7 to javascript, so it more or less works the same way.
      */
-    _calculateColorPalette: function (pixBuf) {
+    _calculateColorPalette: function () {
         if (iconCacheMap.get(this.app.get_id())) {
             // We already know the answer
             return iconCacheMap.get(this.app.get_id());
         }
+
+        let pixBuf = this._getIconPixBuf();
+        if (pixBuf == null)
+            return null;
     
         let colorUtils = new Utils.ColorUtils();       
         

--- a/appIcons.js
+++ b/appIcons.js
@@ -805,10 +805,11 @@ const MyAppIcon = new Lang.Class({
      */
     _resamplePixels: function (pixBuf, pixels, resampleX, resampleY) {
         let resampledPixels = [];
+        let limit = pixBuf.get_height() * pixBuf.get_width() / (resampleX * resampleY);
 
-        for (let i = 0; i < pixBuf.get_height() * pixBuf.get_width() / (resampleX * resampleY); i++) {
+        for (let i = 0; i < limit; i++) {
             let pixel = i * resampleX * resampleY;
-            
+
             resampledPixels.push(pixels[pixel * 4]);
             resampledPixels.push(pixels[pixel * 4 + 1]);
             resampledPixels.push(pixels[pixel * 4 + 2]);

--- a/appIcons.js
+++ b/appIcons.js
@@ -706,7 +706,7 @@ const MyAppIcon = new Lang.Class({
         }
         
         // Get the pixel buffer from the icon theme
-        return themeLoader.load_icon(iconTexture.get_names()[0], 24, 0);
+        return themeLoader.load_icon(iconTexture.get_names()[0], 64, 0);
     },
 
     /**

--- a/appIcons.js
+++ b/appIcons.js
@@ -87,6 +87,7 @@ const MyAppIcon = new Lang.Class({
         this._monitorIndex = monitorIndex;
         this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._nWindows = 0;
+        this._backgroundColor = null;
 
         this.parent(app, iconParams);
 
@@ -703,7 +704,12 @@ const MyAppIcon = new Lang.Class({
      * Unity7 to javascript, so it more or less works the same way.
      */
     _calculateColorPalette: function (pixBuf) {
-        let colorUtils = new Utils.ColorUtils();
+        if (this._backgroundColor !== null) {
+            // We already know the answer
+            return this._backgroundColor;
+        }
+    
+        let colorUtils = new Utils.ColorUtils();       
         
         let pixels = pixBuf.get_pixels(),
             offset = 0;
@@ -746,11 +752,14 @@ const MyAppIcon = new Lang.Class({
 
         let rgb = colorUtils.HSVtoRGB(hsv.h, hsv.s, hsv.v);
 
-        return {
+        // Cache the result.
+        this._backgroundColors = {
             lighter: colorUtils.ColorLuminance(rgb.r, rgb.g, rgb.b, 0.2),
             original: colorUtils.ColorLuminance(rgb.r, rgb.g, rgb.b, 0),
             darker: colorUtils.ColorLuminance(rgb.r, rgb.g, rgb.b, -0.5)
         };
+
+        return this._backgroundColors
     },
 
     _drawCircles: function(area, side) {

--- a/appIcons.js
+++ b/appIcons.js
@@ -803,7 +803,7 @@ const MyAppIcon = new Lang.Class({
      *
      * @return [];
      */
-    _resamplePixels: function (pixBuf, pixels, resampleX, resampleY)
+    _resamplePixels: function (pixBuf, pixels, resampleX, resampleY) {
         let resampledPixels = [];
 
         for (let i = 0; i < pixBuf.get_height() * pixBuf.get_width() / (resampleX * resampleY); i++) {

--- a/appIcons.js
+++ b/appIcons.js
@@ -140,6 +140,10 @@ const MyAppIcon = new Lang.Class({
             this._dtdSettings,
             'changed::unity-backlit-items',
             Lang.bind(this, this._toggleBacklight)
+        ],[
+            this._dtdSettings,
+            'changed::apply-custom-theme',
+            Lang.bind(this, this._toggleBacklight)
         ]);
         this._glossyBackground();
     },
@@ -323,6 +327,7 @@ const MyAppIcon = new Lang.Class({
         if (
             this.app.state !== Shell.AppState.STOPPED &&
             this._dtdSettings.get_boolean('unity-backlit-items') === true &&
+            this._dtdSettings.get_boolean('apply-custom-theme') === false &&
             getInterestingWindows(this.app, this._dtdSettings).length > 0
         ) {
             this._enableBacklight();
@@ -925,10 +930,12 @@ const MyAppIcon = new Lang.Class({
         let backgroundStyle =
             'background-image: url(\'' + path + '/media/glossy.svg\');' +
             'background-size: contain;'
-        
+
+        let applyBacklight = this._dtdSettings.get_boolean('unity-backlit-items') &&
+                            !this._dtdSettings.get_boolean('apply-custom-theme');
+
         this._iconContainer.get_children()[1].set_style(
-            this._dtdSettings.get_boolean('unity-backlit-items') === true ?
-                backgroundStyle : null
+            applyBacklight ? backgroundStyle : null
         );
     },
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -851,10 +851,13 @@ const MyAppIcon = new Lang.Class({
 
     _glossyBackground: function () {
         let path = imports.misc.extensionUtils.getCurrentExtension().path;
+        let backgroundStyle =
+            'background-image: url(\'' + path + '/media/glossy.svg\');' +
+            'background-size: contain;'
         
         this._iconContainer.get_children()[1].set_style(
             this._dtdSettings.get_boolean('unity-backlit-items') === true ?
-                'background-image: url(\'' + path + '/media/glossy.svg\');' : ''
+                backgroundStyle : ''
         );
     },
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -671,8 +671,8 @@ const MyAppIcon = new Lang.Class({
     },
 
     _disableBacklight: function() {
-        this._iconContainer.set_style('');
-        this._dot.set_style('');
+        this._iconContainer.set_style(null);
+        this._dot.set_style(null);
     },
     
     /**
@@ -902,7 +902,7 @@ const MyAppIcon = new Lang.Class({
         
         this._iconContainer.get_children()[1].set_style(
             this._dtdSettings.get_boolean('unity-backlit-items') === true ?
-                backgroundStyle : ''
+                backgroundStyle : null
         );
     },
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -729,8 +729,32 @@ const MyAppIcon = new Lang.Class({
             gTotal = 0,
             bTotal = 0;
 
-        for (let i = 0; i < pixBuf.get_height(); i++) {
-            for (let x = 0; x < pixBuf.get_width(); x++) {
+        // Re sampling if necessary
+        let resample_x = 1;
+        let resample_y = 1;
+        if (pixBuf.get_height() == 512)
+            resample_y = 8;
+        else if (pixBuf.get_height() == 256)
+            resample_y = 4;
+        if (pixBuf.get_width() == 512)
+            resample_x = 8;
+        else if (pixBuf.get_width() == 256)
+            resample_x = 4;
+
+        if (resample_x > 1 || resample_y > 1) {
+            let resampledPixels = [];
+            for (let i = 0; i < pixBuf.get_height()*pixBuf.get_width()/(resample_x * resample_y); i++) {
+                let pixel = i * resample_x * resample_y;
+                resampledPixels.push(pixels[pixel*4]);
+                resampledPixels.push(pixels[pixel*4 + 1]);
+                resampledPixels.push(pixels[pixel*4 + 2]);
+                resampledPixels.push(pixels[pixel*4 + 3]);
+            }
+            pixels = resampledPixels;
+        }
+
+        for (let i = 0; i < pixBuf.get_height()/resample_y; i++) {
+            for (let x = 0; x < pixBuf.get_width()/resample_x; x++) {
                 let r = pixels[offset],
                     g = pixels[offset + 1],
                     b = pixels[offset + 2], 

--- a/appIcons.js
+++ b/appIcons.js
@@ -747,8 +747,11 @@ const MyAppIcon = new Lang.Class({
             pixels = this._resamplePixels(pixBuf, pixels, resample_x, resample_y);
         }
 
-        for (let i = 0; i < pixBuf.get_height() / resample_y; i++) {
-            for (let x = 0; x < pixBuf.get_width() / resample_x; x++) {
+        let limitY = pixBuf.get_height() / resample_y;
+        let limitX = pixBuf.get_width() / resample_x;
+
+        for (let i = 0; i < limitY; i++) {
+            for (let x = 0; x < limitX; x++) {
                 let r = pixels[offset],
                     g = pixels[offset + 1],
                     b = pixels[offset + 2], 

--- a/appIcons.js
+++ b/appIcons.js
@@ -318,8 +318,16 @@ const MyAppIcon = new Lang.Class({
         this._updateCounterClass();
         
         // Enable / Disable the backlight of running apps
-        if (this.app.state !== Shell.AppState.STOPPED && this._dtdSettings.get_boolean('unity-backlit-items') === true) {
+        if (
+            this.app.state !== Shell.AppState.STOPPED &&
+            this._dtdSettings.get_boolean('unity-backlit-items') === true &&
+            getInterestingWindows(this.app, this._dtdSettings).length > 0
+        ) {
             this._enableBacklight();
+            
+            // Repaint the dots to make sure they have the correct color
+            if (this._dots)
+                this._dots.queue_repaint();
         } else {
             this._disableBacklight();
         }

--- a/appIcons.js
+++ b/appIcons.js
@@ -803,7 +803,7 @@ const MyAppIcon = new Lang.Class({
      *
      * @return [];
      */
-    _resamplePixels: function (pixels, pixBuf, resampleX, resampleY) {
+    _resamplePixels: function (pixBuf, pixels, resampleX, resampleY)
         let resampledPixels = [];
 
         for (let i = 0; i < pixBuf.get_height() * pixBuf.get_width() / (resampleX * resampleY); i++) {

--- a/appIcons.js
+++ b/appIcons.js
@@ -1,6 +1,7 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
 const Clutter = imports.gi.Clutter;
+const GdkPixbuf = imports.gi.GdkPixbuf
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
@@ -57,6 +58,10 @@ let recentlyClickedApp = null;
 let recentlyClickedAppWindows = null;
 let recentlyClickedAppIndex = 0;
 
+// We need an icons theme object, this is the only way I managed to get
+// pixel buffers that can be used for calculating the backlight color
+let themeLoader = null;
+
 /**
  * Extend AppIcon
  *
@@ -69,6 +74,7 @@ let recentlyClickedAppIndex = 0;
  * - Customize click actions.
  * - Update minimization animation target
  * - Update menu if open on windows change
+ * - Unity7-esk backlit item emulation
  */
 const MyAppIcon = new Lang.Class({
     Name: 'DashToDock.AppIcon',
@@ -125,6 +131,14 @@ const MyAppIcon = new Lang.Class({
 
         this._previewMenuManager = null;
         this._previewMenu = null;
+
+        // Toggle glossy background
+        this._signalsHandler.add([
+            this._dtdSettings,
+            'changed::unity-backlit-items',
+            Lang.bind(this, this._toggleBacklight)
+        ]);
+        this._glossyBackground();
     },
 
     _onDestroy: function() {
@@ -301,6 +315,13 @@ const MyAppIcon = new Lang.Class({
             this.parent();
         this._onFocusAppChanged();
         this._updateCounterClass();
+        
+        // Enable / Disable the backlight of running apps
+        if (this.app.state !== Shell.AppState.STOPPED && this._dtdSettings.get_boolean('unity-backlit-items') === true) {
+            this._enableBacklight();
+        } else {
+            this._disableBacklight();
+        }
     },
 
     popupMenu: function() {
@@ -593,6 +614,145 @@ const MyAppIcon = new Lang.Class({
             this._dots.queue_repaint();
     },
 
+    _enableBacklight: function() {
+        let pixBuf = this._getIconPixBuf();
+
+        // Fallback
+        if (pixBuf === null) {
+            this._iconContainer.set_style(
+                'border-radius: 5px;' +
+                'background-gradient-direction: vertical;' +
+                'background-gradient-start: #e0e0e0;' +
+                'background-gradient-end: darkgray;'
+            );
+            
+            this._dot.set_style(
+                'height: 0px;' +
+                'border: 0px solid white;' +
+                'background-color: gray;'
+            );
+
+            return;
+        }
+        
+        let colorPallete = this._calculateColorPalette(pixBuf);
+
+        this._iconContainer.set_style(
+            'border-radius: 5px;' +
+            'background-gradient-direction: vertical;' +
+            'background-gradient-start: ' + colorPallete.original + ';' +
+            'background-gradient-end: ' +  colorPallete.darker + ';'
+        );
+
+        this._dot.set_style(
+            'height: 0px;' +
+            'border: 0px solid ' + colorPallete.lighter  + ';' +
+            'background-color: ' + colorPallete.darker + ';'
+        );
+    },
+
+    _toggleBacklight: function () {
+        this._glossyBackground();
+        this._updateRunningStyle();
+        
+        if (this._dots)
+            this._dots.queue_repaint();
+    },
+
+    _disableBacklight: function() {
+        this._iconContainer.set_style('');
+        this._dot.set_style('');
+    },
+    
+    /**
+     * Try to get the pixel buffer for the current icon, if not fail gracefully     
+     */
+    _getIconPixBuf: function() {
+        let iconTexture = this.app.create_icon_texture(16);
+
+        if (themeLoader === null) {
+            let ifaceSettings = new Gio.Settings({ schema: "org.gnome.desktop.interface" });
+
+            themeLoader = new Gtk.IconTheme(),
+            themeLoader.set_custom_theme(ifaceSettings.get_string('icon-theme')); // Make sure the correct theme is loaded
+        }        
+
+        // Unable to load the icon texture, use fallback
+        if (iconTexture instanceof St.Icon === false) {
+            return null;
+        }
+
+        iconTexture = iconTexture.get_gicon();       
+
+        // Unable to load the icon texture, use fallback
+        if (iconTexture === null) {
+            return null;
+        }
+
+        if (iconTexture instanceof Gio.FileIcon) {
+            // Use GdkPixBuf to load the pixel buffer from the provided file path
+            return GdkPixbuf.Pixbuf.new_from_file(iconTexture.get_file().get_path());
+        }
+        
+        // Get the pixel buffer from the icon theme
+        return themeLoader.load_icon(iconTexture.get_names()[0], 24, 0);
+    },
+
+    /**
+     * The backlight color choosing algorithm was mostly ported from the C++ source of Canonicals
+     * Unity7 to javascript, so it more or less works the same way.
+     */
+    _calculateColorPalette: function (pixBuf) {
+        let colorUtils = new Utils.ColorUtils();
+        
+        let pixels = pixBuf.get_pixels(),
+            offset = 0;
+
+        let total  = 0,
+            rTotal = 0,
+            gTotal = 0,
+            bTotal = 0;
+
+        for (let i = 0; i < pixBuf.get_height(); i++) {
+            for (let x = 0; x < pixBuf.get_width(); x++) {
+                let r = pixels[offset],
+                    g = pixels[offset + 1],
+                    b = pixels[offset + 2], 
+                    a = pixels[offset + 3];
+                
+                offset += 4;
+
+                let saturation = (Math.max(r, Math.max(g, b)) - Math.min(r, Math.min(g, b))) / 255;
+                let relevance  = 0.1 + 0.9 * (a / 255.0) * saturation;
+
+                rTotal += Math.round(r * relevance);
+                gTotal += Math.round(g * relevance);
+                bTotal += Math.round(b * relevance);
+                
+                total += relevance * 255;
+            }
+        }
+
+        let r = rTotal / total,
+            g = gTotal / total,
+            b = bTotal / total;
+
+        let hsv = colorUtils.RGBtoHSV(r * 255, g * 255, b * 255);
+
+        if (hsv.s > 0.15) {
+          hsv.s = 0.65;
+        }
+        hsv.v = 0.90;
+
+        let rgb = colorUtils.HSVtoRGB(hsv.h, hsv.s, hsv.v);
+
+        return {
+            lighter: colorUtils.ColorLuminance(rgb.r, rgb.g, rgb.b, 0.2),
+            original: colorUtils.ColorLuminance(rgb.r, rgb.g, rgb.b, 0),
+            darker: colorUtils.ColorLuminance(rgb.r, rgb.g, rgb.b, -0.5)
+        };
+    },
+
     _drawCircles: function(area, side) {
         let borderColor, borderWidth, bodyColor;
 
@@ -622,6 +782,12 @@ const MyAppIcon = new Lang.Class({
         let padding = 0; // distance from the margin
         let spacing = radius + borderWidth; // separation between the dots
         let n = this._nWindows;
+
+        // Lightly adjust the styling in case of unity7 backlit mode
+        if (this._dtdSettings.get_boolean('unity-backlit-items') === true) {
+            padding = 1.45;
+            borderWidth = 2;
+        }
 
         cr.setLineWidth(borderWidth);
         Clutter.cairo_set_source_color(cr, borderColor);
@@ -681,6 +847,15 @@ const MyAppIcon = new Lang.Class({
 
         this._iconContainer.add_child(this._numberOverlayBin);
 
+    },
+
+    _glossyBackground: function () {
+        let path = imports.misc.extensionUtils.getCurrentExtension().path;
+        
+        this._iconContainer.get_children()[1].set_style(
+            this._dtdSettings.get_boolean('unity-backlit-items') === true ?
+                'background-image: url(\'' + path + '/media/glossy.svg\');' : ''
+        );
     },
 
     updateNumberOverlay: function() {

--- a/media/glossy.svg
+++ b/media/glossy.svg
@@ -15,7 +15,7 @@
    viewBox="0 0 14.674843 14.674842"
    version="1.1"
    id="svg4941"
-   sodipodi:docname="drawing.svg"
+   sodipodi:docname="glossy.svg"
    inkscape:version="0.92.1 r15371">
   <defs
      id="defs4935">
@@ -36,7 +36,7 @@
        xlink:href="#linearGradient18962"
        id="linearGradient35463"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.26528889,0,0,0.13792641,-48.727743,167.27654)"
+       gradientTransform="matrix(0.29132751,0,0,0.15428114,-54.210829,160.22776)"
        x1="214.71877"
        y1="404.36081"
        x2="214.71877"
@@ -73,7 +73,7 @@
        fx="7.3538475"
        fy="230.28426"
        r="7.2099228"
-       gradientTransform="matrix(5.8641186,-0.04778481,0.01655274,4.2319024,-39.581823,-740.85273)"
+       gradientTransform="matrix(5.9484829,-0.0346444,0.01679088,3.0681664,-40.338609,-476.01412)"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
@@ -83,16 +83,16 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.67"
-     inkscape:cx="50.631228"
-     inkscape:cy="50.268973"
+     inkscape:zoom="10.68"
+     inkscape:cx="65.485107"
+     inkscape:cy="29.432163"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="945"
-     inkscape:window-height="704"
-     inkscape:window-x="79"
-     inkscape:window-y="27"
+     inkscape:window-width="2560"
+     inkscape:window-height="1406"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      scale-x="0.8"
      fit-margin-top="0"
@@ -120,20 +120,20 @@
        inkscape:export-ydpi="180"
        inkscape:export-xdpi="180"
        inkscape:export-filename="C:\Arbeit\Blog\Tutorials\glossybutton\Glossy_Button_Tutorial.png"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient35463);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.35863268;marker:none;enable-background:accumulate;opacity:0.351"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.35100002;fill:url(#linearGradient35463);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.39747861;marker:none;enable-background:accumulate"
        id="rect19155"
-       width="13.326818"
-       height="3.3428361"
-       x="0.67401558"
-       y="223.37906"
-       rx="1.4111111"
-       ry="0.73365098" />
+       width="14.634871"
+       height="3.7392156"
+       x="0.039808333"
+       y="222.98268"
+       rx="1.5496143"
+       ry="0.82064426" />
     <rect
-       style="opacity:0.84299999;fill:url(#radialGradient6798);fill-opacity:1;stroke:#ffffff;stroke-width:0.25988582;stroke-opacity:1"
+       style="opacity:0.427;fill:url(#radialGradient6798);fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect6706"
-       width="14.15996"
-       height="19.868254"
-       x="0.27386767"
-       y="223.40225" />
+       width="14.363673"
+       height="14.404656"
+       x="0.090466507"
+       y="223.07919" />
   </g>
 </svg>

--- a/media/glossy.svg
+++ b/media/glossy.svg
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="18.343554mm"
+   height="18.343554mm"
+   viewBox="0 0 14.674843 14.674842"
+   version="1.1"
+   id="svg4941"
+   sodipodi:docname="drawing.svg"
+   inkscape:version="0.92.1 r15371">
+  <defs
+     id="defs4935">
+    <linearGradient
+       id="linearGradient6812"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6810" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop6808" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient18962"
+       id="linearGradient35463"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26528889,0,0,0.13792641,-48.727743,167.27654)"
+       x1="214.71877"
+       y1="404.36081"
+       x2="214.71877"
+       y2="443.54596" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient18962">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop18964" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop18966" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18806">
+      <stop
+         style="stop-color:#ff0101;stop-opacity:1;"
+         offset="0"
+         id="stop18808" />
+      <stop
+         style="stop-color:#800000;stop-opacity:1;"
+         offset="1"
+         id="stop18810" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6812"
+       id="radialGradient6798"
+       cx="7.3538475"
+       cy="230.28426"
+       fx="7.3538475"
+       fy="230.28426"
+       r="7.2099228"
+       gradientTransform="matrix(5.8641186,-0.04778481,0.01655274,4.2319024,-39.581823,-740.85273)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.67"
+     inkscape:cx="50.631228"
+     inkscape:cy="50.268973"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="945"
+     inkscape:window-height="704"
+     inkscape:window-x="79"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     scale-x="0.8"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata4938">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-222.92515)">
+    <rect
+       inkscape:export-ydpi="180"
+       inkscape:export-xdpi="180"
+       inkscape:export-filename="C:\Arbeit\Blog\Tutorials\glossybutton\Glossy_Button_Tutorial.png"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient35463);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.35863268;marker:none;enable-background:accumulate;opacity:0.351"
+       id="rect19155"
+       width="13.326818"
+       height="3.3428361"
+       x="0.67401558"
+       y="223.37906"
+       rx="1.4111111"
+       ry="0.73365098" />
+    <rect
+       style="opacity:0.84299999;fill:url(#radialGradient6798);fill-opacity:1;stroke:#ffffff;stroke-width:0.25988582;stroke-opacity:1"
+       id="rect6706"
+       width="14.15996"
+       height="19.868254"
+       x="0.27386767"
+       y="223.40225" />
+  </g>
+</svg>

--- a/prefs.js
+++ b/prefs.js
@@ -583,6 +583,11 @@ const Settings = new Lang.Class({
         this._builder.get_object('custom_opacity_scale').set_value(this._settings.get_double('background-opacity'));
         this._settings.bind('opaque-background', this._builder.get_object('custom_opacity'), 'sensitive', Gio.SettingsBindFlags.DEFAULT);
 
+        this._settings.bind('unity-backlit-items',
+            this._builder.get_object('unity_backlit_items_switch'),
+            'active', Gio.SettingsBindFlags.DEFAULT
+        );
+
         this._settings.bind('force-straight-corner',
             this._builder.get_object('force_straight_corner_switch'),
             'active', Gio.SettingsBindFlags.DEFAULT);

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -704,5 +704,10 @@
       <summary>Force straight corners in dash</summary>
       <description>Make the borders in the dash non rounded</description>
     </key>
+    <key name="unity-backlit-items" type="b">
+      <default>false</default>
+      <summary>Enable unity7 like glossy backlit items</summary>
+      <description>Emulate the unity7 backlit glossy items behaviour</description>
+    </key>
   </schema>
 </schemalist>

--- a/utils.js
+++ b/utils.js
@@ -83,6 +83,81 @@ const GlobalSignalsHandler = new Lang.Class({
 });
 
 /**
+ * Color manipulation utilities
+ * 
+ * Most of this code comes from reposts on stackoverflow, I was unable to trace the
+ * original authors, otherwise I would have credited them here.
+ */
+const ColorUtils = new Lang.Class({
+    Name: 'DashToDock.ColorUtils',
+    
+    ColorLuminance: function(r, g, b, lum) {
+        var hex = b | (g << 8) | (r << 16);
+        
+        hex = (0x1000000 + hex).toString(16).slice(1);
+
+        // convert to decimal and change luminosity
+        var rgb = "#", c, i;
+        for (i = 0; i < 3; i++) {
+            c = parseInt(hex.substr(i*2,2), 16);
+            c = Math.round(Math.min(Math.max(0, c + (c * lum)), 255)).toString(16);
+            rgb += ("00"+c).substr(c.length);
+        }
+
+        return rgb;
+    },
+
+    HSVtoRGB: function(h, s, v) {
+        var r, g, b, i, f, p, q, t;
+        if (arguments.length === 1) {
+            s = h.s, v = h.v, h = h.h;
+        }
+        i = Math.floor(h * 6);
+        f = h * 6 - i;
+        p = v * (1 - s);
+        q = v * (1 - f * s);
+        t = v * (1 - (1 - f) * s);
+        switch (i % 6) {
+            case 0: r = v, g = t, b = p; break;
+            case 1: r = q, g = v, b = p; break;
+            case 2: r = p, g = v, b = t; break;
+            case 3: r = p, g = q, b = v; break;
+            case 4: r = t, g = p, b = v; break;
+            case 5: r = v, g = p, b = q; break;
+        }
+        return {
+            r: Math.round(r * 255),
+            g: Math.round(g * 255),
+            b: Math.round(b * 255)
+        };
+    },
+
+    RGBtoHSV: function (r, g, b) {
+        if (arguments.length === 1) {
+            g = r.g, b = r.b, r = r.r;
+        }
+        var max = Math.max(r, g, b), min = Math.min(r, g, b),
+            d = max - min,
+            h,
+            s = (max === 0 ? 0 : d / max),
+            v = max / 255;
+
+        switch (max) {
+            case min: h = 0; break;
+            case r: h = (g - b) + d * (g < b ? 6: 0); h /= 6 * d; break;
+            case g: h = (b - r) + d * 2; h /= 6 * d; break;
+            case b: h = (r - g) + d * 4; h /= 6 * d; break;
+        }
+
+        return {
+            h: h,
+            s: s,
+            v: v
+        };
+    }
+});
+
+/**
  * Manage function injection: both instances and prototype can be overridden
  * and restored
  */


### PR DESCRIPTION
Hi,

Since Unity7 is sort-of discontinued I switched to Gnome3, dash to dock provides most of the missing 
functionality for me.

However I always liked the look of the colorful side-bar that clearly indicated what applications are active. So I tried to replicate this functionality in dash-to-dock and I  think I succeeded.

![example](https://cloud.githubusercontent.com/assets/1238070/26582699/6469a65c-4542-11e7-9bd3-20a941250708.png)

I added a toggle to the Appearance tab to enable / disable the functionality.

I hope you like it.

* There is a small issue where you can only go up to 48px max icon size, since there seems to be a SVG scaling issue in Gtk itself, but other than that it works flawlessly.