### PR TITLE
Update dockManager variable declaration for Gnome 3.26 GJS (mozjs52)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -4,7 +4,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Docking = Me.imports.docking;
 const Convenience = Me.imports.convenience;
 
-let dockManager;
+var dockManager;
 
 function init() {
     Convenience.initTranslations('dashtodock');


### PR DESCRIPTION
Dash-to-Dock's dockManager properties are not accessible by the workspaces-to-dock extension after locking/unlocking the Gnome 3.26 desktop or after disabling/enabling the extension (see https://github.com/passingthru67/workspaces-to-dock/issues/119). What's weird is that it seems to work fine on the initial login to the desktop. Changing the dockManager declaration from 'let' to 'var' fixes the issue.



