### PR TITLE
Add support to workspace-grid extension

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1335,16 +1335,16 @@ const DockedDash = new Lang.Class({
                         Main.wm._workspaceSwitcherPopup = null;
                     });
 
-                // Do not show wokspaceSwithcer in overview
-                if (!Main.overview.visible)
-                    Main.wm._workspaceSwitcherPopup.display(direction, ws.index());
-
                 // If Workspace Grid is installed, let them handle the scroll behaviour.
                 if (Utils.DisplayWrapper.getWorkspaceManager().workspace_grid !== undefined)
-                    Utils.DisplayWrapper.getWorkspaceManager().workspace_grid
+                    ws = Utils.DisplayWrapper.getWorkspaceManager().workspace_grid
                         .actionMoveWorkspace(direction);
                 else
                     Main.wm.actionMoveWorkspace(ws);
+
+                // Do not show wokspaceSwithcer in overview
+                if (!Main.overview.visible)
+                    Main.wm._workspaceSwitcherPopup.display(direction, ws.index());
 
                 return true;
             }

--- a/docking.js
+++ b/docking.js
@@ -1321,7 +1321,12 @@ const DockedDash = new Lang.Class({
                 ws = activeWs.get_neighbor(direction)
 
                 if (Main.wm._workspaceSwitcherPopup == null)
-                    Main.wm._workspaceSwitcherPopup = new WorkspaceSwitcherPopup.WorkspaceSwitcherPopup();
+                    // Support Workspace Grid extension showing their custom Grid Workspace Switcher
+                    if (Utils.DisplayWrapper.getWorkspaceManager().workspace_grid !== undefined)
+                        Main.wm._workspaceSwitcherPopup = Utils.DisplayWrapper.getWorkspaceManager()
+                            .workspace_grid.getWorkspaceSwitcherPopup();
+                    else
+                        Main.wm._workspaceSwitcherPopup = new WorkspaceSwitcherPopup.WorkspaceSwitcherPopup();
                     // Set the actor non reactive, so that it doesn't prevent the
                     // clicks events from reaching the dash actor. I can't see a reason
                     // why it should be reactive.
@@ -1333,7 +1338,13 @@ const DockedDash = new Lang.Class({
                 // Do not show wokspaceSwithcer in overview
                 if (!Main.overview.visible)
                     Main.wm._workspaceSwitcherPopup.display(direction, ws.index());
-                Main.wm.actionMoveWorkspace(ws);
+
+                // If Workspace Grid is installed, let them handle the scroll behaviour.
+                if (Utils.DisplayWrapper.getWorkspaceManager().workspace_grid !== undefined)
+                    Utils.DisplayWrapper.getWorkspaceManager().workspace_grid
+                        .actionMoveWorkspace(direction);
+                else
+                    Main.wm.actionMoveWorkspace(ws);
 
                 return true;
             }


### PR DESCRIPTION
In this PR, support has been added to the [workspace grid](https://github.com/zakkak/workspace-grid) extension, in case the user has installed it. Previously, swapping the workspaces using the scroll over the dock was causing unexpected behavior when using the Dash to Dock in conjunction with the Workspaces Grid (jumping workspaces 2 in 2, 3 in 3, and so on) making it very annoying to use both extensions together.

To add support, functions exported by the Workspaces Grid extension were used.