### PR TITLE
locations: Fix a remaining use of `nautilus` vs `gio open`

### DIFF
--- a/locations.js
+++ b/locations.js
@@ -176,7 +176,7 @@ var Removables = class DashToDock_Removables {
         volumeKeys.set_string('Desktop Entry', 'Name', volume.get_name());
         volumeKeys.set_string('Desktop Entry', 'Icon', this._getWorkingIconName(volume.get_icon()));
         volumeKeys.set_string('Desktop Entry', 'Type', 'Application');
-        volumeKeys.set_string('Desktop Entry', 'Exec', 'nautilus "' + uri + '"');
+        volumeKeys.set_string('Desktop Entry', 'Exec', 'gio open "' + uri + '"');
         volumeKeys.set_string('Desktop Entry', 'StartupNotify', 'false');
         volumeKeys.set_string('Desktop Entry', 'Actions', 'mount;');
         volumeKeys.set_string('Desktop Action mount', 'Name', __('Mount'));


### PR DESCRIPTION
I missed this originally.

This is the one outstanding change from #677 that isn't merged.