### PR TITLE
Style focused overview-icon backgrounds only for built-in theme

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -82,7 +82,6 @@
 }
 
 
-#dashtodockContainer.running-dots .app-well-app.focused  .overview-icon,
 #dashtodockContainer.dashtodock .app-well-app.focused  .overview-icon {
     background-color: rgba(238, 238, 236, 0.2);
 }


### PR DESCRIPTION
Focused application's icon is highlighted with light background in stylesheet.css when using custom window counter indicators, or dash-to-dock's built-in theme.

Since that highlight style isn't necessarily visible (if the dock has light background), or simply doesn't look good with some gnome-shell themes, it seems better to style the background only when using the built-in theme, and use default focused styling from the shell theme otherwise.

In addition to the above, the setting label "Customize window counter indicators" implies that it would only have effect on the running dots, and leave any other styling as it is.

This PR removes the focused icon highlight when using custom running dots, and it is only applied for the built-in theme.