### PR TITLE
Trash and Removable Device Icons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 
 UUID = dash-to-dock@micxgx.gmail.com
 BASE_MODULES = extension.js stylesheet.css metadata.json COPYING README.md
-EXTRA_MODULES = dash.js docking.js appIcons.js appIconIndicators.js launcherAPI.js windowPreview.js intellihide.js prefs.js theming.js utils.js Settings.ui
+EXTRA_MODULES = dash.js docking.js appIcons.js appIconIndicators.js launcherAPI.js locations.js windowPreview.js intellihide.js prefs.js theming.js utils.js Settings.ui
 EXTRA_MEDIA = logo.svg glossy.svg highlight_stacked_bg.svg highlight_stacked_bg_h.svg
-TOLOCALIZE =  prefs.js appIcons.js
+TOLOCALIZE =  prefs.js appIcons.js locations.js
 MSGSRC = $(wildcard po/*.po)
 ifeq ($(strip $(DESTDIR)),)
 	INSTALLTYPE = local

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 UUID = dash-to-dock@micxgx.gmail.com
 BASE_MODULES = extension.js stylesheet.css metadata.json COPYING README.md
-EXTRA_MODULES = dash.js docking.js appIcons.js appIconIndicators.js launcherAPI.js locations.js windowPreview.js intellihide.js prefs.js theming.js utils.js Settings.ui
+EXTRA_MODULES = dash.js docking.js appIcons.js appIconIndicators.js fileManager1API.js launcherAPI.js locations.js windowPreview.js intellihide.js prefs.js theming.js utils.js Settings.ui
 EXTRA_MEDIA = logo.svg glossy.svg highlight_stacked_bg.svg highlight_stacked_bg_h.svg
 TOLOCALIZE =  prefs.js appIcons.js locations.js
 MSGSRC = $(wildcard po/*.po)

--- a/Settings.ui
+++ b/Settings.ui
@@ -1338,6 +1338,90 @@
                     </child>
                   </object>
                 </child>
+                <child>
+                  <object class="GtkListBoxRow" id="listboxrow18">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkGrid" id="shrink_dash4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkSwitch" id="show_trash_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="shrink_dash_label4">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Show trash can</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow" id="listboxrow19">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkGrid" id="shrink_dash5">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkSwitch" id="show_mounts_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="shrink_dash_label5">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Show mounted volumes and devices</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
             <child type="label_item">

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -165,7 +165,7 @@ var RunningIndicatorBase = class DashToDock_RunningIndicatorBase extends Indicat
 
         // In the case of workspace isolation, we need to hide the dots of apps with
         // no windows in the current workspace
-        if (this._source.app.state != Shell.AppState.STOPPED  && this._nWindows > 0)
+        if ((this._source.app.state != Shell.AppState.STOPPED || this._source.isLocation()) && this._nWindows > 0)
             this._isRunning = true;
         else
             this._isRunning = false;

--- a/appIcons.js
+++ b/appIcons.js
@@ -29,7 +29,7 @@ const Util = imports.misc.util;
 const Workspace = imports.ui.workspace;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const FileManager1API = Me.imports.fileManager1API;
+const Docking = Me.imports.docking;
 const Utils = Me.imports.utils;
 const WindowPreview = Me.imports.windowPreview;
 const AppIconIndicators = Me.imports.appIconIndicators;
@@ -134,11 +134,14 @@ var MyAppIcon = class DashToDock_AppIcon extends AppDisplay.AppIcon {
                 this._updateIndicatorStyle.bind(this)
             ]);
         }, this);
-        this._signalsHandler.add([
-            FileManager1API.fm1Client,
-            'windows-changed',
-            this.onWindowsChanged.bind(this)
-        ]);
+
+        if (this._location) {
+            this._signalsHandler.add([
+                Docking.DockManager.getDefault().fm1Client,
+                'windows-changed',
+                this.onWindowsChanged.bind(this)
+            ]);
+        }
 
         this._dtdSettings.connect('changed::scroll-action', () => {
             this._optionalScrollCycleWindows();
@@ -997,8 +1000,8 @@ const MyAppIconMenu = class DashToDock_MyAppIconMenu extends AppDisplay.AppIconM
 Signals.addSignalMethods(MyAppIconMenu.prototype);
 
 function getWindows(app, location) {
-    if (location != null) {
-        return FileManager1API.fm1Client.getWindows(location);
+    if (location != null && Docking.DockManager.getDefault().fm1Client) {
+        return Docking.DockManager.getDefault().fm1Client.getWindows(location);
     } else {
         return app.get_windows();
     }

--- a/dash.js
+++ b/dash.js
@@ -755,6 +755,7 @@ var MyDash = class DashToDock_MyDash {
             Array.prototype.push.apply(newApps, this._removables.getApps());
         } else if (this._removables) {
             this._signalsHandler.removeWithLabel('show-mounts');
+            this._removables.destroy();
             this._removables = null;
         }
 
@@ -769,6 +770,7 @@ var MyDash = class DashToDock_MyDash {
             newApps.push(this._trash.getApp());
         } else if (this._trash) {
             this._signalsHandler.removeWithLabel('show-trash');
+            this._trash.destroy();
             this._trash = null;
         }
 

--- a/dash.js
+++ b/dash.js
@@ -274,12 +274,6 @@ var MyDash = class DashToDock_MyDash {
 
         this._appSystem = Shell.AppSystem.get_default();
 
-        // Remove Drive Icons
-        this._removables = new Locations.Removables();
-
-        // Trash Icon
-        this._trash = new Locations.Trash();
-
         this._signalsHandler.add([
             this._appSystem,
             'installed-changed',
@@ -307,14 +301,6 @@ var MyDash = class DashToDock_MyDash {
             Main.overview,
             'item-drag-cancelled',
             this._onDragCancelled.bind(this)
-        ], [
-            this._trash,
-            'changed',
-            this._queueRedisplay.bind(this)
-        ], [
-            this._removables,
-            'changed',
-            this._queueRedisplay.bind(this)
         ]);
     }
 
@@ -758,8 +744,33 @@ var MyDash = class DashToDock_MyDash {
             }
         }
 
-        Array.prototype.push.apply(newApps, this._removables.getApps());
-        newApps.push(this._trash.getApp());
+        if (this._dtdSettings.get_boolean('show-mounts')) {
+            if (!this._removables) {
+                this._removables = new Locations.Removables();
+                this._signalsHandler.addWithLabel('show-mounts',
+                    [ this._removables,
+                      'changed',
+                      this._queueRedisplay.bind(this) ]);
+            }
+            Array.prototype.push.apply(newApps, this._removables.getApps());
+        } else if (this._removables) {
+            this._signalsHandler.removeWithLabel('show-mounts');
+            this._removables = null;
+        }
+
+        if (this._dtdSettings.get_boolean('show-trash')) {
+            if (!this._trash) {
+                this._trash = new Locations.Trash();
+                this._signalsHandler.addWithLabel('show-trash',
+                    [ this._trash,
+                      'changed',
+                      this._queueRedisplay.bind(this) ]);
+            }
+            newApps.push(this._trash.getApp());
+        } else if (this._trash) {
+            this._signalsHandler.removeWithLabel('show-trash');
+            this._trash = null;
+        }
 
         // Figure out the actual changes to the list of items; we iterate
         // over both the list of items currently in the dash and the list

--- a/dash.js
+++ b/dash.js
@@ -274,6 +274,9 @@ var MyDash = class DashToDock_MyDash {
 
         this._appSystem = Shell.AppSystem.get_default();
 
+        // Remove Drive Icons
+        this._removables = new Locations.Removables();
+
         // Trash Icon
         this._trash = new Locations.Trash();
 
@@ -306,6 +309,10 @@ var MyDash = class DashToDock_MyDash {
             this._onDragCancelled.bind(this)
         ], [
             this._trash,
+            'changed',
+            this._queueRedisplay.bind(this)
+        ], [
+            this._removables,
             'changed',
             this._queueRedisplay.bind(this)
         ]);
@@ -751,6 +758,7 @@ var MyDash = class DashToDock_MyDash {
             }
         }
 
+        Array.prototype.push.apply(newApps, this._removables.getApps());
         newApps.push(this._trash.getApp());
 
         // Figure out the actual changes to the list of items; we iterate

--- a/dash.js
+++ b/dash.js
@@ -25,6 +25,7 @@ const Workspace = imports.ui.workspace;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Utils = Me.imports.utils;
 const AppIcons = Me.imports.appIcons;
+const Locations = Me.imports.locations;
 
 let DASH_ANIMATION_TIME = Dash.DASH_ANIMATION_TIME;
 let DASH_ITEM_LABEL_HIDE_TIME = Dash.DASH_ITEM_LABEL_HIDE_TIME;
@@ -273,6 +274,9 @@ var MyDash = class DashToDock_MyDash {
 
         this._appSystem = Shell.AppSystem.get_default();
 
+        // Trash Icon
+        this._trash = new Locations.Trash();
+
         this._signalsHandler.add([
             this._appSystem,
             'installed-changed',
@@ -300,6 +304,10 @@ var MyDash = class DashToDock_MyDash {
             Main.overview,
             'item-drag-cancelled',
             this._onDragCancelled.bind(this)
+        ], [
+            this._trash,
+            'changed',
+            this._queueRedisplay.bind(this)
         ]);
     }
 
@@ -742,6 +750,8 @@ var MyDash = class DashToDock_MyDash {
                 newApps.push(app);
             }
         }
+
+        newApps.push(this._trash.getApp());
 
         // Figure out the actual changes to the list of items; we iterate
         // over both the list of items currently in the dash and the list

--- a/docking.js
+++ b/docking.js
@@ -483,6 +483,14 @@ var DockedDash = class DashToDock {
             () => { this.dash.resetAppIcons(); }
         ], [
             this._settings,
+            'changed::show-trash',
+            () => { this.dash.resetAppIcons(); }
+        ], [
+            this._settings,
+            'changed::show-mounts',
+            () => { this.dash.resetAppIcons(); }
+        ], [
+            this._settings,
             'changed::show-running',
             () => { this.dash.resetAppIcons(); }
         ], [

--- a/docking.js
+++ b/docking.js
@@ -485,11 +485,13 @@ var DockedDash = class DashToDock {
         ], [
             this._settings,
             'changed::show-trash',
-            () => { this.dash.resetAppIcons(); }
+            () => { this.dash.resetAppIcons(); },
+            Utils.SignalsHandlerFlags.CONNECT_AFTER,
         ], [
             this._settings,
             'changed::show-mounts',
-            () => { this.dash.resetAppIcons(); }
+            () => { this.dash.resetAppIcons(); },
+            Utils.SignalsHandlerFlags.CONNECT_AFTER
         ], [
             this._settings,
             'changed::show-running',

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -1,0 +1,218 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Gio = imports.gi.Gio;
+const Signals = imports.signals;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Utils = Me.imports.utils;
+
+const FileManager1Iface = '<node><interface name="org.freedesktop.FileManager1">\
+                               <property name="XUbuntuOpenLocationsXids" type="a{uas}" access="read"/>\
+                               <property name="OpenWindowsWithLocations" type="a{sas}" access="read"/>\
+                           </interface></node>';
+
+const FileManager1Proxy = Gio.DBusProxy.makeProxyWrapper(FileManager1Iface);
+
+/**
+ * This class implements a client for the org.freedesktop.FileManager1 dbus
+ * interface, and specifically for the OpenWindowsWithLocations property
+ * which is published by Nautilus, but is not an official part of the interface.
+ *
+ * The property is a map from window identifiers to a list of locations open in
+ * the window.
+ *
+ * While OpeWindowsWithLocations is part of upstream Nautilus, for many years
+ * prior, Ubuntu patched Nautilus to publish XUbuntuOpenLocationsXids, which is
+ * similar but uses Xids as the window identifiers instead of gtk window paths.
+ *
+ * When an old or unpatched Nautilus is running, we will observe the properties
+ * to always be empty arrays, but there will not be any correctness issues.
+ */
+var FileManager1Client = class DashToDock_FileManager1Client {
+
+    constructor() {
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
+
+        this._locationMap = new Map();
+        this._proxy = new FileManager1Proxy(Gio.DBus.session,
+                                            "org.freedesktop.FileManager1",
+                                            "/org/freedesktop/FileManager1",
+                                            (initable, error) => {
+            // Use async construction to avoid blocking on errors.
+            if (error) {
+                global.log(error);
+            } else {
+                this._updateLocationMap();
+            }
+        });
+
+        this._signalsHandler.add([
+            this._proxy,
+            'g-properties-changed',
+            this._onPropertyChanged.bind(this)
+        ], [
+            // We must additionally listen for Screen events to know when to
+            // rebuild our location map when the set of available windows changes.
+            global.workspace_manager,
+            'workspace-switched',
+            this._updateLocationMap.bind(this)
+        ], [
+            global.display,
+            'window-entered-monitor',
+            this._updateLocationMap.bind(this)
+        ], [
+            global.display,
+            'window-left-monitor',
+            this._updateLocationMap.bind(this)
+        ]);
+    }
+
+    destroy() {
+        this._signalsHandler.destroy();
+    }
+
+    /**
+     * Return an array of windows that are showing a location or
+     * sub-directories of that location.
+     */
+    getWindows(location) {
+        let ret = [];
+        for (let [k,v] of this._locationMap) {
+            if (k.startsWith(location)) {
+                for (let l of v) {
+                    ret.push(l);
+                }
+            }
+        }
+        return ret;
+    }
+
+    _onPropertyChanged(proxy, changed, invalidated) {
+        let property = changed.unpack();
+        if (property &&
+            ('XUbuntuOpenLocationsXids' in property ||
+             'OpenWindowsWithLocations' in property)) {
+            this._updateLocationMap();
+        }
+    }
+
+    _updateLocationMap() {
+        let properties = this._proxy.get_cached_property_names();
+        if (properties == null) {
+            // Nothing to check yet.
+            return;
+        }
+
+        if (properties.includes('OpenWindowsWithLocations')) {
+            this._updateFromPaths();
+        } else if (properties.includes('XUbuntuOpenLocationsXids')) {
+            this._updateFromXids();
+        }
+    }
+
+    _updateFromPaths() {
+        let pathToLocations = this._proxy.OpenWindowsWithLocations;
+        let pathToWindow = getPathToWindow();
+
+        let locationToWindow = new Map();
+        for (let path in pathToLocations) {
+            let locations = pathToLocations[path];
+            for (let i = 0; i < locations.length; i++) {
+                let l = locations[i];
+                // Use a set to deduplicate when a window has a
+                // location open in multiple tabs.
+                if (!locationToWindow.has(l)) {
+                    locationToWindow.set(l, new Set());
+                }
+                let window = pathToWindow.get(path);
+                if (window != null) {
+                    locationToWindow.get(l).add(window);
+                }
+            }
+        }
+        this._locationMap = locationToWindow;
+        this.emit('windows-changed');
+    }
+
+    _updateFromXids() {
+        let xidToLocations = this._proxy.XUbuntuOpenLocationsXids;
+        let xidToWindow = getXidToWindow();
+
+        let locationToWindow = new Map();
+        for (let xid in xidToLocations) {
+            let locations = xidToLocations[xid];
+            for (let i = 0; i < locations.length; i++) {
+                let l = locations[i];
+                // Use a set to deduplicate when a window has a
+                // location open in multiple tabs.
+                if (!locationToWindow.has(l)) {
+                    locationToWindow.set(l, new Set());
+                }
+                let window = xidToWindow.get(parseInt(xid));
+                if (window != null) {
+                    locationToWindow.get(l).add(window);
+                }
+            }
+        }
+        this._locationMap = locationToWindow;
+        this.emit('windows-changed');
+    }
+}
+Signals.addSignalMethods(FileManager1Client.prototype);
+
+/**
+ * Construct a map of gtk application window object paths to MetaWindows.
+ */
+function getPathToWindow() {
+    let pathToWindow = new Map();
+
+    for (let i = 0; i < global.workspace_manager.n_workspaces; i++) {
+        let ws = global.workspace_manager.get_workspace_by_index(i);
+        ws.list_windows().map(function(w) {
+            let path = w.get_gtk_window_object_path();
+	    if (path != null) {
+                pathToWindow.set(path, w);
+            }
+        });
+    }
+    return pathToWindow;
+}
+
+/**
+ * Construct a map of XIDs to MetaWindows.
+ *
+ * This is somewhat annoying as you cannot lookup a window by
+ * XID in any way, and must iterate through all of them looking
+ * for a match.
+ */
+function getXidToWindow() {
+    let xidToWindow = new Map();
+
+    for (let i = 0; i < global.workspace_manager.n_workspaces; i++) {
+        let ws = global.workspace_manager.get_workspace_by_index(i);
+        ws.list_windows().map(function(w) {
+            let xid = guessWindowXID(w);
+	    if (xid != null) {
+                xidToWindow.set(parseInt(xid), w);
+            }
+        });
+    }
+    return xidToWindow;
+}
+
+/**
+ * Guesses the X ID of a window.
+ *
+ * This is the basic implementation that is sufficient for Nautilus
+ * windows. The pixel-saver extension has a much more complex
+ * implementation if we ever need it.
+ */
+function guessWindowXID(win) {
+    try {
+        return win.get_description().match(/0x[0-9a-f]+/)[0];
+    } catch (err) {
+        return null;
+    }
+}
+
+var fm1Client = new FileManager1Client();

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -69,6 +69,7 @@ var FileManager1Client = class DashToDock_FileManager1Client {
 
     destroy() {
         this._signalsHandler.destroy();
+        this._proxy.run_dispose();
     }
 
     /**
@@ -214,5 +215,3 @@ function guessWindowXID(win) {
         return null;
     }
 }
-
-var fm1Client = new FileManager1Client();

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -76,15 +76,15 @@ var FileManager1Client = class DashToDock_FileManager1Client {
      * sub-directories of that location.
      */
     getWindows(location) {
-        let ret = [];
+        let ret = new Set();
         for (let [k,v] of this._locationMap) {
             if (k.startsWith(location)) {
                 for (let l of v) {
-                    ret.push(l);
+                    ret.add(l);
                 }
             }
         }
-        return ret;
+        return Array.from(ret);
     }
 
     _onPropertyChanged(proxy, changed, invalidated) {

--- a/locations.js
+++ b/locations.js
@@ -2,6 +2,7 @@
 
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
+const Gtk = imports.gi.Gtk;
 const Shell = imports.gi.Shell;
 const Signals = imports.signals;
 
@@ -10,6 +11,9 @@ const Signals = imports.signals;
 const Gettext = imports.gettext.domain('dashtodock');
 const __ = Gettext.gettext;
 const N__ = function(e) { return e };
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Utils = Me.imports.utils;
 
 /**
  * This class maintains a Shell.App representing the Trash and keeps it
@@ -83,3 +87,178 @@ var Trash = class DashToDock_Trash {
     }
 }
 Signals.addSignalMethods(Trash.prototype);
+
+/**
+ * This class maintains Shell.App representations for removable devices
+ * plugged into the system, and keeps the list of Apps up-to-date as
+ * devices come and go and are mounted and unmounted.
+ */
+var Removables = class DashToDock_Removables {
+
+    constructor() {
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
+
+        this._monitor = Gio.VolumeMonitor.get();
+        this._volumeApps = []
+        this._mountApps = []
+
+        this._monitor.get_volumes().forEach(
+            (volume) => {
+                this._onVolumeAdded(this._monitor, volume);
+            }
+        );
+
+        this._monitor.get_mounts().forEach(
+            (mount) => {
+                this._onMountAdded(this._monitor, mount);
+            }
+        );
+
+        this._signalsHandler.add([
+            this._monitor,
+            'mount-added',
+            this._onMountAdded.bind(this)
+        ], [
+            this._monitor,
+            'mount-removed',
+            this._onMountRemoved.bind(this)
+        ], [
+            this._monitor,
+            'volume-added',
+            this._onVolumeAdded.bind(this)
+        ], [
+            this._monitor,
+            'volume-removed',
+            this._onVolumeRemoved.bind(this)
+        ]);
+    }
+
+    destroy() {
+        this._signalsHandler.destroy();
+    }
+
+    _getWorkingIconName(icon) {
+        if (icon instanceof Gio.ThemedIcon) {
+            let iconTheme = Gtk.IconTheme.get_default();
+            let names = icon.get_names();
+            for (let i = 0; i < names.length; i++) {
+                let iconName = names[i];
+                if (iconTheme.has_icon(iconName)) {
+                    return iconName;
+                }
+            }
+            return '';
+        } else {
+            return icon.to_string();
+        }
+    }
+
+    _onVolumeAdded(monitor, volume) {
+        if (!volume.can_mount()) {
+            return;
+        }
+
+        let activationRoot = volume.get_activation_root();
+        if (!activationRoot) {
+            // Can't offer to mount a device if we don't know
+            // where to mount it.
+            // These devices are usually ejectable so you
+            // don't normally unmount them anyway.
+            return;
+        }
+        let uri = GLib.uri_unescape_string(activationRoot.get_uri(), null);
+
+        let volumeKeys = new GLib.KeyFile();
+        volumeKeys.set_string('Desktop Entry', 'Name', volume.get_name());
+        volumeKeys.set_string('Desktop Entry', 'Icon', this._getWorkingIconName(volume.get_icon()));
+        volumeKeys.set_string('Desktop Entry', 'Type', 'Application');
+        volumeKeys.set_string('Desktop Entry', 'Exec', 'gio open "' + uri + '"');
+        volumeKeys.set_string('Desktop Entry', 'StartupNotify', 'false');
+        volumeKeys.set_string('Desktop Entry', 'Actions', 'mount;');
+        volumeKeys.set_string('Desktop Action mount', 'Name', __('Mount'));
+        volumeKeys.set_string('Desktop Action mount', 'Exec', 'gio mount "' + uri + '"');
+        let volumeAppInfo = Gio.DesktopAppInfo.new_from_keyfile(volumeKeys);
+        let volumeApp = new Shell.App({appInfo: volumeAppInfo});
+        this._volumeApps.push(volumeApp);
+        this.emit('changed');
+    }
+
+    _onVolumeRemoved(monitor, volume) {
+        for (let i = 0; i < this._volumeApps.length; i++) {
+            let app = this._volumeApps[i];
+            if (app.get_name() == volume.get_name()) {
+                this._volumeApps.splice(i, 1);
+            }
+        }
+        this.emit('changed');
+    }
+
+    _onMountAdded(monitor, mount) {
+        // Filter out uninteresting mounts
+        if (!mount.can_eject() && !mount.can_unmount())
+            return;
+        if (mount.is_shadowed())
+            return;
+
+        let volume = mount.get_volume();
+        if (!volume || volume.get_identifier('class') == 'network') {
+            return;
+        }
+
+        let escapedUri = mount.get_root().get_uri()
+        let uri = GLib.uri_unescape_string(escapedUri, null);
+
+        let mountKeys = new GLib.KeyFile();
+        mountKeys.set_string('Desktop Entry', 'Name', mount.get_name());
+        mountKeys.set_string('Desktop Entry', 'Icon',
+                             this._getWorkingIconName(volume.get_icon()));
+        mountKeys.set_string('Desktop Entry', 'Type', 'Application');
+        mountKeys.set_string('Desktop Entry', 'Exec', 'gio open "' + uri + '"');
+        mountKeys.set_string('Desktop Entry', 'StartupNotify', 'false');
+        mountKeys.set_string('Desktop Entry', 'XdtdUri', escapedUri);
+        mountKeys.set_string('Desktop Entry', 'Actions', 'unmount;');
+        if (mount.can_eject()) {
+            mountKeys.set_string('Desktop Action unmount', 'Name', __('Eject'));
+            mountKeys.set_string('Desktop Action unmount', 'Exec',
+                                 'gio mount -e "' + uri + '"');
+        } else {
+            mountKeys.set_string('Desktop Entry', 'Actions', 'unmount;');
+            mountKeys.set_string('Desktop Action unmount', 'Name', __('Unmount'));
+            mountKeys.set_string('Desktop Action unmount', 'Exec',
+                                 'gio mount -u "' + uri + '"');
+        }
+        let mountAppInfo = Gio.DesktopAppInfo.new_from_keyfile(mountKeys);
+        let mountApp = new Shell.App({appInfo: mountAppInfo});
+        this._mountApps.push(mountApp);
+        this.emit('changed');
+    }
+
+    _onMountRemoved(monitor, mount) {
+        for (let i = 0; i < this._mountApps.length; i++) {
+            let app = this._mountApps[i];
+            if (app.get_name() == mount.get_name()) {
+                this._mountApps.splice(i, 1);
+            }
+        }
+        this.emit('changed');
+    }
+
+    getApps() {
+        // When we have both a volume app and a mount app, we prefer
+        // the mount app.
+        let apps = new Map();
+        this._volumeApps.map(function(app) {
+           apps.set(app.get_name(), app);
+        });
+        this._mountApps.map(function(app) {
+           apps.set(app.get_name(), app);
+        });
+
+        let ret = [];
+        for (let app of apps.values()) {
+            ret.push(app);
+        }
+        return ret;
+    }
+}
+Signals.addSignalMethods(Removables.prototype);

--- a/locations.js
+++ b/locations.js
@@ -135,6 +135,7 @@ var Removables = class DashToDock_Removables {
 
     destroy() {
         this._signalsHandler.destroy();
+        this._monitor.run_dispose();
     }
 
     _getWorkingIconName(icon) {

--- a/locations.js
+++ b/locations.js
@@ -1,0 +1,85 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const Shell = imports.gi.Shell;
+const Signals = imports.signals;
+
+// Use __ () and N__() for the extension gettext domain, and reuse
+// the shell domain with the default _() and N_()
+const Gettext = imports.gettext.domain('dashtodock');
+const __ = Gettext.gettext;
+const N__ = function(e) { return e };
+
+/**
+ * This class maintains a Shell.App representing the Trash and keeps it
+ * up-to-date as the trash fills and is emptied over time.
+ */
+var Trash = class DashToDock_Trash {
+
+    constructor() {
+        this._file = Gio.file_new_for_uri('trash://');
+        try {
+            this._monitor = this._file.monitor_directory(0, null);
+            this._signalId = this._monitor.connect(
+                'changed',
+                this._onTrashChange.bind(this));
+        } catch (e) {
+            log(`Unable to monitor trash: ${e}`);
+        }
+        this._lastEmpty = true;
+        this._empty = true;
+        this._onTrashChange();
+    }
+
+    destroy() {
+        if (this._monitor) {
+            this._monitor.disconnect(this._signalId);
+            this._monitor.run_dispose();
+        }
+        this._file.run_dispose();
+    }
+
+    _onTrashChange() {
+        try {
+            let children = this._file.enumerate_children('*', 0, null);
+            this._empty = children.next_file(null) == null;
+            children.close(null);
+        } catch (e) {
+            log(`Unable to enumerate trash children: ${e}`);
+        }
+
+        this._ensureApp();
+    }
+
+    _ensureApp() {
+        if (this._trashApp == null ||
+            this._lastEmpty != this._empty) {
+            let trashKeys = new GLib.KeyFile();
+            trashKeys.set_string('Desktop Entry', 'Name', __('Trash'));
+            trashKeys.set_string('Desktop Entry', 'Icon',
+                                 this._empty ? 'user-trash' : 'user-trash-full');
+            trashKeys.set_string('Desktop Entry', 'Type', 'Application');
+            trashKeys.set_string('Desktop Entry', 'Exec', 'gio open trash:///');
+            trashKeys.set_string('Desktop Entry', 'StartupNotify', 'false');
+            trashKeys.set_string('Desktop Entry', 'XdtdUri', 'trash:///');
+            if (!this._empty) {
+                trashKeys.set_string('Desktop Entry', 'Actions', 'empty-trash;');
+                trashKeys.set_string('Desktop Action empty-trash', 'Name', __('Empty Trash'));
+                trashKeys.set_string('Desktop Action empty-trash', 'Exec',
+                                     'dbus-send --print-reply --dest=org.gnome.Nautilus /org/gnome/Nautilus org.gnome.Nautilus.FileOperations.EmptyTrash');
+            }
+
+            let trashAppInfo = Gio.DesktopAppInfo.new_from_keyfile(trashKeys);
+            this._trashApp = new Shell.App({appInfo: trashAppInfo});
+            this._lastEmpty = this._empty;
+
+            this.emit('changed');
+        }
+    }
+
+    getApp() {
+        return this._trashApp;
+    }
+}
+Signals.addSignalMethods(Trash.prototype);

--- a/prefs.js
+++ b/prefs.js
@@ -481,6 +481,14 @@ var Settings = class DashToDock_Settings {
                             this._builder.get_object('show_favorite_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-trash',
+                            this._builder.get_object('show_trash_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-mounts',
+                            this._builder.get_object('show_mounts_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-show-apps-button',
                             this._builder.get_object('show_applications_button_switch'),
                             'active',

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -215,6 +215,16 @@
       <summary>Show favorites apps</summary>
       <description>Show or hide favorite appplications icons in the dash</description>
     </key>
+    <key type="b" name="show-trash">
+      <default>true</default>
+      <summary>Show trash can</summary>
+      <description>Show or hide the trash can icon in the dash</description>
+    </key>
+    <key type="b" name="show-mounts">
+      <default>true</default>
+      <summary>Show mounted volumes and devices</summary>
+      <description>Show or hide mounted volume and device icons in the dash</description>
+    </key>
     <key type="b" name="show-show-apps-button">
       <default>true</default>
       <summary>Show applications button</summary>


### PR DESCRIPTION
This is a re-submission after the original pull request ( #619 ) was accidentally merged and then unmerged.

This set of changes adds Trash and Removable Device/Drive icons similar to what the Unity dock offers.
- Trash icon that reflects whether trash is empty or not, and has an action to empty the trash
- Icons for removable devices and mounted volumes with unmount and eject actions (as appropriate)
- Preferences to control whether to show icons or not
- Window tracking using either the original extended Ubuntu fileManager1 api added for Unity, or the new upstream Nautilus version (which works with Wayland)

![dashtodock](https://user-images.githubusercontent.com/512286/35133848-693ff490-fc87-11e7-8df3-2c2cf08c3ba7.png)

To summarise the old discussion, this is mostly complete with a few issues that I wouldn't consider blockers:

- No drag and drop for trash. I think the best thing to do here is let the gnome shell folks implement this for [their desktop icons extension](https://gitlab.gnome.org/csoriano/org.gnome.desktop-icons) and then copy/use it. :-)
- Trash icon cannot be pinned to the bottom of the bar as in Unity. This could be done by someone with more knowledge than me but I really struggled to understand the St layout code.