### PR TITLE
RFC: Trash and Removable Device Icons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 UUID = dash-to-dock@micxgx.gmail.com
 BASE_MODULES = extension.js stylesheet.css metadata.json COPYING README.md
-EXTRA_MODULES = convenience.js dash.js docking.js appIcons.js appIconIndicators.js launcherAPI.js locations.js windowPreview.js intellihide.js prefs.js theming.js utils.js Settings.ui
+EXTRA_MODULES = convenience.js dash.js docking.js appIcons.js appIconIndicators.js fileManager1API.js launcherAPI.js locations.js windowPreview.js intellihide.js prefs.js theming.js utils.js Settings.ui
 EXTRA_MEDIA = logo.svg glossy.svg highlight_stacked_bg.svg highlight_stacked_bg_h.svg
 TOLOCALIZE =  prefs.js appIcons.js locations.js
 MSGSRC = $(wildcard po/*.po)

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 
 UUID = dash-to-dock@micxgx.gmail.com
 BASE_MODULES = extension.js stylesheet.css metadata.json COPYING README.md
-EXTRA_MODULES = convenience.js dash.js docking.js appIcons.js appIconIndicators.js launcherAPI.js windowPreview.js intellihide.js prefs.js theming.js utils.js Settings.ui
+EXTRA_MODULES = convenience.js dash.js docking.js appIcons.js appIconIndicators.js launcherAPI.js locations.js windowPreview.js intellihide.js prefs.js theming.js utils.js Settings.ui
 EXTRA_MEDIA = logo.svg glossy.svg highlight_stacked_bg.svg highlight_stacked_bg_h.svg
-TOLOCALIZE =  prefs.js appIcons.js
+TOLOCALIZE =  prefs.js appIcons.js locations.js
 MSGSRC = $(wildcard po/*.po)
 ifeq ($(strip $(DESTDIR)),)
 	INSTALLTYPE = local

--- a/Settings.ui
+++ b/Settings.ui
@@ -1332,6 +1332,90 @@
                     </child>
                   </object>
                 </child>
+                <child>
+                  <object class="GtkListBoxRow" id="listboxrow18">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkGrid" id="shrink_dash4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkSwitch" id="show_trash_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="shrink_dash_label4">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Show trash can</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow" id="listboxrow19">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkGrid" id="shrink_dash5">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkSwitch" id="show_mounts_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="shrink_dash_label5">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Show mounted volumes and devices</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
             <child type="label_item">

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -169,7 +169,7 @@ const RunningIndicatorBase = new Lang.Class({
 
         // In the case of workspace isolation, we need to hide the dots of apps with
         // no windows in the current workspace
-        if (this._source.app.state != Shell.AppState.STOPPED  && this._nWindows > 0)
+        if ((this._source.app.state != Shell.AppState.STOPPED || this._source.isLocation()) && this._nWindows > 0)
             this._isRunning = true;
         else
             this._isRunning = false;

--- a/dash.js
+++ b/dash.js
@@ -25,6 +25,7 @@ const Workspace = imports.ui.workspace;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Utils = Me.imports.utils;
 const AppIcons = Me.imports.appIcons;
+const Locations = Me.imports.locations;
 
 let DASH_ANIMATION_TIME = Dash.DASH_ANIMATION_TIME;
 let DASH_ITEM_LABEL_HIDE_TIME = Dash.DASH_ITEM_LABEL_HIDE_TIME;
@@ -277,6 +278,9 @@ var MyDash = new Lang.Class({
 
         this._appSystem = Shell.AppSystem.get_default();
 
+        // Trash Icon
+        this._trash = new Locations.Trash();
+
         this._signalsHandler.add([
             this._appSystem,
             'installed-changed',
@@ -304,6 +308,10 @@ var MyDash = new Lang.Class({
             Main.overview,
             'item-drag-cancelled',
             Lang.bind(this, this._onDragCancelled)
+        ], [
+            this._trash,
+            'changed',
+            Lang.bind(this, this._queueRedisplay)
         ]);
     },
 
@@ -746,6 +754,8 @@ var MyDash = new Lang.Class({
                 newApps.push(app);
             }
         }
+
+        newApps.push(this._trash.getApp());
 
         // Figure out the actual changes to the list of items; we iterate
         // over both the list of items currently in the dash and the list

--- a/dash.js
+++ b/dash.js
@@ -762,8 +762,13 @@ var MyDash = new Lang.Class({
             }
         }
 
-        Array.prototype.push.apply(newApps, this._removables.getApps());
-        newApps.push(this._trash.getApp());
+        if (this._dtdSettings.get_boolean('show-mounts')) {
+            Array.prototype.push.apply(newApps, this._removables.getApps());
+        }
+
+        if (this._dtdSettings.get_boolean('show-trash')) {
+            newApps.push(this._trash.getApp());
+        }
 
         // Figure out the actual changes to the list of items; we iterate
         // over both the list of items currently in the dash and the list

--- a/dash.js
+++ b/dash.js
@@ -278,6 +278,9 @@ var MyDash = new Lang.Class({
 
         this._appSystem = Shell.AppSystem.get_default();
 
+        // Remove Drive Icons
+        this._removables = new Locations.Removables();
+
         // Trash Icon
         this._trash = new Locations.Trash();
 
@@ -310,6 +313,10 @@ var MyDash = new Lang.Class({
             Lang.bind(this, this._onDragCancelled)
         ], [
             this._trash,
+            'changed',
+            Lang.bind(this, this._queueRedisplay)
+        ], [
+            this._removables,
             'changed',
             Lang.bind(this, this._queueRedisplay)
         ]);
@@ -755,6 +762,7 @@ var MyDash = new Lang.Class({
             }
         }
 
+        Array.prototype.push.apply(newApps, this._removables.getApps());
         newApps.push(this._trash.getApp());
 
         // Figure out the actual changes to the list of items; we iterate

--- a/docking.js
+++ b/docking.js
@@ -509,6 +509,18 @@ const DockedDash = new Lang.Class({
             })
         ], [
             this._settings,
+            'changed::show-trash',
+            Lang.bind(this, function() {
+                    this.dash.resetAppIcons();
+            })
+        ], [
+            this._settings,
+            'changed::show-mounts',
+            Lang.bind(this, function() {
+                    this.dash.resetAppIcons();
+            })
+        ], [
+            this._settings,
             'changed::show-running',
             Lang.bind(this, function() {
                     this.dash.resetAppIcons();

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -30,9 +30,18 @@ var FileManager1Client = new Lang.Class({
     _init: function() {
         this._signalsHandler = new Utils.GlobalSignalsHandler();
 
+        this._locationMap = new Map();
         this._proxy = new FileManager1Proxy(Gio.DBus.session,
                                             "org.freedesktop.FileManager1",
-                                            "/org/freedesktop/FileManager1");
+                                            "/org/freedesktop/FileManager1",
+                                            Lang.bind(this, function(initable, error) {
+            // Use async construction to avoid blocking on errors.
+            if (error) {
+                global.log(error);
+            } else {
+                this._updateLocationMap();
+            }
+        }));
 
         this._signalsHandler.add([
             this._proxy,
@@ -53,8 +62,6 @@ var FileManager1Client = new Lang.Class({
             'window-left-monitor',
             Lang.bind(this, this._updateLocationMap)
         ]);
-
-        this._updateLocationMap();
     },
 
     destroy: function() {

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -62,11 +62,17 @@ var FileManager1Client = new Lang.Class({
     },
 
     /**
-     * Return an array of windows that are showing a given location.
+     * Return an array of windows that are showing a location or
+     * sub-directories of that location.
      */
     getWindows: function(location) {
-        let ret = this._locationMap.get(location);
-        return ret ? ret : [];
+        let ret = [];
+        for (let [k,v] of this._locationMap) {
+            if (k.startsWith(location)) {
+                Array.prototype.push.apply(ret, v);
+            }
+        }
+        return ret;
     },
 
     _onPropertyChanged: function(proxy, changed, invalidated) {

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -1,0 +1,131 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Gio = imports.gi.Gio;
+const Lang = imports.lang;
+const Signals = imports.signals;
+
+const FileManager1Iface = '<node><interface name="org.freedesktop.FileManager1">\
+                               <property name="XUbuntuOpenLocationsXids" type="a{uas}" access="read"/>\
+                           </interface></node>';
+
+const FileManager1Proxy = Gio.DBusProxy.makeProxyWrapper(FileManager1Iface);
+
+/**
+ * This class implements a client for the org.freedesktop.FileManager1 dbus
+ * interface, and specifically for the XUbuntuOpenLocationsXids property that
+ * is not an official part of the interface. On Ubuntu, Nautilus has been
+ * patched to offer this additional property, and it maps file locations to
+ * Window XIDs, as the name suggests.
+ *
+ * When an unpatched Nautilus is running, we will never observe the property
+ * to contain anything interesting, but there will not be any correctness
+ * issues.
+ */
+var FileManager1Client = new Lang.Class({
+    Name: 'DashToDock.FileManager1Client',
+
+    _init: function() {
+        this._proxy = new FileManager1Proxy(Gio.DBus.session,
+                                            "org.freedesktop.FileManager1",
+                                            "/org/freedesktop/FileManager1");
+        this._proxy.connect('g-properties-changed',
+                            Lang.bind(this, this._onPropertyChanged));
+
+        // We must additionally listen for Screen events to know when to
+        // rebuild our location map when the set of available windows changes.
+        this._screenSignals = [];
+        this._screenSignals.push(
+            global.screen.connect('workspace-switched',
+                                  Lang.bind(this, this._updateLocationMap)));
+        this._screenSignals.push(
+            global.screen.connect('window-entered-monitor',
+                                  Lang.bind(this, this._updateLocationMap)));
+        this._screenSignals.push(
+            global.screen.connect('window-left-monitor',
+                                  Lang.bind(this, this._updateLocationMap)));
+        this._updateLocationMap();
+    },
+
+    destroy: function() {
+        for (let i = 0; i < this._screenSignals.length; i++) {
+            global.screen.disconnect(this._screenSignals[i]);
+        }
+    },
+
+    /**
+     * Return an array of windows that are showing a given location.
+     */
+    getWindows: function(location) {
+        let ret = this._locationMap.get(location);
+        return ret ? ret : [];
+    },
+
+    _onPropertyChanged: function(proxy, changed, invalidated) {
+        let property = changed.unpack();
+        if (property && 'XUbuntuOpenLocationsXids' in property) {
+            this._updateLocationMap();
+        }
+    },
+
+    _updateLocationMap: function() {
+        let xidToLocations = this._proxy.XUbuntuOpenLocationsXids;
+        let xidToWindow = getXidToWindow();
+
+        let locationToWindow = new Map();
+        for (let xid in xidToLocations) {
+            let locations = xidToLocations[xid];
+            for (let i = 0; i < locations.length; i++) {
+                let l = locations[i];
+                if (!locationToWindow.has(l)) {
+                    locationToWindow.set(l, []);
+                }
+                let window = xidToWindow.get(parseInt(xid));
+                if (window != null) {
+                    locationToWindow.get(l).push(window);
+                }
+            }
+        }
+        this._locationMap = locationToWindow;
+        this.emit('windows-changed');
+    }
+});
+Signals.addSignalMethods(FileManager1Client.prototype);
+
+/**
+ * Construct a map of XIDs to MetaWindows.
+ *
+ * This is somewhat annoying as you cannot lookup a window by
+ * XID in any way, and must iterate through all of them looking
+ * for a match.
+ */
+function getXidToWindow() {
+    let xidToWindow = new Map();
+
+    for (let i = 0; i < global.screen.n_workspaces; i++) {
+        let ws = global.screen.get_workspace_by_index(i);
+        ws.list_windows().map(function(w) {
+            let xid = guessWindowXID(w);
+	    if (xid != null) {
+                xidToWindow.set(parseInt(xid), w);
+            }
+        });
+    }
+    return xidToWindow;
+}
+
+/**
+ * Guesses the X ID of a window.
+ *
+ * This is the basic implementation that is sufficient for Nautilus
+ * windows. The pixel-saver extension has a much more complex
+ * implementation if we ever need it.
+ */
+function guessWindowXID(win) {
+    try {
+        return win.get_description().match(/0x[0-9a-f]+/)[0];
+    } catch (err) {
+        return null;
+    }
+}
+
+var fm1Client = new FileManager1Client();

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -76,7 +76,9 @@ var FileManager1Client = new Lang.Class({
         let ret = [];
         for (let [k,v] of this._locationMap) {
             if (k.startsWith(location)) {
-                Array.prototype.push.apply(ret, v);
+                for (let l of v) {
+                    ret.push(l);
+                }
             }
         }
         return ret;
@@ -98,12 +100,14 @@ var FileManager1Client = new Lang.Class({
             let locations = xidToLocations[xid];
             for (let i = 0; i < locations.length; i++) {
                 let l = locations[i];
+                // Use a set to deduplicate when a window has a
+                // location open in multiple tabs.
                 if (!locationToWindow.has(l)) {
-                    locationToWindow.set(l, []);
+                    locationToWindow.set(l, new Set());
                 }
                 let window = xidToWindow.get(parseInt(xid));
                 if (window != null) {
-                    locationToWindow.get(l).push(window);
+                    locationToWindow.get(l).add(window);
                 }
             }
         }

--- a/locations.js
+++ b/locations.js
@@ -1,0 +1,79 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const Lang = imports.lang;
+const Signals = imports.signals;
+const Shell = imports.gi.Shell;
+
+// Use __ () and N__() for the extension gettext domain, and reuse
+// the shell domain with the default _() and N_()
+const Gettext = imports.gettext.domain('dashtodock');
+const __ = Gettext.gettext;
+const N__ = function(e) { return e };
+
+/**
+ * This class maintains a Shell.App representing the Trash and keeps it
+ * up-to-date as the trash fills and is emptied over time.
+ */
+var Trash = new Lang.Class({
+    Name: 'DashToDock.Trash',
+
+    _init: function() {
+        this._file = Gio.file_new_for_uri('trash://');
+        this._monitor = this._file.monitor_directory(0, null);
+        this._lastEmpty = null;
+        this._empty = null;
+        this._signalId =
+            this._monitor.connect('changed',
+                                  Lang.bind(this, this._onTrashChange));
+        this._onTrashChange();
+    },
+
+    destroy: function() {
+        this._monitor.disconnect(this._signalId);
+    },
+
+    _onTrashChange: function() {
+        let children = this._file.enumerate_children('*', 0, null);
+        let count  = 0;
+        while (children.next_file(null) != null) {
+            count++;
+        }
+        children.close(null);
+        this._empty = count == 0;
+        if (this._lastEmpty != this._empty) {
+            this._makeApp();
+            this.emit('changed');
+        }
+    },
+
+    _makeApp: function() {
+        if (this._trashApp == null ||
+            this._lastEmpty != this._empty) {
+            let trashKeys = new GLib.KeyFile();
+            trashKeys.set_string('Desktop Entry', 'Name', __('Trash'));
+            trashKeys.set_string('Desktop Entry', 'Icon',
+                                 this._empty ? 'user-trash' : 'user-trash-full');
+            trashKeys.set_string('Desktop Entry', 'Type', 'Application');
+            trashKeys.set_string('Desktop Entry', 'Exec', 'gio open trash:///');
+            trashKeys.set_string('Desktop Entry', 'StartupNotify', 'true');
+            trashKeys.set_string('Desktop Entry', 'XdtdUri', 'trash:///');
+            if (!this._empty) {
+                trashKeys.set_string('Desktop Entry', 'Actions', 'empty-trash;');
+                trashKeys.set_string('Desktop Action empty-trash', 'Name', __('Empty Trash'));
+                trashKeys.set_string('Desktop Action empty-trash', 'Exec',
+                                     'dbus-send --print-reply --dest=org.gnome.Nautilus /org/gnome/Nautilus org.gnome.Nautilus.FileOperations.EmptyTrash');
+            }
+
+            let trashAppInfo = Gio.DesktopAppInfo.new_from_keyfile(trashKeys);
+            this._trashApp = new Shell.App({appInfo: trashAppInfo});
+            this._lastEmpty = this._empty;
+        }
+    },
+
+    getApp: function() {
+        return this._trashApp;
+    }
+});
+Signals.addSignalMethods(Trash.prototype);

--- a/locations.js
+++ b/locations.js
@@ -2,6 +2,7 @@
 
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
+const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const Signals = imports.signals;
 const Shell = imports.gi.Shell;
@@ -11,6 +12,9 @@ const Shell = imports.gi.Shell;
 const Gettext = imports.gettext.domain('dashtodock');
 const __ = Gettext.gettext;
 const N__ = function(e) { return e };
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Utils = Me.imports.utils;
 
 /**
  * This class maintains a Shell.App representing the Trash and keeps it
@@ -77,3 +81,175 @@ var Trash = new Lang.Class({
     }
 });
 Signals.addSignalMethods(Trash.prototype);
+
+/**
+ * This class maintains Shell.App representations for removable devices
+ * plugged into the system, and keeps the list of Apps up-to-date as
+ * devices come and go and are mounted and unmounted.
+ */
+var Removables = new Lang.Class({
+    Name: "DashToDock.Removables",
+
+    _init: function() {
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
+
+        this._monitor = Gio.VolumeMonitor.get();
+        this._volumeApps = []
+        this._mountApps = []
+
+        this._monitor.get_volumes().forEach(Lang.bind(this, function(volume) {
+            this._onVolumeAdded(this._monitor, volume);
+        }));
+
+        this._monitor.get_mounts().forEach(Lang.bind(this, function(mount) {
+            this._onMountAdded(this._monitor, mount);
+        }));
+
+        this._signalsHandler.add([
+            this._monitor,
+            'mount-added',
+            Lang.bind(this, this._onMountAdded)
+        ], [
+            this._monitor,
+            'mount-removed',
+            Lang.bind(this, this._onMountRemoved)
+        ], [
+            this._monitor,
+            'volume-added',
+            Lang.bind(this, this._onVolumeAdded)
+        ], [
+            this._monitor,
+            'volume-removed',
+            Lang.bind(this, this._onVolumeRemoved)
+        ]);
+    },
+
+    destroy: function() {
+        this._signalsHandler.destroy();
+    },
+
+    _getWorkingIconName: function(icon) {
+        if (icon instanceof Gio.ThemedIcon) {
+            let iconTheme = Gtk.IconTheme.get_default();
+            let names = icon.get_names();
+            for (let i = 0; i < names.length; i++) {
+                let iconName = names[i];
+                if (iconTheme.has_icon(iconName)) {
+                    return iconName;
+                }
+            }
+            return '';
+        } else {
+            return icon.to_string();
+        }
+    },
+
+    _onVolumeAdded: function(monitor, volume) {
+        if (!volume.can_mount()) {
+            return;
+        }
+
+        let activationRoot = volume.get_activation_root();
+        if (!activationRoot) {
+            // Can't offer to mount a device if we don't know
+            // where to mount it.
+            // These devices are usually ejectable so you
+            // don't normally unmount them anyway.
+            return;
+        }
+        let uri = GLib.uri_unescape_string(activationRoot.get_uri(), null);
+
+        let volumeKeys = new GLib.KeyFile();
+        volumeKeys.set_string('Desktop Entry', 'Name', volume.get_name());
+        volumeKeys.set_string('Desktop Entry', 'Icon', this._getWorkingIconName(volume.get_icon()));
+        volumeKeys.set_string('Desktop Entry', 'Type', 'Application');
+        volumeKeys.set_string('Desktop Entry', 'Exec', 'nautilus ' + uri);
+        volumeKeys.set_string('Desktop Entry', 'StartupNotify', 'true');
+        volumeKeys.set_string('Desktop Entry', 'Actions', 'mount;');
+        volumeKeys.set_string('Desktop Action mount', 'Name', __('Mount'));
+        volumeKeys.set_string('Desktop Action mount', 'Exec', 'gio mount ' + uri);
+        let volumeAppInfo = Gio.DesktopAppInfo.new_from_keyfile(volumeKeys);
+        let volumeApp = new Shell.App({appInfo: volumeAppInfo});
+        this._volumeApps.push(volumeApp);
+        this.emit('changed');
+    },
+
+    _onVolumeRemoved: function(monitor, volume) {
+        for (let i = 0; i < this._volumeApps.length; i++) {
+            let app = this._volumeApps[i];
+            if (app.get_name() == volume.get_name()) {
+                this._volumeApps.splice(i, 1);
+            }
+        }
+        this.emit('changed');
+    },
+
+    _onMountAdded: function(monitor, mount) {
+        // Filter out uninteresting mounts
+        if (!mount.can_eject() && !mount.can_unmount())
+            return;
+        if (mount.is_shadowed())
+            return;
+
+        let volume = mount.get_volume();
+        if (!volume || volume.get_identifier('class') == 'network') {
+            return;
+        }
+
+        let escapedUri = mount.get_root().get_uri()
+        let uri = GLib.uri_unescape_string(escapedUri, null);
+
+        let mountKeys = new GLib.KeyFile();
+        mountKeys.set_string('Desktop Entry', 'Name', mount.get_name());
+        mountKeys.set_string('Desktop Entry', 'Icon',
+                             this._getWorkingIconName(volume.get_icon()));
+        mountKeys.set_string('Desktop Entry', 'Type', 'Application');
+        mountKeys.set_string('Desktop Entry', 'Exec', 'gio open ' + uri);
+        mountKeys.set_string('Desktop Entry', 'StartupNotify', 'true');
+        mountKeys.set_string('Desktop Entry', 'XdtdUri', escapedUri);
+        mountKeys.set_string('Desktop Entry', 'Actions', 'unmount;');
+        if (mount.can_eject()) {
+            mountKeys.set_string('Desktop Action unmount', 'Name', __('Eject'));
+            mountKeys.set_string('Desktop Action unmount', 'Exec',
+                                 'gio mount -e ' + uri);
+        } else {
+            mountKeys.set_string('Desktop Entry', 'Actions', 'unmount;');
+            mountKeys.set_string('Desktop Action unmount', 'Name', __('Unmount'));
+            mountKeys.set_string('Desktop Action unmount', 'Exec',
+                                 'gio mount -u ' + uri);
+        }
+        let mountAppInfo = Gio.DesktopAppInfo.new_from_keyfile(mountKeys);
+        let mountApp = new Shell.App({appInfo: mountAppInfo});
+        this._mountApps.push(mountApp);
+        this.emit('changed');
+    },
+
+    _onMountRemoved: function(monitor, mount) {
+        for (let i = 0; i < this._mountApps.length; i++) {
+            let app = this._mountApps[i];
+            if (app.get_name() == mount.get_name()) {
+                this._mountApps.splice(i, 1);
+            }
+        }
+        this.emit('changed');
+    },
+
+    getApps: function() {
+        // When we have both a volume app and a mount app, we prefer
+        // the mount app.
+        let apps = new Map();
+        this._volumeApps.map(function(app) {
+           apps.set(app.get_name(), app);
+        });
+        this._mountApps.map(function(app) {
+           apps.set(app.get_name(), app);
+        });
+
+        let ret = [];
+        for (let app of apps.values()) {
+            ret.push(app);
+        }
+        return ret;
+    }
+});
+Signals.addSignalMethods(Removables.prototype);

--- a/prefs.js
+++ b/prefs.js
@@ -348,6 +348,14 @@ const Settings = new Lang.Class({
                             this._builder.get_object('show_favorite_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-trash',
+                            this._builder.get_object('show_trash_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-mounts',
+                            this._builder.get_object('show_mounts_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-show-apps-button',
                             this._builder.get_object('show_applications_button_switch'),
                             'active',

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -214,6 +214,16 @@
       <summary>Show favorites apps</summary>
       <description>Show or hide favorite appplications icons in the dash</description>
     </key>
+    <key type="b" name="show-trash">
+      <default>true</default>
+      <summary>Show trash can</summary>
+      <description>Show or hide the trash can icon in the dash</description>
+    </key>
+    <key type="b" name="show-mounts">
+      <default>true</default>
+      <summary>Show mounted volumes and devices</summary>
+      <description>Show or hide mounted volume and device icons in the dash</description>
+    </key>
     <key type="b" name="show-show-apps-button">
       <default>true</default>
       <summary>Show applications button</summary>


### PR DESCRIPTION
This set of changes adds Trash and Removable Device/Drive icons similar to what the Unity dock offers. 

I don't consider it a complete change at this point; I think the code organisation isn't correct, if nothing else, but I'm particularly interested in feedback on the way I created the icons using DesktopAppInfo.

Other obvious shortcomings:
- Lack of Translations
- Nautilus dependency in Empty Trash call
- No drag-and-drop for Trash (I don't personally care about this)
- 'Inauthentic' placement of Trash Icon

![dash](https://user-images.githubusercontent.com/512286/31319211-082454bc-ac14-11e7-88e7-85594521f0bf.png)