### PR TITLE
Number Overlay: set color.

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -624,7 +624,7 @@ const MyAppIcon = new Lang.Class({
             x_align: St.Align.START, y_align: St.Align.START,
             x_expand: true, y_expand: true
         });
-        this._numberOverlayStyle = 'background-color: rgba(0,0,0,0.8);'
+        this._numberOverlayLabel.add_style_class_name('number-overlay');
         this._numberOverlayOrder = -1;
         this._numberOverlayBin.hide();
 
@@ -643,9 +643,7 @@ const MyAppIcon = new Lang.Class({
         let font_size = Math.round(Math.max(12, 0.3*natWidth) / scaleFactor);
         let size = Math.round(font_size*1.2);
         this._numberOverlayLabel.set_style(
-            this._numberOverlayStyle +
            'font-size: ' + font_size + 'px;' +
-           'text-align: center;' +
            'border-radius: ' + this.icon.iconSize + 'px;' +
            'width: ' + size + 'px; height: ' + size +'px;'
         );

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -95,7 +95,7 @@
     background: #2e3436;
 }
 
-.number-overlay {
+#dashtodockContainer .number-overlay {
     color: rgba(255,255,255,1);
     background-color: rgba(0,0,0,0.8);
     text-align: center;

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -94,3 +94,9 @@
 #dashtodockContainer.dashtodock #dash {
     background: #2e3436;
 }
+
+.number-overlay {
+    color: rgba(255,255,255,1);
+    background-color: rgba(0,0,0,0.8);
+    text-align: center;
+}


### PR DESCRIPTION
With some themes, the font is transparent and the overlay cannot be seen, reported here: https://github.com/jderose9/dash-to-panel/issues/182.

We can put the style in stylesheet.css, or in the code directly. I thought that have it in stylesheet.css was enough for theming, but since it's not, I guess it makes no difference. Let me know if you'd rather have it in stylesheet.css.