### PR TITLE
Resolve animation hang issue in Gnome 3.34 with auto-hidden dock

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -697,14 +697,10 @@ var DockedDash = GObject.registerClass({
         // If no hiding animation is running or queued
         if ((this._dockState == State.SHOWN) || (this._dockState == State.SHOWING)) {
             let settings = DockManager.settings;
-            let delay;
+            // Remove delay if dock is in the process of showing
+            let delay = 0;
 
-            if (this._dockState == State.SHOWING)
-                //if a show already started, let it finish; queue hide without removing the show.
-                // to obtain this I increase the delay to avoid the overlap and interference
-                // between the animations
-                delay = settings.get_double('hide-delay') + settings.get_double('animation-time');
-            else
+            if (this._dockState != State.SHOWING)
                 delay = settings.get_double('hide-delay');
 
             this.emit('hiding');


### PR DESCRIPTION
In Gnome 3.34, when activating an auto-hidden dock, quickly moving the mouse onto and off of the dock causes its animation to hang for the duration of the delay that was configured in the extension's settings.

This removes the delay if the dock is in the process of showing so that it returns to its hidden position as it was probably an accidental activation.