### PR TITLE
Make notification badges configurable

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAdjustment" id="animation_time_adjustment">
@@ -1987,6 +1987,67 @@
                   </object>
                 </child>
                 <child>
+                  <object class="GtkListBoxRow">
+                    <property name="width_request">100</property>
+                    <property name="height_request">80</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkGrid" id="show_badges">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkSwitch" id="show_badges_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                            <property name="height">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="show_badges_description">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Show Unity-like notification and progress indicators</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="show_badge_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Show notification badges</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
                   <object class="GtkListBoxRow" id="listboxrow3">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -2409,7 +2470,7 @@
           <object class="GtkImage" id="logo">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="pixbuf">./media/logo.svg</property>
+            <property name="pixbuf">media/logo.svg</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -2654,54 +2715,6 @@ See the &lt;a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"&gt;G
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="min_alpha_box">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">12</property>
-                        <property name="margin_right">12</property>
-                        <property name="margin_top">12</property>
-                        <property name="margin_bottom">12</property>
-                        <property name="spacing">32</property>
-                        <child>
-                          <object class="GtkLabel" id="min_alpha_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Minimum opacity</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkScale" id="min_alpha_scale">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="adjustment">min_opacity_adjustement</property>
-                            <property name="lower_stepper_sensitivity">on</property>
-                            <property name="restrict_to_fill_level">False</property>
-                            <property name="fill_level">0</property>
-                            <property name="round_digits">0</property>
-                            <property name="digits">2</property>
-                            <property name="value_pos">right</property>
-                            <signal name="format-value" handler="min_opacity_scale_format_value_cb" swapped="no"/>
-                            <signal name="value-changed" handler="min_opacity_scale_value_changed_cb" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
                       <object class="GtkBox" id="max_alpha_box">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -2735,6 +2748,54 @@ See the &lt;a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"&gt;G
                             <property name="value_pos">right</property>
                             <signal name="format-value" handler="max_opacity_scale_format_value_cb" swapped="no"/>
                             <signal name="value-changed" handler="max_opacity_scale_value_changed_cb" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="min_alpha_box">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="min_alpha_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Minimum opacity</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScale" id="min_alpha_scale">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="adjustment">min_opacity_adjustement</property>
+                            <property name="lower_stepper_sensitivity">on</property>
+                            <property name="restrict_to_fill_level">False</property>
+                            <property name="fill_level">0</property>
+                            <property name="round_digits">0</property>
+                            <property name="digits">2</property>
+                            <property name="value_pos">right</property>
+                            <signal name="format-value" handler="min_opacity_scale_format_value_cb" swapped="no"/>
+                            <signal name="value-changed" handler="min_opacity_scale_value_changed_cb" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">True</property>

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -39,16 +39,16 @@ var AppIconIndicator = class DashToDock_AppIconIndicator {
 
     constructor(source) {
         this._indicators = [];
-
-        // Unity indicators always enabled for now
-        let unityIndicator = new UnityIndicator(source);
-        this._indicators.push(unityIndicator);
+        let settings = Docking.DockManager.settings;
+        if (settings.get_boolean('show-notification-badges')) {
+            let unityIndicator = new UnityIndicator(source);
+            this._indicators.push(unityIndicator);
+        }
 
         // Choose the style for the running indicators
         let runningIndicator = null;
         let runningIndicatorStyle;
 
-        let settings = Docking.DockManager.settings;
         if (settings.get_boolean('apply-custom-theme' )) {
             runningIndicatorStyle = RunningIndicatorStyle.DOTS;
         } else {

--- a/prefs.js
+++ b/prefs.js
@@ -664,6 +664,7 @@ var Settings = class DashToDock_Settings {
         this._settings.bind('apply-custom-theme', this._builder.get_object('customize_theme'), 'sensitive', Gio.SettingsBindFlags.INVERT_BOOLEAN | Gio.SettingsBindFlags.GET);
         this._settings.bind('apply-custom-theme', this._builder.get_object('builtin_theme_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('custom-theme-shrink', this._builder.get_object('shrink_dash_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-notification-badges', this._builder.get_object('show_badges_switch'), 'active', Gio.SettingsBindFlags.DEFAULT);
 
         // Running indicators
         this._builder.get_object('running_indicators_combo').set_active(

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -170,6 +170,11 @@
       <summary>TODO</summary>
       <description>TODO</description>
     </key>
+    <key type="b" name="show-notification-badges">
+      <default>false</default>
+      <summary>Show Unity-like notification and progress indicators.</summary>
+      <description>Show Unity-like notification and progress indicators.</description>
+    </key>
     <key type="b" name="custom-theme-customize-running-dots">
       <default>false</default>
       <summary>Customize the style of the running application indicators.</summary>


### PR DESCRIPTION
Fixes: https://github.com/micheleg/dash-to-dock/issues/872
Disabling icon badge count not possible

In the past, the Unity-like notification badges where always enabled. It is now possible to enable or disable the badges in the settings UI in the Appearance Tab