### PR TITLE
Load gettext dashtodock domain before calling gettext()

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -3,11 +3,11 @@
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Docking = Me.imports.docking;
 const Convenience = Me.imports.convenience;
+Convenience.initTranslations('dashtodock');
 
 let dockManager;
 
 function init() {
-    Convenience.initTranslations('dashtodock');
 }
 
 function enable() {


### PR DESCRIPTION
appIcons.js is assigning const __ = Gettext.gettext.
This is what enables to have "All windows" and other non Shell strings (dash to dock specific) translated.
However, the domain was set in init(), after this assignement, which was thus loading the GNOME Shell domain. Ensure we bind the domain before (which is a really fast call).