### PR TITLE
Fix Polish translation header

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -3,7 +3,7 @@
 # This file is distributed under the same license as the dash-to-dock package.
 # 
 # 
-# Piotr Sokół <psokol.l10n@gmail.com>, 2012, 2013, 2015, 2016, 2017., 2017.
+# Piotr Sokół <psokol.l10n@gmail.com>, 2012, 2013, 2015, 2016, 2017.
 #
 msgid ""
 msgstr ""


### PR DESCRIPTION
The Polish translation has a Windows line ending which causes problems for at least Launchpad's importer.

I believe this issue was caused by the gtranslator app. The app has gotten updates recently so hopefully that bug was fixed.