### PR TITLE
appIconIndicators: fix back backLight for workspace/monitor isolation.

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -330,6 +330,8 @@ const RunningIndicatorDots = new Lang.Class({
             this._source._iconContainer.get_children()[1].set_style(this._glossyBackgroundStyle);
             if (this._isRunning)
                 this._enableBacklight();
+            else
+                this._disableBacklight();
         } else {
             this._disableBacklight();
             this._source._iconContainer.get_children()[1].set_style(null);


### PR DESCRIPTION
Hi,

Just a quick fix for semi-broken monitor/ws isolation.

With the code reorganization (nice work btw! I still need to rebase some branches here and there), the backlights remain on when switching ws.