### PR TITLE
windowPreview: Use symbolic icon for close button

### DIFF
--- a/windowPreview.js
+++ b/windowPreview.js
@@ -336,6 +336,7 @@ var WindowPreviewMenuItem = class DashToDock_WindowPreviewMenuItem extends Popup
         this.closeButton = new St.Button({ style_class: 'window-close',
                                           x_expand: true,
                                           y_expand: true});
+        this.closeButton.add_actor(new St.Icon({ icon_name: 'window-close-symbolic' }));
         this.closeButton.set_x_align(Clutter.ActorAlign.END);
         this.closeButton.set_y_align(Clutter.ActorAlign.START);
 


### PR DESCRIPTION
As per upstream commit 4d2dce2c, the actual close button is generated using
custom css and a symbolic icon.

Apply the same change to dash-to-dock too, or the window preview close button
will miss the 'x'.