### PR TITLE
use a wrapper to access to Screen, Workspacess and Monitor

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -114,7 +114,7 @@ var MyAppIcon = new Lang.Class({
             Main.layoutManager.monitors.length > 1) {
             this._signalsHandler.removeWithLabel('isolate-monitors');
             this._signalsHandler.addWithLabel('isolate-monitors', [
-                global.screen,
+                Utils.DisplayWrapper.getScreen(),
                 'window-entered-monitor',
                 Lang.bind(this, this._onWindowEntered)
             ]);
@@ -642,7 +642,7 @@ var MyAppIcon = new Lang.Class({
     _minimizeWindow: function(param) {
         // Param true make all app windows minimize
         let windows = this.getInterestingWindows();
-        let current_workspace = global.screen.get_active_workspace();
+        let current_workspace = Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace();
         for (let i = 0; i < windows.length; i++) {
             let w = windows[i];
             if (w.get_workspace() == current_workspace && w.showing_on_its_workspace()) {
@@ -666,7 +666,7 @@ var MyAppIcon = new Lang.Class({
 
         // then activate all other app windows in the current workspace
         let windows = this.getInterestingWindows();
-        let activeWorkspace = global.screen.get_active_workspace_index();
+        let activeWorkspace = Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace_index();
 
         if (windows.length <= 0)
             return;
@@ -944,7 +944,7 @@ const MyAppIconMenu = new Lang.Class({
 
             if (windows.length > 0) {
 
-                let activeWorkspace = global.screen.get_active_workspace();
+                let activeWorkspace = Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace();
                 let separatorShown =  windows[0].get_workspace() != activeWorkspace;
 
                 for (let i = 0; i < windows.length; i++) {
@@ -982,7 +982,7 @@ function getInterestingWindows(app, settings, monitorIndex) {
     // that are not in the current workspace
     if (settings.get_boolean('isolate-workspaces'))
         windows = windows.filter(function(w) {
-            return w.get_workspace().index() == global.screen.get_active_workspace_index();
+            return w.get_workspace().index() == Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace_index();
         });
 
     if (settings.get_boolean('isolate-monitors'))

--- a/docking.js
+++ b/docking.js
@@ -297,7 +297,7 @@ const DockedDash = new Lang.Class({
         ], [
             // update when workarea changes, for instance if  other extensions modify the struts
             //(like moving th panel at the bottom)
-            global.screen,
+            Utils.DisplayWrapper.getScreen(),
             'workareas-changed',
             Lang.bind(this, this._resetPosition)
         ], [
@@ -323,7 +323,7 @@ const DockedDash = new Lang.Class({
             'notify::checked',
             Lang.bind(this, this._syncShowAppsButtonToggled)
         ], [
-            global.screen,
+            Utils.DisplayWrapper.getScreen(),
             'in-fullscreen-changed',
             Lang.bind(this, this._updateBarrier)
         ], [
@@ -1291,7 +1291,7 @@ const DockedDash = new Lang.Class({
             if (Main.overview.visible && Main.overview.viewSelector.getActivePage() !== ViewSelector.ViewPage.WINDOWS)
                 return false;
 
-            let activeWs = global.screen.get_active_workspace();
+            let activeWs = Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace();
             let direction = null;
 
             switch (event.get_scroll_direction()) {
@@ -1584,7 +1584,7 @@ const WorkspaceIsolation = new Lang.Class({
 
         this._allDocks.forEach(function(dock) {
             this._signalsHandler.addWithLabel('isolation', [
-                global.screen,
+                Utils.DisplayWrapper.getScreen(),
                 'restacked',
                 Lang.bind(dock.dash, dock.dash._queueRedisplay)
             ], [
@@ -1597,7 +1597,7 @@ const WorkspaceIsolation = new Lang.Class({
             // might migrate from one monitor to another without triggering 'restacked'
             if (this._settings.get_boolean('isolate-monitors'))
                 this._signalsHandler.addWithLabel('isolation', [
-                    global.screen,
+                    Utils.DisplayWrapper.getScreen(),
                     'window-entered-monitor',
                     Lang.bind(dock.dash, dock.dash._queueRedisplay)
                 ]);
@@ -1608,13 +1608,13 @@ const WorkspaceIsolation = new Lang.Class({
         function IsolatedOverview() {
             // These lines take care of Nautilus for icons on Desktop
             let windows = this.get_windows().filter(function(w) {
-                return w.get_workspace().index() == global.screen.get_active_workspace_index();
+                return w.get_workspace().index() == Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace_index();
             });
             if (windows.length == 1)
                 if (windows[0].skip_taskbar)
                     return this.open_new_window(-1);
 
-            if (this.is_on_workspace(global.screen.get_active_workspace()))
+            if (this.is_on_workspace(Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace()))
                 return Main.activateWindow(windows[0]);
             return this.open_new_window(-1);
         }
@@ -1668,7 +1668,7 @@ var DockManager = new Lang.Class({
         // Connect relevant signals to the toggling function
         this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._signalsHandler.add([
-            global.screen,
+            Utils.DisplayWrapper.getMonitorManager(),
             'monitors-changed',
             Lang.bind(this, this._toggle)
         ], [

--- a/intellihide.js
+++ b/intellihide.js
@@ -76,7 +76,7 @@ var Intellihide = new Lang.Class({
         ], [
             // triggered for instance when the window list order changes,
             // included when the workspace is switched
-            global.screen,
+            Utils.DisplayWrapper.getScreen(),
             'restacked',
             Lang.bind(this, this._checkOverlap)
         ], [
@@ -87,9 +87,9 @@ var Intellihide = new Lang.Class({
             Lang.bind(this, this._checkOverlap)
         ], [
             // update wne monitor changes, for instance in multimonitor when monitor are attached
-            global.screen,
+            Utils.DisplayWrapper.getMonitorManager(),
             'monitors-changed',
-            Lang.bind(this, this._checkOverlap )
+            Lang.bind(this, this._checkOverlap)
         ]);
     },
 
@@ -249,7 +249,7 @@ var Intellihide = new Lang.Class({
         if (!this._handledWindow(wa))
             return false;
 
-        let currentWorkspace = global.screen.get_active_workspace_index();
+        let currentWorkspace = Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace_index();
         let wksp = meta_win.get_workspace();
         let wksp_index = wksp.index();
 

--- a/theming.js
+++ b/theming.js
@@ -473,7 +473,7 @@ const Transparency = new Lang.Class({
         if (this._dockActor.has_style_pseudo_class('overview'))
             return false;
         /* Get all the windows in the active workspace that are in the primary monitor and visible */
-        let activeWorkspace = global.screen.get_active_workspace();
+        let activeWorkspace = Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace();
         let dash = this._dash;
         let windows = activeWorkspace.list_windows().filter(function(metaWindow) {
             return metaWindow.get_monitor() === dash._monitorIndex &&
@@ -536,7 +536,7 @@ const Transparency = new Lang.Class({
 
         /* Get all the windows in the active workspace that are in the
          * primary monitor and visible */
-        let activeWorkspace = global.screen.get_active_workspace();
+        let activeWorkspace = Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace();
         let windows = activeWorkspace.list_windows().filter(function(metaWindow) {
             return metaWindow.is_on_primary_monitor() &&
                 metaWindow.showing_on_its_workspace() &&

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,6 @@
 const Clutter = imports.gi.Clutter;
 const Lang = imports.lang;
+const Meta = imports.gi.Meta;
 const St = imports.gi.St;
 
 /**
@@ -253,3 +254,17 @@ function drawRoundedLine(cr, x, y, width, height, isRoundLeft, isRoundRight, str
         cr.setSource(stroke);
     cr.stroke();
 }
+
+var DisplayWrapper = {
+    getScreen() {
+        return global.screen || global.display;
+    },
+
+    getWorkspaceManager() {
+        return global.screen || global.workspace_manager;
+    },
+
+    getMonitorManager() {
+        return global.screen || Meta.MonitorManager.get();
+    }
+};

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -272,7 +272,7 @@ const WindowPreviewList = new Lang.Class({
         }
 
         // Separate windows from other workspaces
-        let ws_index = global.screen.get_active_workspace_index();
+        let ws_index = Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace_index();
         let separator_index = 0;
         for (let i = 0; i < newWin.length; i++)
             if (newWin[i].get_workspace().index() == ws_index)
@@ -349,7 +349,7 @@ const WindowPreviewList = new Lang.Class({
     },
 
     sortWindowsCompareFunction: function(windowA, windowB) {
-        let ws_index = global.screen.get_active_workspace_index();
+        let ws_index = Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace_index();
         let winA_inActiveWS = windowA.get_workspace().index() == ws_index;
         let winB_inActiveWS = windowB.get_workspace().index() == ws_index;
 


### PR DESCRIPTION
As per [mutter xwayland-on-demand preparation branch refactory](https://gitlab.gnome.org/GNOME/mutter/merge_requests/95),
MetaScreen has been removed, thus replacing the dead objects.

Basically global.screen moved to global.display, while all the
workspace related features have been moved to the WorkspaceManager
and displays are managed by DisplayManager.