### PR TITLE
Automatic Transparency

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -33,7 +33,7 @@ const LauncherAPI = Me.imports.launcherAPI;
 
 const DOCK_DWELL_CHECK_INTERVAL = 100;
 
-const State = {
+var State = {
     HIDDEN:  0,
     SHOWING: 1,
     SHOWN:   2,


### PR DESCRIPTION
Here is a proposal to imitate the work done upstream on the top bar. The idea is that the dash blends in more uniformly, by behaving according to the top bar's new transparency when 'free-floating'.

**Default behavior**
As of Gnome 3.26, the top bar will be only 20% opaque by default. Hence, as a proof-of-concept, I have modified the default behavior for the dash. I have lowered the default opacity from 80% to 20% (as upstream), and the transparency logic is now a bit different. So far we assumed that the dash was opaque, unless the opacity setting was used.

I have now inverted this logic: the dash is 20% opaque, unless the user decides to set the opacity (permanently) to something else.

**Option**
I did it this way for simplicity, but we can of course change how this is done. The setting could be a combo-box with a few options like "Default, Automatic, Permanent" or something like that.

**Regarding the code**
I tried to keep the `_updateSolidStyle()` function as close as possible to upstream, so that it's easier to update if something changes. There are of course some differences stemming from the dash's complexity:
 - The dash is not only on the primary monitor
 - The dash has a border (that can have a different opacity)
 - The dash can have a custom color

Also, I tried to limit the number of operations on this function, as it gets called very often, hence having an impact on CPU time and responsiveness.