### PR TITLE
Avoid repainting an unchanging dock.

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -74,6 +74,11 @@ const MyDashActor = new Lang.Class({
             layout_manager: layout,
             clip_to_allocation: true
         });
+
+        // Since we are usually visible but not usually changing, make sure
+        // most repaint requests don't actually require us to repaint anything.
+        // This saves significant CPU when repainting the screen.
+        this.set_offscreen_redirect(Clutter.OffscreenRedirect.ALWAYS);
     },
 
     vfunc_allocate: function(box, flags) {


### PR DESCRIPTION
Since we are usually visible but not usually changing, make sure
most repaint requests don't actually require us to repaint anything.

This eliminates about a third of gnome-shell's CPU usage when a window
redraws while touching the dock.

https://launchpad.net/bugs/1743976