### PR TITLE
theming: explicitly update solid style on showing the overview

### DIFF
--- a/theming.js
+++ b/theming.js
@@ -376,9 +376,13 @@ const Transparency = new Lang.Class({
             global.window_manager,
             'switch-workspace',
             Lang.bind(this, this._updateSolidStyle)
-        ],[
+        ], [
             Main.overview,
             'hiding',
+            Lang.bind(this, this._updateSolidStyle)
+        ], [
+            Main.overview,
+            'showing',
             Lang.bind(this, this._updateSolidStyle)
         ]);
 


### PR DESCRIPTION
Properly update top bar and dock styling with maximized windows in the overview when transparency-mode set is set to ADAPTIVE