### PR TITLE
Don't use markups in a normal string

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -240,7 +240,7 @@ msgstr "Afficher le raccourci <i>Afficher les Applications</i>"
 #: Settings.ui.h:43
 msgid "Move the applications button at the beginning of the dock."
 msgstr ""
-"Placer le raccourci <i>Afficher les Applications</i> en première position"
+"Placer le bouton des applications en première position"
 
 #: Settings.ui.h:44
 msgid "Animate <i>Show Applications</i>."


### PR DESCRIPTION
The original strings doesn't use markups and the code seems to expect a normal label, the current translation results in <i></i> to be displayed in the text.