### PR TITLE
locations: Fix missing behaviour for volume backed locations

### DIFF
--- a/locations.js
+++ b/locations.js
@@ -162,6 +162,10 @@ var Removables = class DashToDock_Removables {
             return;
         }
 
+        if (volume.get_identifier('class') == 'network') {
+            return;
+        }
+
         let activationRoot = volume.get_activation_root();
         if (!activationRoot) {
             // Can't offer to mount a device if we don't know

--- a/locations.js
+++ b/locations.js
@@ -170,7 +170,9 @@ var Removables = class DashToDock_Removables {
             // don't normally unmount them anyway.
             return;
         }
-        let uri = GLib.uri_unescape_string(activationRoot.get_uri(), null);
+
+        let escapedUri = activationRoot.get_uri()
+        let uri = GLib.uri_unescape_string(escapedUri, null);
 
         let volumeKeys = new GLib.KeyFile();
         volumeKeys.set_string('Desktop Entry', 'Name', volume.get_name());
@@ -178,6 +180,7 @@ var Removables = class DashToDock_Removables {
         volumeKeys.set_string('Desktop Entry', 'Type', 'Application');
         volumeKeys.set_string('Desktop Entry', 'Exec', 'gio open "' + uri + '"');
         volumeKeys.set_string('Desktop Entry', 'StartupNotify', 'false');
+        volumeKeys.set_string('Desktop Entry', 'XdtdUri', escapedUri);
         volumeKeys.set_string('Desktop Entry', 'Actions', 'mount;');
         volumeKeys.set_string('Desktop Action mount', 'Name', __('Mount'));
         volumeKeys.set_string('Desktop Action mount', 'Exec', 'gio mount "' + uri + '"');


### PR DESCRIPTION
I forgot to add this originally. Without it, we don't know that
the icon is a location rather than an app, and some undesired items
are added to the menu.

Mount icons already had this set and didn't have a problem.

Fixes #1037