### PR TITLE
Support GNOME 3.34 and modernize code

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -535,7 +535,7 @@ var MyAppIcon = class DashToDock_AppIcon extends AppDisplay.AppIcon {
 
     _windowPreviews() {
         if (!this._previewMenu) {
-            this._previewMenuManager = new PopupMenu.PopupMenuManager(this);
+            this._previewMenuManager = new PopupMenu.PopupMenuManager(this.actor);
 
             this._previewMenu = new WindowPreview.WindowPreviewMenu(this, this._dtdSettings);
 
@@ -1042,7 +1042,7 @@ var ShowAppsIconWrapper = class DashToDock_ShowAppsIconWrapper {
         this.actor.connect('popup-menu', this._onKeyboardPopupMenu.bind(this));
 
         this._menu = null;
-        this._menuManager = new PopupMenu.PopupMenuManager(this);
+        this._menuManager = new PopupMenu.PopupMenuManager(this.actor);
         this._menuTimeoutId = 0;
 
         this.realShowAppsIcon._dtdSettings = settings;

--- a/appIcons.js
+++ b/appIcons.js
@@ -1021,30 +1021,16 @@ var MyShowAppsIcon = GObject.registerClass({
         this._dtdSettings = settings;
 
         // Re-use appIcon methods
-        this._removeMenuTimeout = AppDisplay.AppIcon.prototype._removeMenuTimeout;
-        this._setPopupTimeout = AppDisplay.AppIcon.prototype._setPopupTimeout;
-        this._onButtonPress = AppDisplay.AppIcon.prototype._onButtonPress;
-        this._onKeyboardPopupMenu = AppDisplay.AppIcon.prototype._onKeyboardPopupMenu;
-        this._onLeaveEvent = AppDisplay.AppIcon.prototype._onLeaveEvent;
-        this._onTouchEvent = AppDisplay.AppIcon.prototype._onTouchEvent;
-        this._onMenuPoppedDown = AppDisplay.AppIcon.prototype._onMenuPoppedDown;
-
-        // No action on clicked (showing of the appsview is controlled elsewhere)
-        this._onClicked = (actor, button) => {
-            this._removeMenuTimeout();
-        };
-
-        this.actor.connect('leave-event', this._onLeaveEvent.bind(this));
-        this.actor.connect('button-press-event', this._onButtonPress.bind(this));
-        this.actor.connect('touch-event', this._onTouchEvent.bind(this));
-        this.actor.connect('clicked', this._onClicked.bind(this));
-        this.actor.connect('popup-menu', this._onKeyboardPopupMenu.bind(this));
+        let appIconPrototype = AppDisplay.AppIcon.prototype;
+        this.actor.connect('leave-event', appIconPrototype._onLeaveEvent.bind(this));
+        this.actor.connect('button-press-event', appIconPrototype._onButtonPress.bind(this));
+        this.actor.connect('touch-event', appIconPrototype._onTouchEvent.bind(this));
+        this.actor.connect('popup-menu', appIconPrototype._onKeyboardPopupMenu.bind(this));
+        this.actor.connect('clicked', this._removeMenuTimeout.bind(this));
 
         this._menu = null;
         this._menuManager = new PopupMenu.PopupMenuManager(this.actor);
         this._menuTimeoutId = 0;
-
-        this.showLabel = itemShowLabel;
     }
 
     get actor() {
@@ -1052,6 +1038,22 @@ var MyShowAppsIcon = GObject.registerClass({
          * compatibility layer or the shell won't be able to access to the
          * actual actor */
         return this.toggleButton;
+    }
+
+    showLabel() {
+        itemShowLabel.call(this);
+    }
+
+    _onMenuPoppedDown() {
+        AppDisplay.AppIcon.prototype._onMenuPoppedDown.apply(this, arguments);
+    }
+
+    _setPopupTimeout() {
+        AppDisplay.AppIcon.prototype._onMenuPoppedDown.apply(this, arguments);
+    }
+
+    _removeMenuTimeout() {
+        AppDisplay.AppIcon.prototype._removeMenuTimeout.apply(this, arguments);
     }
 
     popupMenu() {

--- a/appIcons.js
+++ b/appIcons.js
@@ -35,7 +35,7 @@ const AppIconIndicators = Me.imports.appIconIndicators;
 
 let tracker = Shell.WindowTracker.get_default();
 
-let DASH_ITEM_LABEL_SHOW_TIME = Dash.DASH_ITEM_LABEL_SHOW_TIME;
+let DASH_ITEM_LABEL_SHOW_TIME = Dash.DASH_ITEM_LABEL_SHOW_TIME / 1000;
 
 const clickAction = {
     SKIP: 0,
@@ -1166,7 +1166,7 @@ function itemShowLabel()  {
     this.label.set_position(x, y);
     Tweener.addTween(this.label, {
         opacity: 255,
-        time: DASH_ITEM_LABEL_SHOW_TIME,
+        time: DASH_ITEM_LABEL_SHOW_TIME / 1000,
         transition: 'easeOutQuad',
     });
 }

--- a/appIcons.js
+++ b/appIcons.js
@@ -25,7 +25,6 @@ const DND = imports.ui.dnd;
 const IconGrid = imports.ui.iconGrid;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
-const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
 const Workspace = imports.ui.workspace;
 
@@ -36,8 +35,6 @@ const WindowPreview = Me.imports.windowPreview;
 const AppIconIndicators = Me.imports.appIconIndicators;
 
 let tracker = Shell.WindowTracker.get_default();
-
-let DASH_ITEM_LABEL_SHOW_TIME = Dash.DASH_ITEM_LABEL_SHOW_TIME / 1000;
 
 const clickAction = {
     SKIP: 0,
@@ -1169,10 +1166,11 @@ function itemShowLabel()  {
     else if (x + labelWidth > monitor.x + monitor.width - gap)
         x -= x + labelWidth - (monitor.x + monitor.width) + gap;
 
+    this.label.remove_all_transitions();
     this.label.set_position(x, y);
-    Tweener.addTween(this.label, {
+    this.label.ease({
         opacity: 255,
-        time: DASH_ITEM_LABEL_SHOW_TIME / 1000,
-        transition: 'easeOutQuad',
+        duration: Dash.DASH_ITEM_LABEL_SHOW_TIME,
+        mode: Clutter.AnimationMode.EASE_OUT_QUAD
     });
 }

--- a/appIcons.js
+++ b/appIcons.js
@@ -1015,6 +1015,7 @@ var ShowAppsIconWrapper = class DashToDock_ShowAppsIconWrapper {
     constructor(settings) {
         this._dtdSettings = settings;
         this.realShowAppsIcon = new Dash.ShowAppsIcon();
+        this.realShowAppsIcon.show();
 
         /* the variable equivalent to toggleButton has a different name in the appIcon class
         (actor): duplicate reference to easily reuse appIcon methods */

--- a/appIcons.js
+++ b/appIcons.js
@@ -85,6 +85,7 @@ var MyAppIcon = class DashToDock_AppIcon extends AppDisplay.AppIcon {
         this._indicator = null;
 
         this._updateIndicatorStyle();
+        this._optionalScrollCycleWindows();
 
         // Monitor windows-changes instead of app state.
         // Keep using the same Id and function callback (that is extended)

--- a/appIcons.js
+++ b/appIcons.js
@@ -207,7 +207,7 @@ var MyAppIcon = class DashToDock_AppIcon extends AppDisplay.AppIcon {
         if (!appIsRunning)
             return false
 
-        if (this._optionalScrollCycleWindowsDeadTimeId > 0)
+        if (this._optionalScrollCycleWindowsDeadTimeId)
             return false;
         else
             this._optionalScrollCycleWindowsDeadTimeId = Mainloop.timeout_add(250, () => {

--- a/dash.js
+++ b/dash.js
@@ -26,9 +26,9 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Utils = Me.imports.utils;
 const AppIcons = Me.imports.appIcons;
 
-let DASH_ANIMATION_TIME = Dash.DASH_ANIMATION_TIME;
-let DASH_ITEM_LABEL_HIDE_TIME = Dash.DASH_ITEM_LABEL_HIDE_TIME;
-let DASH_ITEM_HOVER_TIMEOUT = Dash.DASH_ITEM_HOVER_TIMEOUT;
+const DASH_ANIMATION_TIME = Dash.DASH_ANIMATION_TIME / 1000;
+const DASH_ITEM_LABEL_HIDE_TIME = Dash.DASH_ITEM_LABEL_HIDE_TIME / 1000;
+const DASH_ITEM_HOVER_TIMEOUT = Dash.DASH_ITEM_HOVER_TIMEOUT / 1000;
 
 /**
  * Extend DashItemContainer
@@ -1155,7 +1155,7 @@ function ensureActorVisibleInScrollView(scrollView, actor) {
 
     if (vvalue !== vvalue0) {
         Tweener.addTween(vadjustment, { value: vvalue,
-            time: Util.SCROLL_TIME,
+            time: Util.SCROLL_TIME / 1000,
             transition: 'easeOutQuad'
         });
     }
@@ -1163,7 +1163,7 @@ function ensureActorVisibleInScrollView(scrollView, actor) {
     if (hvalue !== hvalue0) {
         Tweener.addTween(hadjustment,
                          { value: hvalue,
-                           time: Util.SCROLL_TIME,
+                           time: Util.SCROLL_TIME / 1000,
                            transition: 'easeOutQuad' });
     }
 

--- a/dash.js
+++ b/dash.js
@@ -232,19 +232,13 @@ var MyDash = GObject.registerClass({
         this._scrollView.add_actor(this._box);
 
         // Create a wrapper around the real showAppsIcon in order to add a popupMenu.
-        let showAppsIconWrapper = new AppIcons.ShowAppsIconWrapper(this._dtdSettings);
-        showAppsIconWrapper.connect('menu-state-changed', (showAppsIconWrapper, opened) => {
-            this._itemMenuStateChanged(showAppsIconWrapper, opened);
-        });
-        // an instance of the showAppsIcon class is encapsulated in the wrapper
-        this._showAppsIcon = showAppsIconWrapper.realShowAppsIcon;
-
-        this._showAppsIcon.childScale = 1;
-        this._showAppsIcon.childOpacity = 255;
+        this._showAppsIcon = new AppIcons.MyShowAppsIcon(this._dtdSettings);
+        this._showAppsIcon.show();
         this._showAppsIcon.icon.setIconSize(this.iconSize);
         this._hookUpLabel(this._showAppsIcon);
-
-        this.showAppsButton = this._showAppsIcon.toggleButton;
+        this._showAppsIcon.connect('menu-state-changed', (_icon, opened) => {
+            this._itemMenuStateChanged(this._showAppsIcon, opened);
+        });
 
         this._container.add_actor(this._showAppsIcon);
 
@@ -1093,6 +1087,10 @@ var MyDash = GObject.registerClass({
         });
 
         return true;
+    }
+
+    get showAppsButton() {
+        return this._showAppsIcon.toggleButton;
     }
 
     showShowAppsButton() {

--- a/dash.js
+++ b/dash.js
@@ -36,13 +36,20 @@ const DASH_ITEM_HOVER_TIMEOUT = Dash.DASH_ITEM_HOVER_TIMEOUT / 1000;
  * - Pass settings to the constructor
  * - set label position based on dash orientation
  *
- *  I can't subclass the original object because of this: https://bugzilla.gnome.org/show_bug.cgi?id=688973.
- *  thus use this ugly pattern.
  */
-function extendDashItemContainer(dashItemContainer, settings) {
-    dashItemContainer._dtdSettings = settings;
-    dashItemContainer.showLabel = AppIcons.itemShowLabel;
-}
+let MyDashItemContainer = GObject.registerClass(
+class DashToDock_MyDashItemContainer extends Dash.DashItemContainer {
+
+    _init(settings) {
+        this._dtdSettings = settings;
+
+        super._init();
+    }
+
+    showLabel() {
+        return AppIcons.itemShowLabel.call(this);
+    }
+});
 
 /**
  * This class is a fork of the upstream DashActor class (ui.dash.js)
@@ -458,9 +465,7 @@ var MyDash = GObject.registerClass({
             this._itemMenuStateChanged(item, opened);
         });
 
-        let item = new Dash.DashItemContainer();
-
-        extendDashItemContainer(item, this._dtdSettings);
+        let item = new MyDashItemContainer(this._dtdSettings);
         item.setChild(appIcon.actor);
 
         appIcon.actor.connect('notify::hover', () => {

--- a/dash.js
+++ b/dash.js
@@ -18,7 +18,6 @@ const DND = imports.ui.dnd;
 const IconGrid = imports.ui.iconGrid;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
-const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
 const Workspace = imports.ui.workspace;
 
@@ -27,9 +26,9 @@ const Docking = Me.imports.docking;
 const Utils = Me.imports.utils;
 const AppIcons = Me.imports.appIcons;
 
-const DASH_ANIMATION_TIME = Dash.DASH_ANIMATION_TIME / 1000;
-const DASH_ITEM_LABEL_HIDE_TIME = Dash.DASH_ITEM_LABEL_HIDE_TIME / 1000;
-const DASH_ITEM_HOVER_TIMEOUT = Dash.DASH_ITEM_HOVER_TIMEOUT / 1000;
+const DASH_ANIMATION_TIME = Dash.DASH_ANIMATION_TIME;
+const DASH_ITEM_LABEL_HIDE_TIME = Dash.DASH_ITEM_LABEL_HIDE_TIME;
+const DASH_ITEM_HOVER_TIMEOUT = Dash.DASH_ITEM_HOVER_TIMEOUT;
 
 /**
  * Extend DashItemContainer
@@ -678,12 +677,13 @@ var MyDash = GObject.registerClass({
             icon.icon.set_size(icon.icon.width * scale,
                                icon.icon.height * scale);
 
-            Tweener.addTween(icon.icon,
-                             { width: targetWidth,
-                               height: targetHeight,
-                               time: DASH_ANIMATION_TIME,
-                               transition: 'easeOutQuad',
-                             });
+            icon.icon.remove_all_transitions();
+            icon.icon.ease({
+                width: targetWidth,
+                height: targetHeight,
+                time: DASH_ANIMATION_TIME,
+                mode: Clutter.AnimationMode.EASE_OUT_QUAD
+            });
         }
     }
 
@@ -1112,8 +1112,8 @@ function ensureActorVisibleInScrollView(scrollView, actor) {
     let adjust_v = true;
     let adjust_h = true;
 
-    let vadjustment = scrollView.vscroll.adjustment;
-    let hadjustment = scrollView.hscroll.adjustment;
+    let vadjustment = scrollView.get_vscroll_bar().get_adjustment();
+    let hadjustment = scrollView.get_hscroll_bar().get_adjustment();
     let [vvalue, vlower, vupper, vstepIncrement, vpageIncrement, vpageSize] = vadjustment.get_values();
     let [hvalue, hlower, hupper, hstepIncrement, hpageIncrement, hpageSize] = hadjustment.get_values();
 
@@ -1154,17 +1154,17 @@ function ensureActorVisibleInScrollView(scrollView, actor) {
         hvalue = Math.min(hupper - hpageSize, x2 + hoffset - hpageSize);
 
     if (vvalue !== vvalue0) {
-        Tweener.addTween(vadjustment, { value: vvalue,
-            time: Util.SCROLL_TIME / 1000,
-            transition: 'easeOutQuad'
+        vadjustment.ease(vvalue, {
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+            duration: Util.SCROLL_TIME
         });
     }
 
     if (hvalue !== hvalue0) {
-        Tweener.addTween(hadjustment,
-                         { value: hvalue,
-                           time: Util.SCROLL_TIME / 1000,
-                           transition: 'easeOutQuad' });
+        hadjustment.ease(hvalue, {
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+            duration: Util.SCROLL_TIME
+        });
     }
 
     return [hvalue- hvalue0, vvalue - vvalue0];

--- a/docking.js
+++ b/docking.js
@@ -1756,7 +1756,7 @@ var DockManager = class DashToDock_DockManager {
                         Main.overview.viewSelector._activePage.hide();
                         Main.overview.viewSelector._activePage = Main.overview.viewSelector._appsPage;
                         Main.overview.viewSelector._activePage.show();
-                        grid.actor.opacity = 0;
+                        grid.opacity = 0;
 
                         // The animation has to be trigered manually because the AppDisplay.animate
                         // method is waiting for an allocation not happening, as we skip the workspace view
@@ -1766,7 +1766,7 @@ var DockManager = class DashToDock_DockManager {
                         let overviewShownId = Main.overview.connect('shown', () => {
                             Main.overview.disconnect(overviewShownId);
                             Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
-                                grid.actor.opacity = 255;
+                                grid.opacity = 255;
                                 grid.animateSpring(IconGrid.AnimationDirection.IN, this._allDocks[0].dash.showAppsButton);
                             });
                         });
@@ -1774,7 +1774,7 @@ var DockManager = class DashToDock_DockManager {
                     else {
                         Main.overview.viewSelector._activePage = Main.overview.viewSelector._appsPage;
                         Main.overview.viewSelector._activePage.show();
-                        grid.actor.opacity = 255;
+                        grid.opacity = 255;
                     }
 
                 }
@@ -1792,7 +1792,6 @@ var DockManager = class DashToDock_DockManager {
                         // workspaceView to avoid the zoomout animation. Hide the appPage
                         // onComplete to avoid ugly flashing of original icons.
                         let view = Main.overview.viewSelector.appDisplay._views[visibleView].view;
-                        let grid = view._grid;
                         view.animate(IconGrid.AnimationDirection.OUT, () => {
                             Main.overview.viewSelector._appsPage.hide();
                             Main.overview.hide();

--- a/docking.js
+++ b/docking.js
@@ -16,7 +16,6 @@ const IconGrid = imports.ui.iconGrid;
 const Overview = imports.ui.overview;
 const OverviewControls = imports.ui.overviewControls;
 const PointerWatcher = imports.ui.pointerWatcher;
-const Tweener = imports.ui.tweener;
 const Signals = imports.signals;
 const ViewSelector = imports.ui.viewSelector;
 const WorkspaceSwitcherPopup= imports.ui.workspaceSwitcherPopup;
@@ -674,7 +673,7 @@ var DockedDash = GObject.registerClass({
     _show() {
         if ((this._dockState == State.HIDDEN) || (this._dockState == State.HIDING)) {
             if (this._dockState == State.HIDING)
-                // suppress all potential queued hiding animations - i.e. added to Tweener but not started,
+                // suppress all potential queued transitions - i.e. added but not started,
                 // always give priority to show
                 this._removeAnimations();
 
@@ -705,11 +704,10 @@ var DockedDash = GObject.registerClass({
     _animateIn(time, delay) {
         this._dockState = State.SHOWING;
 
-        Tweener.addTween(this._slider, {
-            slidex: 1,
-            time: time,
-            delay: delay,
-            transition: 'easeOutQuad',
+        this._slider.ease_property('slidex', 1, {
+            duration: time * 1000,
+            delay: delay * 1000,
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
             onComplete: () => {
                 this._dockState = State.SHOWN;
                 // Remove barrier so that mouse pointer is released and can access monitors on other side of dock
@@ -724,11 +722,11 @@ var DockedDash = GObject.registerClass({
 
     _animateOut(time, delay) {
         this._dockState = State.HIDING;
-        Tweener.addTween(this._slider, {
-            slidex: 0,
-            time: time,
-            delay: delay ,
-            transition: 'easeOutQuad',
+
+        this._slider.ease_property('slidex', 0, {
+            duration: time * 1000,
+            delay: delay * 1000,
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
             onComplete: () => {
                 this._dockState = State.HIDDEN;
                 // Remove queued barried removal if any
@@ -1102,7 +1100,7 @@ var DockedDash = GObject.registerClass({
     }
 
     _removeAnimations() {
-        Tweener.removeTweens(this._slider);
+        this._slider.remove_all_transitions();
     }
 
     _onDragStart() {

--- a/docking.js
+++ b/docking.js
@@ -1643,7 +1643,6 @@ var DockManager = class DashToDock_DockManager {
 
         // First we create the main Dock, to get the extra features to bind to this one
         let dock = new DockedDash(this._settings, this._remoteModel, this._preferredMonitorIndex);
-        this._mainShowAppsButton = dock.dash.showAppsButton;
         this._allDocks.push(dock);
 
         // connect app icon into the view selector

--- a/docking.js
+++ b/docking.js
@@ -1208,14 +1208,12 @@ var DockedDash = GObject.registerClass({
                 'scroll-event',
                 onScrollEvent.bind(this)
             ]);
-
-            this._optionalScrollWorkspaceSwitchDeadTimeId = 0;
         }
 
         function disable() {
             this._signalsHandler.removeWithLabel(label);
 
-            if (this._optionalScrollWorkspaceSwitchDeadTimeId > 0) {
+            if (this._optionalScrollWorkspaceSwitchDeadTimeId) {
                 Mainloop.source_remove(this._optionalScrollWorkspaceSwitchDeadTimeId);
                 this._optionalScrollWorkspaceSwitchDeadTimeId = 0;
             }
@@ -1252,7 +1250,7 @@ var DockedDash = GObject.registerClass({
                 // Usefull on laptops when using a touchpad.
 
                 // During the deadtime do nothing
-                if (this._optionalScrollWorkspaceSwitchDeadTimeId > 0)
+                if (this._optionalScrollWorkspaceSwitchDeadTimeId)
                     return false;
                 else
                     this._optionalScrollWorkspaceSwitchDeadTimeId = Mainloop.timeout_add(250, () => {

--- a/extension.js
+++ b/extension.js
@@ -13,11 +13,9 @@ function init() {
 }
 
 function enable() {
-    dockManager = new Docking.DockManager();
+    new Docking.DockManager();
 }
 
 function disable() {
     dockManager.destroy();
-
-    dockManager=null;
 }

--- a/intellihide.js
+++ b/intellihide.js
@@ -9,6 +9,7 @@ const Main = imports.ui.main;
 const Signals = imports.signals;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Docking = Me.imports.docking;
 const Utils = Me.imports.utils;
 
 // A good compromise between reactivity and efficiency; to be tuned.
@@ -46,9 +47,8 @@ const handledWindowTypes = [
  */
 var Intellihide = class DashToDock_Intellihide {
 
-    constructor(settings, monitorIndex) {
+    constructor(monitorIndex) {
         // Load settings
-        this._settings = settings;
         this._monitorIndex = monitorIndex;
 
         this._signalsHandler = new Utils.GlobalSignalsHandler();
@@ -252,7 +252,7 @@ var Intellihide = class DashToDock_Intellihide {
         let wksp_index = wksp.index();
 
         // Depending on the intellihide mode, exclude non-relevent windows
-        switch (this._settings.get_enum('intellihide-mode')) {
+        switch (Docking.DockManager.settings.get_enum('intellihide-mode')) {
             case IntellihideMode.ALL_WINDOWS:
                 // Do nothing
                 break;

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
 "shell-version": [
-    "3.32"
+    "3.34"
 ],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",

--- a/theming.js
+++ b/theming.js
@@ -45,7 +45,7 @@ var ThemeManager = class DashToDock_ThemeManager {
         this._settings = settings;
         this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._bindSettingsChanges();
-        this._actor = dock.actor;
+        this._actor = dock;
         this._dash = dock.dash;
 
         // initialize colors with generic values
@@ -329,7 +329,7 @@ var Transparency = class DashToDock_Transparency {
         this._settings = settings;
         this._dash = dock.dash;
         this._actor = this._dash._container;
-        this._dockActor = dock.actor;
+        this._dockActor = dock;
         this._dock = dock;
         this._panel = Main.panel;
         this._position = Utils.getPosition(this._settings);

--- a/theming.js
+++ b/theming.js
@@ -22,7 +22,7 @@ const Util = imports.misc.util;
 const Workspace = imports.ui.workspace;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Dock = Me.imports.docking;
+const Docking = Me.imports.docking;
 const Utils = Me.imports.utils;
 
 /*
@@ -41,8 +41,7 @@ const TransparencyMode = {
  */
 var ThemeManager = class DashToDock_ThemeManager {
 
-    constructor(settings, dock) {
-        this._settings = settings;
+    constructor(dock) {
         this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._bindSettingsChanges();
         this._actor = dock;
@@ -51,7 +50,7 @@ var ThemeManager = class DashToDock_ThemeManager {
         // initialize colors with generic values
         this._customizedBackground = {red: 0, green: 0, blue: 0, alpha: 0};
         this._customizedBorder = {red: 0, green: 0, blue: 0, alpha: 0};
-        this._transparency = new Transparency(this._settings, dock);
+        this._transparency = new Transparency(dock);
 
         this._signalsHandler.add([
             // When theme changes re-obtain default background color
@@ -91,7 +90,7 @@ var ThemeManager = class DashToDock_ThemeManager {
     }
 
     _updateDashOpacity() {
-        let newAlpha = this._settings.get_double('background-opacity');
+        let newAlpha = Docking.DockManager.settings.get_double('background-opacity');
 
         let [backgroundColor, borderColor] = this._getDefaultColors();
 
@@ -140,7 +139,7 @@ var ThemeManager = class DashToDock_ThemeManager {
         // We want to find the inside border-color of the dock because it is
         // the side most visible to the user. We do this by finding the side
         // opposite the position
-        let position = Utils.getPosition(this._settings);
+        let position = Utils.getPosition();
         let side = position + 2;
         if (side > 3)
             side = Math.abs(side - 4);
@@ -158,16 +157,18 @@ var ThemeManager = class DashToDock_ThemeManager {
         if (backgroundColor==null)
             return;
 
-        if (this._settings.get_boolean('custom-background-color')) {
+        let settings = Docking.DockManager.settings;
+
+        if (settings.get_boolean('custom-background-color')) {
             // When applying a custom color, we need to check the alpha value,
             // if not the opacity will always be overridden by the color below.
             // Note that if using 'dynamic' transparency modes,
             // the opacity will be set by the opaque/transparent styles anyway.
             let newAlpha = Math.round(backgroundColor.alpha/2.55)/100;
-            if (this._settings.get_enum('transparency-mode') == TransparencyMode.FIXED)
-                newAlpha = this._settings.get_double('background-opacity');
+            if (settings.get_enum('transparency-mode') == TransparencyMode.FIXED)
+                newAlpha = settings.get_double('background-opacity');
 
-            backgroundColor = Clutter.color_from_string(this._settings.get_string('background-color'))[1];
+            backgroundColor = Clutter.color_from_string(settings.get_string('background-color'))[1];
             this._customizedBackground = 'rgba(' +
                 backgroundColor.red + ',' +
                 backgroundColor.green + ',' +
@@ -180,24 +181,26 @@ var ThemeManager = class DashToDock_ThemeManager {
     }
 
     _updateCustomStyleClasses() {
-        if (this._settings.get_boolean('apply-custom-theme'))
+        let settings = Docking.DockManager.settings;
+
+        if (settings.get_boolean('apply-custom-theme'))
             this._actor.add_style_class_name('dashtodock');
         else
             this._actor.remove_style_class_name('dashtodock');
 
-        if (this._settings.get_boolean('custom-theme-shrink'))
+        if (settings.get_boolean('custom-theme-shrink'))
             this._actor.add_style_class_name('shrink');
         else
             this._actor.remove_style_class_name('shrink');
 
-        if (this._settings.get_enum('running-indicator-style') !== 0)
+        if (settings.get_enum('running-indicator-style') !== 0)
             this._actor.add_style_class_name('running-dots');
         else
             this._actor.remove_style_class_name('running-dots');
 
         // If not the built-in theme option is not selected
-        if (!this._settings.get_boolean('apply-custom-theme')) {
-            if (this._settings.get_boolean('force-straight-corner'))
+        if (!settings.get_boolean('apply-custom-theme')) {
+            if (settings.get_boolean('force-straight-corner'))
                 this._actor.add_style_class_name('straight-corner');
             else
                 this._actor.remove_style_class_name('straight-corner');
@@ -223,16 +226,18 @@ var ThemeManager = class DashToDock_ThemeManager {
         if (!this._dash._container.get_stage())
             return;
 
+        let settings = Docking.DockManager.settings;
+
         // Remove prior style edits
         this._dash._container.set_style(null);
         this._transparency.disable();
 
         // If built-in theme is enabled do nothing else
-        if (this._settings.get_boolean('apply-custom-theme'))
+        if (settings.get_boolean('apply-custom-theme'))
             return;
 
         let newStyle = '';
-        let position = Utils.getPosition(this._settings);
+        let position = Utils.getPosition(settings);
 
         // obtain theme border settings
         let themeNode = this._dash._container.get_theme_node();
@@ -281,12 +286,12 @@ var ThemeManager = class DashToDock_ThemeManager {
         this._dash._container.set_style(newStyle);
 
         // Customize background
-        let fixedTransparency = this._settings.get_enum('transparency-mode') == TransparencyMode.FIXED;
-        let defaultTransparency = this._settings.get_enum('transparency-mode') == TransparencyMode.DEFAULT;
+        let fixedTransparency = settings.get_enum('transparency-mode') == TransparencyMode.FIXED;
+        let defaultTransparency = settings.get_enum('transparency-mode') == TransparencyMode.DEFAULT;
         if (!defaultTransparency && !fixedTransparency) {
             this._transparency.enable();
         }
-        else if (!defaultTransparency || this._settings.get_boolean('custom-background-color')) {
+        else if (!defaultTransparency || settings.get_boolean('custom-background-color')) {
             newStyle = newStyle + 'background-color:'+ this._customizedBackground + '; ' +
                        'border-color:'+ this._customizedBorder + '; ' +
                        'transition-delay: 0s; transition-duration: 0.250s;';
@@ -310,7 +315,7 @@ var ThemeManager = class DashToDock_ThemeManager {
 
         keys.forEach(function(key) {
             this._signalsHandler.add([
-                this._settings,
+                Docking.DockManager.settings,
                 'changed::' + key,
                 this.updateCustomTheme.bind(this)
            ]);
@@ -325,14 +330,13 @@ var ThemeManager = class DashToDock_ThemeManager {
  */
 var Transparency = class DashToDock_Transparency {
 
-    constructor(settings, dock) {
-        this._settings = settings;
+    constructor(dock) {
         this._dash = dock.dash;
         this._actor = this._dash._container;
         this._dockActor = dock;
         this._dock = dock;
         this._panel = Main.panel;
-        this._position = Utils.getPosition(this._settings);
+        this._position = Utils.getPosition();
 
         // All these properties are replaced with the ones in the .dummy-opaque and .dummy-transparent css classes
         this._backgroundColor = '0,0,0';
@@ -472,7 +476,7 @@ var Transparency = class DashToDock_Transparency {
          * up when it slides out. This is avoid an ugly transition.
          * */
         let factor = 0;
-        if (!this._settings.get_boolean('dock-fixed') &&
+        if (!Docking.DockManager.settings.get_boolean('dock-fixed') &&
             this._dock.getDockState() == Dock.State.HIDDEN)
             factor = 1;
         let [leftCoord, topCoord] = this._actor.get_transformed_position();
@@ -556,10 +560,12 @@ var Transparency = class DashToDock_Transparency {
 
         Main.uiGroup.remove_child(dummyObject);
 
-        if (this._settings.get_boolean('customize-alphas')) {
-            this._opaqueAlpha = this._settings.get_double('max-alpha');
+        let settings = Docking.DockManager.settings;
+
+        if (settings.get_boolean('customize-alphas')) {
+            this._opaqueAlpha = settings.get_double('max-alpha');
             this._opaqueAlphaBorder = this._opaqueAlpha / 2;
-            this._transparentAlpha = this._settings.get_double('min-alpha');
+            this._transparentAlpha = settings.get_double('min-alpha');
             this._transparentAlphaBorder = this._transparentAlpha / 2;
         }
     }

--- a/theming.js
+++ b/theming.js
@@ -17,7 +17,6 @@ const DND = imports.ui.dnd;
 const IconGrid = imports.ui.iconGrid;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
-const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
 const Workspace = imports.ui.workspace;
 

--- a/utils.js
+++ b/utils.js
@@ -53,14 +53,14 @@ const BasicHandler = class DashToDock_BasicHandler {
      * Create single element to be stored in the storage structure
      */
     _create(item) {
-        throw new Error('no implementation of _create in ' + this);
+        throw new GObject.NotImplementedError(`_create in ${this.constructor.name}`);
     }
 
     /**
      * Correctly delete single element
      */
     _remove(item) {
-        throw new Error('no implementation of _remove in ' + this);
+        throw new GObject.NotImplementedError(`_remove in ${this.constructor.name}`);
     }
 };
 

--- a/utils.js
+++ b/utils.js
@@ -2,6 +2,9 @@ const Clutter = imports.gi.Clutter;
 const Meta = imports.gi.Meta;
 const St = imports.gi.St;
 
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Docking = Me.imports.docking;
+
 /**
  * Simplify global signals and function injections handling
  * abstract class
@@ -213,8 +216,8 @@ var InjectionsHandler = class DashToDock_InjectionsHandler extends BasicHandler 
 /**
  * Return the actual position reverseing left and right in rtl
  */
-function getPosition(settings) {
-    let position = settings.get_enum('dock-position');
+function getPosition() {
+    let position = Docking.DockManager.settings.get_enum('dock-position');
     if (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL) {
         if (position == St.Side.LEFT)
             position = St.Side.RIGHT;

--- a/utils.js
+++ b/utils.js
@@ -5,6 +5,11 @@ const St = imports.gi.St;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Docking = Me.imports.docking;
 
+var SignalsHandlerFlags = {
+    NONE: 0,
+    CONNECT_AFTER: 1
+};
+
 /**
  * Simplify global signals and function injections handling
  * abstract class
@@ -34,7 +39,11 @@ const BasicHandler = class DashToDock_BasicHandler {
         // Skip first element of the arguments
         for (let i = 1; i < arguments.length; i++) {
             let item = this._storage[label];
-            item.push(this._create(arguments[i]));
+            try {
+                item.push(this._create(arguments[i]));
+            } catch (e) {
+                logError(e);
+            }
         }
     }
 
@@ -73,7 +82,21 @@ var GlobalSignalsHandler = class DashToDock_GlobalSignalHandler extends BasicHan
         let object = item[0];
         let event = item[1];
         let callback = item[2]
-        let id = object.connect(event, callback);
+        let flags = item.length > 3 ? item[3] : SignalsHandlerFlags.NONE;
+
+        if (!object)
+            throw new Error('Impossible to connect to an invalid object');
+
+        let after = flags == SignalsHandlerFlags.CONNECT_AFTER;
+        let connector = after ? object.connect_after : object.connect;
+
+        if (!connector) {
+            throw new Error(`Requested to connect to signal '${event}', ` +
+                `but no implementation for 'connect${after ? '_after' : ''}' `+
+                `found in ${object.constructor.name}`);
+        }
+
+        let id = connector.call(object, event, callback);
 
         return [object, id];
     }

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -379,7 +379,7 @@ class DashToDock_WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
         // Newly-created windows are added to a workspace before
         // the compositor finds out about them...
         // Moreover sometimes they return an empty texture, thus as a workarounf also check for it size
-        if (!mutterWindow || !mutterWindow.get_texture() || !mutterWindow.get_texture().get_size()[0]) {
+        if (!mutterWindow || !mutterWindow.get_texture() || !mutterWindow.get_size()[0]) {
             this._cloneTextureId = Mainloop.idle_add(() => {
                 // Check if there's still a point in getting the texture,
                 // otherwise this could go on indefinitely
@@ -392,12 +392,9 @@ class DashToDock_WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
             return;
         }
 
-        let windowTexture = mutterWindow.get_texture();
-        let [width, height] = windowTexture.get_size();
-
+        let [width, height] = mutterWindow.get_size();
         let scale = Math.min(1.0, PREVIEW_MAX_WIDTH/width, PREVIEW_MAX_HEIGHT/height);
-
-        let clone = new Clutter.Clone ({ source: windowTexture,
+        let clone = new Clutter.Clone ({ source: mutterWindow,
                                          reactive: true,
                                          width: width * scale,
                                          height: height * scale });

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -25,11 +25,9 @@ const PREVIEW_MAX_HEIGHT = 150;
 
 var WindowPreviewMenu = class DashToDock_WindowPreviewMenu extends PopupMenu.PopupMenu {
 
-    constructor(source, settings) {
-        let side = Utils.getPosition(settings);
+    constructor(source) {
+        let side = Utils.getPosition();
         super(source.actor, 0.5, side);
-
-        this._dtdSettings = settings;
 
         // We want to keep the item hovered while the menu is up
         this.blockSourceEvents = true;
@@ -63,7 +61,7 @@ var WindowPreviewMenu = class DashToDock_WindowPreviewMenu extends PopupMenu.Pop
     _redisplay() {
         if (this._previewBox)
             this._previewBox.destroy();
-        this._previewBox = new WindowPreviewList(this._source, this._dtdSettings);
+        this._previewBox = new WindowPreviewList(this._source);
         this.addMenuItem(this._previewBox);
         this._previewBox._redisplay();
     }
@@ -89,10 +87,8 @@ var WindowPreviewMenu = class DashToDock_WindowPreviewMenu extends PopupMenu.Pop
 
 var WindowPreviewList = class DashToDock_WindowPreviewList extends PopupMenu.PopupMenuSection {
 
-    constructor(source, settings) {
+    constructor(source) {
         super();
-        this._dtdSettings = settings;
-
         this.actor = new St.ScrollView({ name: 'dashtodockWindowScrollview',
                                                hscrollbar_policy: Gtk.PolicyType.NEVER,
                                                vscrollbar_policy: Gtk.PolicyType.NEVER,
@@ -100,7 +96,7 @@ var WindowPreviewList = class DashToDock_WindowPreviewList extends PopupMenu.Pop
 
         this.actor.connect('scroll-event', this._onScrollEvent.bind(this));
 
-        let position = Utils.getPosition(this._dtdSettings);
+        let position = Utils.getPosition();
         this.isHorizontal = position == St.Side.BOTTOM || position == St.Side.TOP;
         this.box.set_vertical(!this.isHorizontal);
         this.box.set_name('dashtodockWindowList');

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -505,7 +505,7 @@ class DashToDock_WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
             this.closeButton.show();
             Tweener.addTween(this.closeButton,
                              { opacity: 255,
-                               time: Workspace.CLOSE_BUTTON_FADE_TIME,
+                               time: Workspace.WINDOW_OVERLAY_FADE_TIME / 1000,
                                transition: 'easeOutQuad' });
         }
     }
@@ -513,7 +513,7 @@ class DashToDock_WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
     _hideCloseButton() {
         Tweener.addTween(this.closeButton,
                          { opacity: 0,
-                           time: Workspace.CLOSE_BUTTON_FADE_TIME,
+                           time: Workspace.WINDOW_OVERLAY_FADE_TIME / 1000,
                            transition: 'easeInQuad' });
     }
 


### PR DESCRIPTION
Another breaking update upstream that needs some changes for which it might be quite hard to maintain multiple versions (while could be possible for some classes, https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/559 will make it even more impossible).

So, better to do all at once:
 - Inheriting from native Actors instead of composition
 - Cleanup settings object usage, by avoiding passing it eveywhere
 - Remove Tweener to animate, in favor of new Clutter transitions (see [upstream change](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/669))