### PR TITLE
Dash: properly initialize the icon size.

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -179,12 +179,15 @@ var MyDash = new Lang.Class({
     Name: 'DashToDock.MyDash',
 
     _init: function(settings, remoteModel, monitorIndex) {
+        this._dtdSettings = settings;
+
+        // Initialize icon variables and size
         this._maxHeight = -1;
-        this.iconSize = 64;
+        this.iconSize = this._dtdSettings.get_int('dash-max-icon-size');
         this._availableIconSizes = baseIconSizes;
         this._shownInitially = false;
+        this._initializeIconSize(this.iconSize);
 
-        this._dtdSettings = settings;
         this._remoteModel = remoteModel;
         this._monitorIndex = monitorIndex;
         this._position = Utils.getPosition(settings);
@@ -902,7 +905,7 @@ var MyDash = new Lang.Class({
         });
     },
 
-    setIconSize: function(max_size, doNotAnimate) {
+    _initializeIconSize: function(max_size) {
         let max_allowed = baseIconSizes[baseIconSizes.length-1];
         max_size = Math.min(max_size, max_allowed);
 
@@ -914,6 +917,10 @@ var MyDash = new Lang.Class({
             });
             this._availableIconSizes.push(max_size);
         }
+    },
+
+    setIconSize: function(max_size, doNotAnimate) {
+        this._initializeIconSize(max_size);
 
         if (doNotAnimate)
             this._shownInitially = false;

--- a/docking.js
+++ b/docking.js
@@ -430,8 +430,6 @@ const DockedDash = new Lang.Class({
             this._paintId=0;
         }
 
-        this.dash.setIconSize(this._settings.get_int('dash-max-icon-size'), true);
-
         // Apply custome css class according to the settings
         this._themeManager.updateCustomTheme();
 


### PR DESCRIPTION
It took me some time to identify the culprit. I thought it was due to several calls to `_resetPosition`, but this was in fact due to quickly resizing the icons when initializing.

Hence, here we:
- Immediately set the icon size upon initilizing.
- Just in case we call `resetPosition` in succession, we all an `idle` call.

Results:
- faster and lighter initialization
- prevents flickering when unlocking the screen
- on Wayland: some windows used to not be maximized properly after unlocking

Addresses #454