### PR TITLE
Settings.ui: Fix GtkEntry property to make the shortcut editable.

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -2849,7 +2849,7 @@ See the &lt;a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"&gt;G
                     <property name="column_spacing">32</property>
                     <child>
                       <object class="GtkEntry" id="shortcut_entry">
-                        <property name="can_focus">False</property>
+                        <property name="can_focus">True</property>
                         <property name="valign">center</property>
                         <property name="width_chars">12</property>
                       </object>


### PR DESCRIPTION
Should fix https://github.com/micheleg/dash-to-dock/issues/781.

The issue was introduced with the update of Settings.ui to Glade 3.22 [7afffc7c2916b54a0dee9fbdb92a39518be731e2].