### PR TITLE
Fix regression with transparencey settings UI.

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -2162,9 +2162,9 @@
                                     <property name="can_focus">False</property>
                                     <property name="valign">center</property>
                                     <items>
-                                      <item translatable="yes">Default</item>
-                                      <item translatable="yes">Fixed</item>
-                                      <item translatable="yes">Dynamic</item>
+                                      <item id="0" translatable="yes">Default</item>
+                                      <item id="1" translatable="yes">Fixed</item>
+                                      <item id="3" translatable="yes">Dynamic</item>
                                     </items>
                                   </object>
                                   <packing>

--- a/prefs.js
+++ b/prefs.js
@@ -751,13 +751,13 @@ var Settings = class DashToDock_Settings {
         });
 
         // Opacity
-        this._builder.get_object('customize_opacity_combo').set_active(
-            this._settings.get_enum('transparency-mode')
+        this._builder.get_object('customize_opacity_combo').set_active_id(
+            this._settings.get_enum('transparency-mode').toString()
         );
         this._builder.get_object('customize_opacity_combo').connect(
             'changed',
             (widget) => {
-                this._settings.set_enum('transparency-mode', widget.get_active());
+                this._settings.set_enum('transparency-mode', parseInt(widget.get_active_id()));
             }
         );
 


### PR DESCRIPTION
We were relying on the settings enum matching the combobox index. Since we
dropped the adaptive transparency mode, we need to explicitely map the combobox
entries via their id and refer to it when getting/setting the option.

Regression introduced by: 8ccc7d2d55e1b425be605ff3d29052f5a43994ec

Fix #926.