### PR TITLE
http to https and a url fix

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -989,7 +989,7 @@ const DominantColorExtractor = new Lang.Class({
     /**
      * The backlight color choosing algorithm was mostly ported to javascript from the
      * Unity7 C++ source of Canonicals:
-     * http://bazaar.launchpad.net/~unity-team/unity/trunk/view/head:/launcher/LauncherIcon.cpp
+     * https://bazaar.launchpad.net/~unity-team/unity/trunk/view/head:/launcher/LauncherIcon.cpp
      * so it more or less works the same way.
      */
     _getColorPalette: function() {

--- a/convenience.js
+++ b/convenience.js
@@ -2,7 +2,7 @@
 
 /*
  * Part of this file comes from gnome-shell-extensions:
- * http://git.gnome.org/browse/gnome-shell-extensions/
+ * https://gitlab.gnome.org/GNOME/gnome-shell-extensions/
  */
 
 const Gettext = imports.gettext;


### PR DESCRIPTION
There are still 2 remaining http urls to be found in README.md that integrate the Flattr button. The button is broken, but you may want to remove it anyway and instead ask your visitors to use the Flattr extension which now seems to be the recommended method: [https://blog.flattr.com/2017/10/the-flattr-relaunch-what-to-expect/](https://blog.flattr.com/2017/10/the-flattr-relaunch-what-to-expect/)