### PR TITLE
Monitor isolation: limit the impact of 'window-entered-monitor'.

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -128,7 +128,7 @@ var MyAppIcon = new Lang.Class({
             this._signalsHandler.addWithLabel('isolate-monitors', [
                 global.screen,
                 'window-entered-monitor',
-                Lang.bind(this, this.onWindowsChanged)
+                Lang.bind(this, this._onWindowEntered)
             ]);
         }
 
@@ -183,6 +183,16 @@ var MyAppIcon = new Lang.Class({
 
         if (this._scrollEventHandler)
             this.actor.disconnect(this._scrollEventHandler);
+    },
+
+    _onWindowEntered: function(metaScreen, monitorIndex, metaWin) {
+        let updateStyle = false;
+        let app = tracker.get_window_app(metaWin);
+        if (app.get_id() == this.app.get_id())
+            updateStyle = true;
+
+        if (updateStyle)
+            this.onWindowsChanged();
     },
 
     _optionalScrollCycleWindows: function() {

--- a/appIcons.js
+++ b/appIcons.js
@@ -188,7 +188,7 @@ var MyAppIcon = new Lang.Class({
     _onWindowEntered: function(metaScreen, monitorIndex, metaWin) {
         let updateStyle = false;
         let app = tracker.get_window_app(metaWin);
-        if (app.get_id() == this.app.get_id())
+        if (app && app.get_id() == this.app.get_id())
             updateStyle = true;
 
         if (updateStyle)

--- a/appIcons.js
+++ b/appIcons.js
@@ -115,9 +115,8 @@ var MyAppIcon = new Lang.Class({
         this._focusAppChangeId = tracker.connect('notify::focus-app',
                                                  Lang.bind(this,
                                                            this._onFocusAppChanged));
-        this._enteredMonitorId = global.screen.connect('window-entered-monitor',
-                                                       Lang.bind(this,
-                                                                 this.onWindowsChanged));
+
+        this._optionalIsolateMonitors();
 
         this._dots = null;
 
@@ -166,15 +165,22 @@ var MyAppIcon = new Lang.Class({
             this._focusAppChangeId = 0;
         }
 
-        if (this._enteredMonitorId > 0) {
-            global.screen.disconnect(this._enteredMonitorId);
-            this._enteredMonitorId = 0;
-        }
-
         this._signalsHandler.destroy();
 
         if (this._scrollEventHandler)
             this.actor.disconnect(this._scrollEventHandler);
+    },
+
+    _optionalIsolateMonitors: function() {
+        if (this._dtdSettings.get_boolean('isolate-monitors') &&
+            Main.layoutManager.monitors.length > 1) {
+            this._signalsHandler.removeWithLabel('isolate-monitors');
+            this._signalsHandler.addWithLabel('isolate-monitors', [
+                global.screen,
+                'window-entered-monitor',
+                Lang.bind(this, this.onWindowsChanged)
+            ]);
+        }
     },
 
     _optionalScrollCycleWindows: function() {


### PR DESCRIPTION
In Wayland sessions, this signal is needed to track the state of windows dragged from one monitor to another. However, the performance impact is questionable as it triggers a redraw of all icons' style quite often.

To limit this, we only really connect to this signal if 'isolate-monitors' is true, and if there are at least 2 monitors.