### PR TITLE
 extension: Ensure signal disconnection 

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -21,20 +21,24 @@ function enable() {
      * Listen to enabled extension, if Dash to Dock is on the list or become active,
      * we disable this dock.
      */
-    dockManager=null; // even if declared, we need to initialize it to not trigger a referenceError.
     _extensionlistenerId = ExtensionSystem.connect('extension-state-changed',
                                                    conditionallyenabledock);
     conditionallyenabledock();
 }
 
 function disable() {
-    dockManager.destroy();
-
-    dockManager=null;
-
-    if (_extensionlistenerId) {
-        ExtensionSystem.disconnect(_extensionlistenerId);
-        _extensionlistenerId = 0;
+    try {
+        if (dockManager != null) {
+            dockManager.destroy();
+            dockManager = null;
+        }
+    } catch(e) {
+        log('Failed to destroy dockManager: %s'.format(e.message));
+    } finally {
+        if (_extensionlistenerId) {
+            ExtensionSystem.disconnect(_extensionlistenerId);
+            _extensionlistenerId = 0;
+        }
     }
 }
 

--- a/extension.js
+++ b/extension.js
@@ -43,13 +43,9 @@ function disable() {
 }
 
 function conditionallyenabledock() {
-    let to_enable = true;
-    let runningExtensions = ExtensionSystem.extensionOrder;
-    for (let i = 0; i < runningExtensions.length; i++) {
-        if (runningExtensions[i] === "dash-to-dock@micxgx.gmail.com") {
-            to_enable = false;
-        }
-    }
+    let to_enable = ExtensionSystem.extensionOrder.every((e) => {
+        return e != 'dash-to-dock@micxgx.gmail.com';
+    });
 
     // enable or disable dock depending on dock status and to_enable state
     if (to_enable && !dockManager) {


### PR DESCRIPTION
Make sure we disconnect from the 'extension-state-changed' signal in the disable
function even if dockManager failed to destroy properly. If we fail to
disconnect from that signal, conditionallyenabledock will be called when the
next extension is disabled, and ubuntu-dock will re-enable itself.