### PR TITLE
theming: Ensure _trackingWindows contains valid windows

### DIFF
--- a/theming.js
+++ b/theming.js
@@ -388,11 +388,13 @@ const Transparency = new Lang.Class({
         ]);
 
         // Window signals
-        global.get_window_actors().forEach(function(win) {
+        global.window_group.get_children().filter(function(child) {
             // An irrelevant window actor ('Gnome-shell') produces an error when the signals are
             // disconnected, therefore do not add signals to it.
-            if (win.get_meta_window().get_wm_class() !== 'Gnome-shell')
-                this._onWindowActorAdded(null, win);
+            return child instanceof Meta.WindowActor &&
+                   child.get_meta_window().get_wm_class() !== 'Gnome-shell';
+        }).forEach(function(win) {
+            this._onWindowActorAdded(null, win);
         }, this);
 
         if (this._settings.get_enum('transparency-mode') === TransparencyMode.ADAPTIVE)


### PR DESCRIPTION
Populate _trackedWindows using global.window_group.get_children() instead of
global.get_window_actors() to guarantee a window is removed from the
_trackedWindows map when the global.window_group 'actor-removed' signal is
received. Without this guarantee we might keep a reference to a destoyed window
actor, causing troubles when trying to disable the extension.

Fixes: https://github.com/micheleg/dash-to-dock/issues/641