### PR TITLE
MyAppIcon: Inherit from Dash.DashIcon

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -72,7 +72,7 @@ let recentlyClickedAppMonitor = -1;
  * - Update minimization animation target
  * - Update menu if open on windows change
  */
-var MyAppIcon = class DashToDock_AppIcon extends AppDisplay.AppIcon {
+var MyAppIcon = class DashToDock_AppIcon extends Dash.DashIcon {
 
     // settings are required inside.
     constructor(remoteModel, app, monitorIndex, iconParams) {


### PR DESCRIPTION
Starting from GNOME/gnome-shell upstream commit ff3d32dd18 AppDisplay is
meant to be used only by the AppGrid and in fact it supports DnD drop
operations, being a drop target for other icons in order to be able to
create an app folder.

However dash-to-dock doesn't need anything of that, so in order to have
proper dock dnd inherit the app icons from the newly introduced (available
since the commit above, included in 3.34.0) Dash.DashIcon

LP: #1846477, #1847102