### PR TITLE
appIconIndicators: fix some warnings.

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -244,11 +244,6 @@ const RunningIndicatorBase = new Lang.Class({
 
     destroy: function() {
         this.parent();
-        this._disableBacklight();
-        // Remove glossy background if the children still exists
-        if (this._source._iconContainer.get_children().length > 1)
-            this._source._iconContainer.get_children()[1].set_style(null);
-        this._restoreDefaultDot();
     }
 });
 
@@ -425,7 +420,6 @@ const RunningIndicatorDots = new Lang.Class({
 
     destroy: function() {
         this.parent();
-        this._area.destroy();
     }
 
 });


### PR DESCRIPTION
Newer versions of `gjs` (Debian testing, although I saw many Arch users complaining about similar things, since they got the update earlier) are more aggressive in showing warnings and errors. This is actually pretty great for debugging. I leave here a link with a neat stack trace showing that we sometimes try to access objects that were already removed from memory.
https://gist.github.com/franglais125/19e5160ca7040aefa5ea7ca699421242

What happens:
- Warnings appear when locking/unlocking the screen (upon calling `disable()`)
- The destroy() method gets only called upon an AppIcon destruction, which
actually deletes the `_source` object, within the `RunningIndicator` class.
- Hence, there is no need to reset the style when destroying.
- Also, `_area` is a child of `_source`, and is hence not available anymore upon destruction (this is a separate warning with the same root cause).

To note:
- this is a non-exhaustive patch, other fixes might be needed if new warnings appear
- more testing might be needed