### PR TITLE
Don't reset border-radius for shrinked dash

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -8,27 +8,23 @@
 #dashtodockContainer.shrink.left #dash,
 #dashtodockContainer.dashtodock.left #dash {
     border-left: 0px;
-    border-radius: 0px 9px 9px 0px;
 }
 
 
 #dashtodockContainer.shrink.right #dash,
 #dashtodockContainer.dashtodock.right #dash {
     border-right: 0px;
-    border-radius: 9px 0px 0px 9px;
 }
 
 
 #dashtodockContainer.shrink.top #dash,
 #dashtodockContainer.dashtodock.top #dash {
     border-top: 0px;
-    border-radius: 0px 0px 9px 9px;
 }
 
 #dashtodockContainer.shrink.bottom #dash,
 #dashtodockContainer.dashtodock.bottom #dash {
     border-bottom: 0px;
-    border-radius: 9px 9px 0px 0px;
 }
 
 #dashtodockContainer.straight-corner #dash,

--- a/theming.js
+++ b/theming.js
@@ -234,53 +234,51 @@ var ThemeManager = class DashToDock_ThemeManager {
         let newStyle = '';
         let position = Utils.getPosition(this._settings);
 
-        if (!this._settings.get_boolean('custom-theme-shrink')) {
-            // obtain theme border settings
-            let themeNode = this._dash._container.get_theme_node();
-            let borderColor = themeNode.get_border_color(St.Side.TOP);
-            let borderWidth = themeNode.get_border_width(St.Side.TOP);
-            let borderRadius = themeNode.get_border_radius(St.Corner.TOPRIGHT);
+        // obtain theme border settings
+        let themeNode = this._dash._container.get_theme_node();
+        let borderColor = themeNode.get_border_color(St.Side.TOP);
+        let borderWidth = themeNode.get_border_width(St.Side.TOP);
+        let borderRadius = themeNode.get_border_radius(St.Corner.TOPRIGHT);
 
-            // We're copying border and corner styles to left border and top-left
-            // corner, also removing bottom border and bottom-right corner styles
-            let borderInner = '';
-            let borderRadiusValue = '';
-            let borderMissingStyle = '';
+        // We're copying border and corner styles to left border and top-left
+        // corner, also removing bottom border and bottom-right corner styles
+        let borderInner = '';
+        let borderRadiusValue = '';
+        let borderMissingStyle = '';
 
-            if (this._rtl && (position != St.Side.RIGHT))
-                borderMissingStyle = 'border-right: ' + borderWidth + 'px solid ' +
-                       borderColor.to_string() + ';';
-            else if (!this._rtl && (position != St.Side.LEFT))
-                borderMissingStyle = 'border-left: ' + borderWidth + 'px solid ' +
-                       borderColor.to_string() + ';';
+        if (this._rtl && (position != St.Side.RIGHT))
+            borderMissingStyle = 'border-right: ' + borderWidth + 'px solid ' +
+                   borderColor.to_string() + ';';
+        else if (!this._rtl && (position != St.Side.LEFT))
+            borderMissingStyle = 'border-left: ' + borderWidth + 'px solid ' +
+                   borderColor.to_string() + ';';
 
-            switch (position) {
-            case St.Side.LEFT:
-                borderInner = 'border-left';
-                borderRadiusValue = '0 ' + borderRadius + 'px ' + borderRadius + 'px 0;';
-                break;
-            case St.Side.RIGHT:
-                borderInner = 'border-right';
-                borderRadiusValue = borderRadius + 'px 0 0 ' + borderRadius + 'px;';
-                break;
-            case St.Side.TOP:
-                borderInner = 'border-top';
-                borderRadiusValue = '0 0 ' + borderRadius + 'px ' + borderRadius + 'px;';
-                break;
-            case St.Side.BOTTOM:
-                borderInner = 'border-bottom';
-                borderRadiusValue = borderRadius + 'px ' + borderRadius + 'px 0 0;';
-                break;
-            }
-
-            newStyle = borderInner + ': none;' +
-                'border-radius: ' + borderRadiusValue +
-                borderMissingStyle;
-
-            // I do call set_style possibly twice so that only the background gets the transition.
-            // The transition-property css rules seems to be unsupported
-            this._dash._container.set_style(newStyle);
+        switch (position) {
+        case St.Side.LEFT:
+            borderInner = 'border-left';
+            borderRadiusValue = '0 ' + borderRadius + 'px ' + borderRadius + 'px 0;';
+            break;
+        case St.Side.RIGHT:
+            borderInner = 'border-right';
+            borderRadiusValue = borderRadius + 'px 0 0 ' + borderRadius + 'px;';
+            break;
+        case St.Side.TOP:
+            borderInner = 'border-top';
+            borderRadiusValue = '0 0 ' + borderRadius + 'px ' + borderRadius + 'px;';
+            break;
+        case St.Side.BOTTOM:
+            borderInner = 'border-bottom';
+            borderRadiusValue = borderRadius + 'px ' + borderRadius + 'px 0 0;';
+            break;
         }
+
+        newStyle = borderInner + ': none;' +
+            'border-radius: ' + borderRadiusValue +
+            borderMissingStyle;
+
+        // I do call set_style possibly twice so that only the background gets the transition.
+        // The transition-property css rules seems to be unsupported
+        this._dash._container.set_style(newStyle);
 
         // Customize background
         let fixedTransparency = this._settings.get_enum('transparency-mode') == TransparencyMode.FIXED;


### PR DESCRIPTION
In stylesheet.css, the border radius is set to 9px for the shrinked and the built-in theme for dash, in order to reduce its size. 

Since the default shell theme is [already using 9px border-radius for dash](https://gitlab.gnome.org/GNOME/gnome-shell/blob/348d3037941b9d43f30cf16b7ba396acdef8426f/data/theme/gnome-shell-sass/_common.scss#L1311), this doesn't really change anything. Additionally, when using custom user-theme for gnome-shell, the border-radius defined in dash-to-dock's stylesheet.css overrides any user-themed stylesheets, possibly breaking the appearence of the shrinked dash with custom gnome-shell themes.

This PR makes dash-to-dock use same border-radius for shrinked and non-shrinked dash, to prevent issues with user-themes.

Here's an example of the issue using the Arc shell theme (before this PR on left, after on right):
![Screenshot from 2019-04-04 09-25-45](https://user-images.githubusercontent.com/39574454/55534605-8c0d4b80-56bd-11e9-8e7e-0c530901a303.png)![Screenshot from 2019-04-04 09-33-04](https://user-images.githubusercontent.com/39574454/55534613-90d1ff80-56bd-11e9-9fdc-434210696b14.png)