### PR TITLE
theming: Ensure _trackingWindows contains valid windows 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gnome-shell-extension-ubuntu-dock (64ubuntu2) UNRELEASED; urgency=medium
+
+  * theming: Ensure _trackingWindows contains valid windows. (LP: #1769383)
+
+ -- Andrea Azzarone <andrea.azzarone@canonical.com>  Tue, 15 Jan 2019 15:47:54 +0000
+
 gnome-shell-extension-ubuntu-dock (64ubuntu1) disco; urgency=medium
 
   [ Marco Trevisan (Treviño) ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-gnome-shell-extension-ubuntu-dock (64ubuntu2) UNRELEASED; urgency=medium
+gnome-shell-extension-ubuntu-dock (64ubuntu2) disco; urgency=medium
 
   * theming: Ensure _trackingWindows contains valid windows. (LP: #1769383)
 

--- a/theming.js
+++ b/theming.js
@@ -388,11 +388,13 @@ const Transparency = new Lang.Class({
         ]);
 
         // Window signals
-        global.get_window_actors().forEach(function(win) {
+        global.window_group.get_children().filter(function(child) {
             // An irrelevant window actor ('Gnome-shell') produces an error when the signals are
             // disconnected, therefore do not add signals to it.
-            if (win.get_meta_window().get_wm_class() !== 'Gnome-shell')
-                this._onWindowActorAdded(null, win);
+            return child instanceof Meta.WindowActor &&
+                   child.get_meta_window().get_wm_class() !== 'Gnome-shell';
+        }).forEach(function(win) {
+            this._onWindowActorAdded(null, win);
         }, this);
 
         if (this._settings.get_enum('transparency-mode') === TransparencyMode.ADAPTIVE)


### PR DESCRIPTION
Populate _trackedWindows using global.window_group.get_children() instead of
global.get_window_actors() to guarantee a window is removed from the
_trackedWindows map when the global.window_group 'actor-removed' signal is
received. Without this guarantee we might keep a reference to a destoyed window
actor, causing troubles when trying to disable the extension.