### PR TITLE
Fixed a translation error in the italian locale

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -286,7 +286,7 @@ msgstr ""
 
 #: Settings.ui.h:53
 msgid "Scroll action"
-msgstr "Azione clic"
+msgstr "Azione scroll"
 
 #: Settings.ui.h:54
 msgid "Do nothing"


### PR DESCRIPTION
Just a quick fix to the locale. "Scroll action" has been named as "Azione clic" which is the one for "Clic action".