### PR TITLE
Remove the Adaptive transparency mode.

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -2160,7 +2160,6 @@
                                     <items>
                                       <item translatable="yes">Default</item>
                                       <item translatable="yes">Fixed</item>
-                                      <item translatable="yes">Adaptive</item>
                                       <item translatable="yes">Dynamic</item>
                                     </items>
                                   </object>

--- a/prefs.js
+++ b/prefs.js
@@ -22,7 +22,6 @@ const DEFAULT_ICONS_SIZES = [ 128, 96, 64, 48, 32, 24, 16 ];
 const TransparencyMode = {
     DEFAULT:  0,
     FIXED:    1,
-    ADAPTIVE: 2,
     DYNAMIC:  3
 };
 
@@ -774,14 +773,12 @@ var Settings = class DashToDock_Settings {
                this._builder.get_object('custom_opacity_scale').set_sensitive(true);
         });
 
-        if (this._settings.get_enum('transparency-mode') !== TransparencyMode.ADAPTIVE &&
-            this._settings.get_enum('transparency-mode') !== TransparencyMode.DYNAMIC) {
+        if (this._settings.get_enum('transparency-mode') !== TransparencyMode.DYNAMIC) {
             this._builder.get_object('dynamic_opacity_button').set_sensitive(false);
         }
 
         this._settings.connect('changed::transparency-mode', () => {
-            if (this._settings.get_enum('transparency-mode') !== TransparencyMode.ADAPTIVE &&
-                this._settings.get_enum('transparency-mode') !== TransparencyMode.DYNAMIC) {
+            if (this._settings.get_enum('transparency-mode') !== TransparencyMode.DYNAMIC) {
                 this._builder.get_object('dynamic_opacity_button').set_sensitive(false);
             }
             else {

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -31,7 +31,6 @@
   <enum id='org.gnome.shell.extensions.dash-to-dock.transparency-mode'>
     <value value='0' nick='DEFAULT'/>
     <value value='1' nick='FIXED'/>
-    <value value='2' nick='ADAPTIVE'/>
     <value value='3' nick='DYNAMIC'/>
   </enum>
     <enum id='org.gnome.shell.extensions.dash-to-dock.running-indicator-style'>
@@ -78,7 +77,7 @@
     <key name="transparency-mode" enum="org.gnome.shell.extensions.dash-to-dock.transparency-mode">
       <default>'DEFAULT'</default>
       <summary>Transparency mode for the dock</summary>
-      <description>FIXED: constant transparency. ADAPTIVE: lock state with the top panel when not hidden. DYNAMIC: dock takes the opaque style only when windows are close to it.</description>
+      <description>FIXED: constant transparency. DYNAMIC: dock takes the opaque style only when windows are close to it.</description>
     </key>
     <key name="running-indicator-style" enum="org.gnome.shell.extensions.dash-to-dock.running-indicator-style">
       <default>'DEFAULT'</default>
@@ -93,7 +92,7 @@
     <key type="b" name="customize-alphas">
       <default>false</default>
       <summary>Manually set the min and max opacity</summary>
-      <description>For Adaptive and Dynamic modes, the min/max opacity values will be given by 'min-alpha' and 'max-alpha'.</description>
+      <description>For the dynamic mode, the min/max opacity values will be given by 'min-alpha' and 'max-alpha'.</description>
     </key>
     <key type="d" name="min-alpha">
       <default>0.2</default>


### PR DESCRIPTION
The panel dynamic transparency was dropped upstream:

https://gitlab.gnome.org/GNOME/gnome-shell/commit/9cfb51c106abd1f96012bf39f3d329cf060035cf

so this option does not make sense any more.

@3v1n0 @azzar1 : any objection? Is this something you are planning to keep supporting in Ubuntu? I'm even considering dropping the 'Dynamic' mode all together.