### PR TITLE
Label: make sure it is still on the stage before updating it.

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -1156,7 +1156,9 @@ const MyShowAppsIconMenu = new Lang.Class({
  * This function is used for both extendShowAppsIcon and extendDashItemContainer
  */
 function itemShowLabel()  {
-    if (!this._labelText)
+    // Check if the label is still present at all. When switching workpaces, the
+    // item might have been destroyed in between.
+    if (!this._labelText || this.label.get_stage() == null)
       return;
 
     this.label.set_text(this._labelText);


### PR DESCRIPTION
Hi Michele,

This one was hard to pinpoint! Here is a small fix for a subtle error when using workspace isolation.

To trigger the error:
1) Activate workspace isolation
2) Hover the mouse on a non-favorite icon (so it will be destroyed when switching workspace)
3) Switch workspace, but do so *before* the icon label shows

What happens:
1) The dashItemContainer is destroyed when switching workspace
2) The label timeout is still running, and tries to set the text.

Error log:
```
clutter_text_get_editable: assertion 'CLUTTER_IS_TEXT (self)' failed
clutter_text_get_text: assertion 'CLUTTER_IS_TEXT (self)' failed
clutter_text_set_text: assertion 'CLUTTER_IS_TEXT (self)' failed
clutter_text_get_text: assertion 'CLUTTER_IS_TEXT (self)' failed
st_widget_get_theme_node called on the widget [0x55731b6bcb50 StLabel.dash-label ("(null)")] which is not in the stage.
```