### PR TITLE
locations: Offer to filter out devices by regex

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1418,6 +1418,35 @@
                             <property name="top_attach">0</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkEntry" id="hide_mounts_regex_entry">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="hexpand">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <property name="margin_top">12</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="shrink_dash_label6">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">False</property>
+                            <property name="label" translatable="yes">Excludes devices matching (regex)</property>
+                            <property name="margin_top">12</property>
+                            <property name="valign">center</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/locations.js
+++ b/locations.js
@@ -13,6 +13,7 @@ const __ = Gettext.gettext;
 const N__ = function(e) { return e };
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Docking = Me.imports.docking;
 const Utils = Me.imports.utils;
 
 /**
@@ -102,8 +103,12 @@ var Removables = class DashToDock_Removables {
         this._signalsHandler = new Utils.GlobalSignalsHandler();
 
         this._monitor = Gio.VolumeMonitor.get();
+        this._settings = Docking.DockManager.settings;
         this._volumeApps = []
         this._mountApps = []
+
+        const regex_str = this._settings.get_string('hide-mounts-regex');
+        this._regex = regex_str ? new RegExp(regex_str) : null;
 
         this._monitor.get_volumes().forEach(
             (volume) => {
@@ -133,6 +138,10 @@ var Removables = class DashToDock_Removables {
             this._monitor,
             'volume-removed',
             this._onVolumeRemoved.bind(this)
+        ], [
+            this._settings,
+            'changed::hide-mounts-regex',
+            this._onRegexChanged.bind(this)
         ]);
     }
 
@@ -157,6 +166,39 @@ var Removables = class DashToDock_Removables {
         }
     }
 
+   _isLocationHidden(name) {
+        const regex = this._regex;
+        return regex ? regex.exec(name) : false;
+    }
+
+    _onRegexChanged(settings, key) {
+        const regex_str = settings.get_string(key);
+        this._regex = regex_str ? new RegExp(regex_str) : null;
+
+        this._monitor.get_volumes().forEach(
+            (volume) => {
+                this._onVolumeRemoved(this._monitor, volume);
+            }
+        );
+
+        this._monitor.get_mounts().forEach(
+            (mount) => {
+                this._onMountRemoved(this._monitor, mount);
+            }
+        );
+        this._monitor.get_volumes().forEach(
+            (volume) => {
+                this._onVolumeAdded(this._monitor, volume);
+            }
+        );
+
+        this._monitor.get_mounts().forEach(
+            (mount) => {
+                this._onMountAdded(this._monitor, mount);
+            }
+        );
+    }
+
     _onVolumeAdded(monitor, volume) {
         if (!volume.can_mount()) {
             return;
@@ -172,6 +214,10 @@ var Removables = class DashToDock_Removables {
             // where to mount it.
             // These devices are usually ejectable so you
             // don't normally unmount them anyway.
+            return;
+        }
+
+        if (this._isLocationHidden(volume.get_name())) {
             return;
         }
 
@@ -213,6 +259,10 @@ var Removables = class DashToDock_Removables {
 
         let volume = mount.get_volume();
         if (!volume || volume.get_identifier('class') == 'network') {
+            return;
+        }
+
+        if (this._isLocationHidden(mount.get_name())) {
             return;
         }
 

--- a/prefs.js
+++ b/prefs.js
@@ -493,6 +493,10 @@ var Settings = class DashToDock_Settings {
                             this._builder.get_object('show_mounts_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('hide-mounts-regex',
+                            this._builder.get_object('hide_mounts_regex_entry'),
+                            'text',
+                            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-show-apps-button',
                             this._builder.get_object('show_applications_button_switch'),
                             'active',

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -225,6 +225,11 @@
       <summary>Show mounted volumes and devices</summary>
       <description>Show or hide mounted volume and device icons in the dash</description>
     </key>
+    <key type="s" name="hide-mounts-regex">
+      <default>""</default>
+      <summary>Regex to filter and hide mounted devices</summary>
+      <description>Hide certain mounted volume and device icons in the dash</description>
+    </key>
     <key type="b" name="show-show-apps-button">
       <default>true</default>
       <summary>Show applications button</summary>


### PR DESCRIPTION
People have asked for the ability to filter out certain devices from
appearing in the doc and today it is all-or-nothing.

This change is somewhat a proof-of-concept as the user configuration
is literally a regex, which is very powerful but not terribly
intuitive. I would be interested in suggesitons on how to handle the
configuration.

Fixes #1081