### PR TITLE
appIcons: Add Focus or Previews click action

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -85,6 +85,7 @@
                           <item translatable="yes">Minimize or overview</item>
                           <item translatable="yes">Show window previews</item>
                           <item translatable="yes">Minimize or show previews</item>
+                          <item translatable="yes">Focus or show previews</item>
                           <item translatable="yes">Quit</item>
                         </items>
                       </object>
@@ -157,6 +158,7 @@
                           <item translatable="yes">Minimize or overview</item>
                           <item translatable="yes">Show window previews</item>
                           <item translatable="yes">Minimize or show previews</item>
+                          <item translatable="yes">Focus or show previews</item>
                           <item translatable="yes">Quit</item>
                         </items>
                       </object>
@@ -229,6 +231,7 @@
                           <item translatable="yes">Minimize or overview</item>
                           <item translatable="yes">Show window previews</item>
                           <item translatable="yes">Minimize or show previews</item>
+                          <item translatable="yes">Focus or show previews</item>
                           <item translatable="yes">Quit</item>
                         </items>
                       </object>
@@ -1589,6 +1592,7 @@
                                   <item translatable="yes">Minimize or overview</item>
                                   <item translatable="yes">Show window previews</item>
                                   <item translatable="yes">Minimize or show previews</item>
+                                  <item translatable="yes">Focus or show previews</item>
                                 </items>
                               </object>
                               <packing>

--- a/appIcons.js
+++ b/appIcons.js
@@ -45,7 +45,8 @@ const clickAction = {
     MINIMIZE_OR_OVERVIEW: 4,
     PREVIEWS: 5,
     MINIMIZE_OR_PREVIEWS: 6,
-    QUIT: 7
+    FOCUS_OR_PREVIEWS: 7,
+    QUIT: 8,
 };
 
 const scrollAction = {
@@ -452,6 +453,17 @@ var MyAppIcon = class DashToDock_AppIcon extends AppDisplay.AppIcon {
                 }
                 else
                     this.app.activate();
+                break;
+
+            case clickAction.FOCUS_OR_PREVIEWS:
+                if (this.app == focusedApp &&
+                    (windows.length > 1 || modifiers || button != 1)) {
+                    this._windowPreviews();
+                } else {
+                    // Activate the first window
+                    let w = windows[0];
+                    Main.activateWindow(w);
+                }
                 break;
 
             case clickAction.LAUNCH:

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -8,7 +8,8 @@
     <value value='4' nick='minimize-or-overview'/>
     <value value='5' nick='previews'/>
     <value value='6' nick='minimize-or-previews'/>
-    <value value='7' nick='quit'/>
+    <value value='7' nick='focus-or-previews'/>
+    <value value='8' nick='quit'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-dock.scrollAction'>
     <value value='0' nick='do-nothing'/>


### PR DESCRIPTION
When clicking over an icon the last used application window will be focused; in
case the application is already the focused one, then we open the previews.

This allows to reduce the clicks when using multiple application icons to go
back and forth windows.