### PR TITLE
Ubuntu depends working version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,11 @@
-gnome-shell-extension-ubuntu-dock (64ubuntu4) UNRELEASED; urgency=medium
+gnome-shell-extension-ubuntu-dock (64ubuntu4) disco; urgency=medium
 
   * Re-upload to disco, with a dependency on gnome-shell versions that this
     extension is declared to work on in its metadata.json:
     - >= 3.31
     - << 3.33
 
- -- Iain Lane <iain@orangesquash.org.uk>  Sun, 24 Feb 2019 20:09:56 +0000
+ -- Iain Lane <iain@orangesquash.org.uk>  Sun, 24 Feb 2019 20:19:55 +0000
 
 gnome-shell-extension-ubuntu-dock (64ubuntu3) disco; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+gnome-shell-extension-ubuntu-dock (64ubuntu4) UNRELEASED; urgency=medium
+
+  * Re-upload to disco, with a dependency on gnome-shell versions that this
+    extension is declared to work on in its metadata.json:
+    - >= 3.31
+    - << 3.33
+
+ -- Iain Lane <iain@orangesquash.org.uk>  Sun, 24 Feb 2019 20:09:56 +0000
+
 gnome-shell-extension-ubuntu-dock (64ubuntu3) disco; urgency=medium
 
   [ Andrea Azzarone ]

--- a/debian/control
+++ b/debian/control
@@ -12,8 +12,10 @@ Homepage: https://github.com/micheleg/dash-to-dock/blob/ubuntu-dock/README.md
 
 Package: gnome-shell-extension-ubuntu-dock
 Architecture: all
-Depends: ${shlibs:Depends},
+Depends: gnome-shell (<< 3.33),
+         gnome-shell (>= 3.31),
          ${misc:Depends},
+         ${shlibs:Depends}
 Replaces: gnome-shell-extension-dashtodock,
 Description: Ubuntu Dock for GNOME Shell
  A dock for the Gnome Shell, default Ubuntu experience.


### PR DESCRIPTION
The previous version got into disco release before the gnome-shell that it needed. i.e. it broke the version of shell that people were using. We can add some dependencies to make sure this doesn't happen, and re-upload.

I'm uploading this to disco now. Please could you also pull the ubuntu-dock-64ubuntu4 tag from my fork?

/cc @3v1n0 