### PR TITLE
dash, docking: remove Shell.GenericContainer

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -54,6 +54,7 @@ function extendDashItemContainer(dashItemContainer, settings) {
  */
 const MyDashActor = new Lang.Class({
     Name: 'DashToDock.MyDashActor',
+    Extends: St.Widget,
 
     _init: function(settings) {
         // a prefix is required to avoid conflicting with the parent class variable
@@ -68,24 +69,20 @@ const MyDashActor = new Lang.Class({
             orientation: this._isHorizontal ? Clutter.Orientation.HORIZONTAL : Clutter.Orientation.VERTICAL
         });
 
-        this.actor = new Shell.GenericContainer({
+        this.parent({
             name: 'dash',
             layout_manager: layout,
             clip_to_allocation: true
         });
-        this.actor.connect('get-preferred-width', Lang.bind(this, this._getPreferredWidth));
-        this.actor.connect('get-preferred-height', Lang.bind(this, this._getPreferredHeight));
-        this.actor.connect('allocate', Lang.bind(this, this._allocate));
-
-        this.actor._delegate = this;
     },
 
-    _allocate: function(actor, box, flags) {
+    vfunc_allocate: function(box, flags) {
+        this.set_allocation(box, flags);
         let contentBox = box;
         let availWidth = contentBox.x2 - contentBox.x1;
         let availHeight = contentBox.y2 - contentBox.y1;
 
-        let [appIcons, showAppsButton] = actor.get_children();
+        let [appIcons, showAppsButton] = this.get_children();
         let [showAppsMinHeight, showAppsNatHeight] = showAppsButton.get_preferred_height(availWidth);
         let [showAppsMinWidth, showAppsNatWidth] = showAppsButton.get_preferred_width(availHeight);
 
@@ -123,37 +120,35 @@ const MyDashActor = new Lang.Class({
         }
     },
 
-    _getPreferredWidth: function(actor, forHeight, alloc) {
+    vfunc_get_preferred_width: function(forHeight) {
         // We want to request the natural height of all our children
         // as our natural height, so we chain up to StWidget (which
         // then calls BoxLayout), but we only request the showApps
         // button as the minimum size
 
-        let [, natWidth] = this.actor.layout_manager.get_preferred_width(this.actor, forHeight);
+        let [, natWidth] = this.layout_manager.get_preferred_width(this, forHeight);
 
-        let themeNode = this.actor.get_theme_node();
-        let [, showAppsButton] = this.actor.get_children();
+        let themeNode = this.get_theme_node();
+        let [, showAppsButton] = this.get_children();
         let [minWidth, ] = showAppsButton.get_preferred_height(forHeight);
 
-        alloc.min_size = minWidth;
-        alloc.natural_size = natWidth;
+        return [minWidth, natWidth];
 
     },
 
-    _getPreferredHeight: function(actor, forWidth, alloc) {
+    vfunc_get_preferred_height: function(forWidth) {
         // We want to request the natural height of all our children
         // as our natural height, so we chain up to StWidget (which
         // then calls BoxLayout), but we only request the showApps
         // button as the minimum size
 
-        let [, natHeight] = this.actor.layout_manager.get_preferred_height(this.actor, forWidth);
+        let [, natHeight] = this.layout_manager.get_preferred_height(this, forWidth);
 
-        let themeNode = this.actor.get_theme_node();
-        let [, showAppsButton] = this.actor.get_children();
+        let themeNode = this.get_theme_node();
+        let [, showAppsButton] = this.get_children();
         let [minHeight, ] = showAppsButton.get_preferred_height(forWidth);
 
-        alloc.min_size = minHeight;
-        alloc.natural_size = natHeight;
+        return [minHeight, natHeight];
     }
 });
 
@@ -203,8 +198,7 @@ var MyDash = new Lang.Class({
         this._ensureAppIconVisibilityTimeoutId = 0;
         this._labelShowing = false;
 
-        this._containerObject = new MyDashActor(settings);
-        this._container = this._containerObject.actor;
+        this._container = new MyDashActor(settings);
         this._scrollView = new St.ScrollView({
             name: 'dashtodockDashScrollview',
             hscrollbar_policy: Gtk.PolicyType.NEVER,

--- a/docking.js
+++ b/docking.js
@@ -58,12 +58,10 @@ const scrollAction = {
  * The slidex parameter can be used to directly animate the sliding. The parent
  * must have a WEST (SOUTH) anchor_point to achieve the sliding to the RIGHT (BOTTOM)
  * side.
- *
- * It can't be an extended object because of this: https://bugzilla.gnome.org/show_bug.cgi?id=688973.
- * thus use the Shell.GenericContainer pattern.
 */
 const DashSlideContainer = new Lang.Class({
     Name: 'DashToDock.DashSlideContainer',
+    Extends: St.Widget,
 
     _init: function(params) {
         // Default local params
@@ -84,13 +82,7 @@ const DashSlideContainer = new Lang.Class({
             }
         }
 
-        this.actor = new Shell.GenericContainer(params);
-        this.actor.connect('get-preferred-width', Lang.bind(this, this._getPreferredWidth));
-        this.actor.connect('get-preferred-height', Lang.bind(this, this._getPreferredHeight));
-        this.actor.connect('allocate', Lang.bind(this, this._allocate));
-
-        this.actor._delegate = this;
-
+        this.parent(params);
         this._child = null;
 
         // slide parameter: 1 = visible, 0 = hidden.
@@ -99,13 +91,15 @@ const DashSlideContainer = new Lang.Class({
         this._slideoutSize = 0; // minimum size when slided out
     },
 
-    _allocate: function(actor, box, flags) {
+    vfunc_allocate: function(box, flags) {
+        this.set_allocation(box, flags);
+
         if (this._child == null)
             return;
 
         let availWidth = box.x2 - box.x1;
         let availHeight = box.y2 - box.y1;
-        let [minChildWidth, minChildHeight, natChildWidth, natChildHeight] =
+        let [, , natChildWidth, natChildHeight] =
             this._child.get_preferred_size();
 
         let childWidth = natChildWidth;
@@ -142,28 +136,25 @@ const DashSlideContainer = new Lang.Class({
     /**
      * Just the child width but taking into account the slided out part
      */
-    _getPreferredWidth: function(actor, forHeight, alloc) {
+    vfunc_get_preferred_width: function(forHeight) {
         let [minWidth, natWidth] = this._child.get_preferred_width(forHeight);
         if ((this._side ==  St.Side.LEFT) || (this._side == St.Side.RIGHT)) {
             minWidth = (minWidth - this._slideoutSize) * this._slidex + this._slideoutSize;
             natWidth = (natWidth - this._slideoutSize) * this._slidex + this._slideoutSize;
         }
-
-        alloc.min_size = minWidth;
-        alloc.natural_size = natWidth;
+        return [minWidth, natWidth];
     },
 
     /**
      * Just the child height but taking into account the slided out part
      */
-    _getPreferredHeight: function(actor, forWidth,  alloc) {
+    vfunc_get_preferred_height: function(forWidth) {
         let [minHeight, natHeight] = this._child.get_preferred_height(forWidth);
         if ((this._side ==  St.Side.TOP) || (this._side ==  St.Side.BOTTOM)) {
             minHeight = (minHeight - this._slideoutSize) * this._slidex + this._slideoutSize;
             natHeight = (natHeight - this._slideoutSize) * this._slidex + this._slideoutSize;
         }
-        alloc.min_size = minHeight;
-        alloc.natural_size = natHeight;
+        return [minHeight, natHeight];
     },
 
     /**
@@ -173,10 +164,10 @@ const DashSlideContainer = new Lang.Class({
     add_child: function(actor) {
         // I'm supposed to have only on child
         if (this._child !== null)
-            this.actor.remove_child(actor);
+            this.remove_child(actor);
 
         this._child = actor;
-        this.actor.add_child(actor);
+        this.parent(actor);
     },
 
     set slidex(value) {
@@ -361,7 +352,7 @@ const DockedDash = new Lang.Class({
                                               Lang.bind(Main.layoutManager, Main.layoutManager._queueUpdateRegions));
 
         this.dash._container.connect('allocation-changed', Lang.bind(this, this._updateStaticBox));
-        this._slider.actor.connect(this._isHorizontal ? 'notify::x' : 'notify::y', Lang.bind(this, this._updateStaticBox));
+        this._slider.connect(this._isHorizontal ? 'notify::x' : 'notify::y', Lang.bind(this, this._updateStaticBox));
 
         // sync hover after a popupmenu is closed
         this.dash.connect('menu-closed', Lang.bind(this, function() {
@@ -395,7 +386,7 @@ const DockedDash = new Lang.Class({
             Main.overview._overview.insert_child_at_index(this._dashSpacer, -1);
 
         // Add dash container actor and the container to the Chrome.
-        this.actor.set_child(this._slider.actor);
+        this.actor.set_child(this._slider);
         this._slider.add_child(this._box);
         this._box.add_actor(this.dash.actor);
 
@@ -406,10 +397,10 @@ const DockedDash = new Lang.Class({
             // Note: tracking the fullscreen directly on the slider actor causes some hiccups when fullscreening
             // windows of certain applications
             Main.layoutManager._trackActor(this.actor, {affectsInputRegion: false, trackFullscreen: true});
-            Main.layoutManager._trackActor(this._slider.actor, {affectsStruts: true});
+            Main.layoutManager._trackActor(this._slider, {affectsStruts: true});
         }
         else
-            Main.layoutManager._trackActor(this._slider.actor);
+            Main.layoutManager._trackActor(this._slider);
 
         // Set initial position
         this._resetDepth();
@@ -535,12 +526,12 @@ const DockedDash = new Lang.Class({
                     if (this._settings.get_boolean('dock-fixed')) {
                         Main.layoutManager._untrackActor(this.actor);
                         Main.layoutManager._trackActor(this.actor, {affectsInputRegion: false, trackFullscreen: true});
-                        Main.layoutManager._untrackActor(this._slider.actor);
-                        Main.layoutManager._trackActor(this._slider.actor, {affectsStruts: true});
+                        Main.layoutManager._untrackActor(this._slider);
+                        Main.layoutManager._trackActor(this._slider, {affectsStruts: true});
                     } else {
                         Main.layoutManager._untrackActor(this.actor);
-                        Main.layoutManager._untrackActor(this._slider.actor);
-                        Main.layoutManager._trackActor(this._slider.actor);
+                        Main.layoutManager._untrackActor(this._slider);
+                        Main.layoutManager._trackActor(this._slider);
                     }
 
                     this._resetPosition();
@@ -1154,8 +1145,8 @@ const DockedDash = new Lang.Class({
 
     _updateStaticBox: function() {
         this.staticBox.init_rect(
-            this.actor.x + this._slider.actor.x - (this._position == St.Side.RIGHT ? this._box.width : 0),
-            this.actor.y + this._slider.actor.y - (this._position == St.Side.BOTTOM ? this._box.height : 0),
+            this.actor.x + this._slider.x - (this._position == St.Side.RIGHT ? this._box.width : 0),
+            this.actor.y + this._slider.y - (this._position == St.Side.BOTTOM ? this._box.height : 0),
             this._box.width,
             this._box.height
         );


### PR DESCRIPTION
[It has been removed upstream](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/153), and extending components instead of compositing them with the delegate pattern is suggested.

We still might use composition by using fake St.Widgets that replicate the same locally, but I guess it's better to follow what upstream does.

Not sure if this means breaking old compatibility though.