### PR TITLE
Emit 'toggled' signal to facilitate reconnecting to dock events

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1607,6 +1607,7 @@ const DockManager = new Lang.Class({
     _toggle: function() {
         this._deleteDocks();
         this._createDocks();
+        this.emit('toggled');
     },
 
     _bindSettingsChanges: function() {
@@ -1866,3 +1867,4 @@ const DockManager = new Lang.Class({
         Main.panel._rightCorner.actor.show();
     }
 });
+Signals.addSignalMethods(DockManager.prototype);


### PR DESCRIPTION
With the merging of the multi-monitor branch, the dock is no longer a single object but an array of objects. It would be nice to have a 'toggled' signal from the dockManager to let other extensions know when the dock(s) have been destroyed and recreated. This would facilitate reconnecting to the dock(s) events such as showing, hiding, and mouse hover.