### PR TITLE
Unity7 backlight: optional glossy effect

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -308,6 +308,11 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkCheckButton" id="apply_gloss_effect_checkbutton">
+                        <property name="label" translatable="yes">Apply glossy effect.</property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkBox">
                         <property name="can_focus">0</property>
                         <child>

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -288,6 +288,7 @@ var RunningIndicatorDots = class DashToDock_RunningIndicatorDots extends Running
                    'custom-theme-running-dots-border-width',
                    'custom-theme-customize-running-dots',
                    'unity-backlit-items',
+                   'apply-glossy-effect',
                    'running-indicator-dominant-color'];
 
         keys.forEach(function(key) {
@@ -311,7 +312,10 @@ var RunningIndicatorDots = class DashToDock_RunningIndicatorDots extends Running
         // Enable / Disable the backlight of running apps
         if (!Docking.DockManager.settings.get_boolean('apply-custom-theme') &&
             Docking.DockManager.settings.get_boolean('unity-backlit-items')) {
-            this._source._iconContainer.get_children()[1].set_style(this._glossyBackgroundStyle);
+            const [icon] = this._source._iconContainer.get_children();
+            icon.set_style(
+                Docking.DockManager.settings.get_boolean('apply-glossy-effect') ?
+                this._glossyBackgroundStyle : null);
             if (this._source.running)
                 this._enableBacklight();
             else

--- a/prefs.js
+++ b/prefs.js
@@ -20,7 +20,8 @@ try {
     imports.misc.extensionUtils;
 } catch (e) {
     const resource = Gio.Resource.load(
-        '/usr/share/gnome-shell/org.gnome.Extensions.src.gresource');
+        (GLib.getenv('JHBUILD_PREFIX') || '/usr') +
+        '/share/gnome-shell/org.gnome.Extensions.src.gresource');
     resource._register();
     imports.searchPath.push('resource:///org/gnome/Extensions/js');
 }

--- a/prefs.js
+++ b/prefs.js
@@ -995,6 +995,15 @@ var Settings = GObject.registerClass({
             this._builder.get_object('unity_backlit_items_switch'),
             'active', Gio.SettingsBindFlags.DEFAULT
         );
+        this._settings.bind('apply-glossy-effect',
+            this._builder.get_object('apply_gloss_effect_checkbutton'),
+            'active', Gio.SettingsBindFlags.DEFAULT
+        );
+        this._settings.bind('unity-backlit-items',
+            this._builder.get_object('apply_gloss_effect_checkbutton'),
+            'sensitive',
+            Gio.SettingsBindFlags.DEFAULT
+        );
 
         this._settings.bind('force-straight-corner',
             this._builder.get_object('force_straight_corner_switch'),

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -567,5 +567,10 @@
       <summary>Enable unity7 like glossy backlit items</summary>
       <description>Emulate the unity7 backlit glossy items behaviour</description>
     </key>
+    <key name="apply-glossy-effect" type="b">
+      <default>true</default>
+      <summary>Enable glossy effect</summary>
+      <description>Toggle the glossy effect of the unity7 backlit feature.</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
@micheleg Just a small PR on something I tried. I turned off the glossy effect and IMO it looks cleaner, especially if only a few apps are open.

I added an option for this. Here are a few screenshots:

![screenshot from 2017-10-02 19-02-29](https://user-images.githubusercontent.com/19195975/31103347-6c00435c-a7a4-11e7-9b88-7330561ee8ae.png)

**Before:**
![screenshot from 2017-10-02 19-01-51](https://user-images.githubusercontent.com/19195975/31103348-72c1ac76-a7a4-11e7-8084-ff0a6f98833a.png)

**After:**
![screenshot from 2017-10-02 19-04-31](https://user-images.githubusercontent.com/19195975/31103367-8e6f746c-a7a4-11e7-941d-9ee2210bfd79.png)