### PR TITLE
Show the "Quit" AppIconMenu entry only for running applications

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -880,11 +880,13 @@ const MyAppIconMenu = class DashToDock_MyAppIconMenu extends AppDisplay.AppIconM
         }
 
         // quit menu
-        this._appendSeparator();
-        this._quitfromDashMenuItem = this._appendMenuItem(_("Quit"));
-        this._quitfromDashMenuItem.connect('activate', () => {
-            this._source.closeAllWindows();
-        });
+        if (this._source.app.state == Shell.AppState.RUNNING) {
+            this._appendSeparator();
+            this._quitfromDashMenuItem = this._appendMenuItem(_("Quit"));
+            this._quitfromDashMenuItem.connect('activate', () => {
+                this._source.closeAllWindows();
+            });
+        }
 
         this.update();
     }


### PR DESCRIPTION
The "Quit" AppIconMenu entry was displayed for every item on the dock, including favorited applications that aren't currently running.

Obviously you can't quit non-running applications, so it makes more sense to display the "Quit" menu item only if the application is actually running.