### PR TITLE
utils.js: Fix #586

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -31,7 +31,8 @@ const BasicHandler = new Lang.Class({
 
         // Skip first element of the arguments
         for (let i = 1; i < arguments.length; i++) {
-            this._storage[label].push( this._create(arguments[i]));
+            let item = this._storage[label];
+            item.push(this._create(arguments[i]));
         }
     },
 


### PR DESCRIPTION
This pull-request fixes (#586) the "reference to undefined property Symbol.toPrimitive" warning. It seems that gnome-shell 3.26 (or mozjs 52?) doesn't like the use of direct method calls on map elements. 
Anyways, I'm not a JS programmer :smile:.