### PR TITLE
Fix mouse trapped due to barrier set up with dock shown.

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -974,16 +974,17 @@ var DockedDash = class DashToDock {
                 direction = Meta.BarrierDirection.NEGATIVE_Y;
             }
 
-            this._barrier = new Meta.Barrier({
-                display: global.display,
-                x1: x1,
-                x2: x2,
-                y1: y1,
-                y2: y2,
-                directions: direction
-            });
-            if (this._pressureBarrier)
+            if (this._pressureBarrier && this._dockState == State.HIDDEN) {
+                this._barrier = new Meta.Barrier({
+                    display: global.display,
+                    x1: x1,
+                    x2: x2,
+                    y1: y1,
+                    y2: y2,
+                    directions: direction
+                });
                 this._pressureBarrier.addBarrier(this._barrier);
+            }
         }
     }
 


### PR DESCRIPTION
We were creating a barrier after each call to the updateBarrier
callback, regardless of the current dock state. If the dock is already shown,
this creat a barrier which is never removed, resulting in the mouse
being trapped. Check for the current dock state instead.

This is triggered for instance when an application enter/exit
fullscreen on any monitor.

The logic controlling pressure barriers and dock state needs
improvements but ths should fix it for now.


fix #743 