### PR TITLE
Fix border radius for built-in theme

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,4 +1,4 @@
-/* Shrink the dash by reducing padding and border radius */
+/* Shrink the dash by reducing padding */
 #dashtodockContainer.shrink #dash,
 #dashtodockContainer.dashtodock #dash {
     border:1px;
@@ -32,22 +32,22 @@
     border-radius: 0px;
 }
 
-/* Adjust built-in theme for different orientations */
-
-#dashtodockContainer.top #dash {
-    border-radius: 0px 0px 8px 8px;
+/* for the built-in theme only, we control border radius directly for each
+position. In the other cases the border are taken dynamically from the theme */
+#dashtodockContainer.dashtodock.top #dash {
+    border-radius: 0px 0px 9px 9px;
 }
 
-#dashtodockContainer.bottom #dash {
-    border-radius: 8px 8px 0px 0px;
+#dashtodockContainer.dashtodock.bottom #dash {
+    border-radius: 9px 9px 0px 0px;
 }
 
-#dashtodockContainer.left #dash {
-    border-radius: 0px 8px 8px 0px;
+#dashtodockContainer.dashtodock.left #dash {
+    border-radius: 0px 9px 9px 0px;
 }
 
-#dashtodockContainer.right #dash {
-    border-radius: 8px 0px 0px 8px;
+#dashtodockContainer.dashtodock.right #dash {
+    border-radius: 9px 0px 0px 9px;
 }
 
 /* Scrollview style */

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -32,6 +32,24 @@
     border-radius: 0px;
 }
 
+/* Adjust built-in theme for different orientations */
+
+#dashtodockContainer.top #dash {
+    border-radius: 0px 0px 8px 8px;
+}
+
+#dashtodockContainer.bottom #dash {
+    border-radius: 8px 8px 0px 0px;
+}
+
+#dashtodockContainer.left #dash {
+    border-radius: 0px 8px 8px 0px;
+}
+
+#dashtodockContainer.right #dash {
+    border-radius: 8px 0px 0px 8px;
+}
+
 /* Scrollview style */
 .bottom #dashtodockDashScrollview,
 .top #dashtodockDashScrollview {


### PR DESCRIPTION
The built-in theme does not account for Dash to Dock being able to place the dock anywhere on the screen, causing mismatched rounded corners if the dock is not placed on the left hand side while the built-in theme is enabled.

Fixes https://github.com/micheleg/dash-to-dock/issues/1010