### PR TITLE
Use new convenience function to open settings

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -27,7 +27,8 @@ const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
 const Workspace = imports.ui.workspace;
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
 const Docking = Me.imports.docking;
 const Utils = Me.imports.utils;
 const WindowPreview = Me.imports.windowPreview;
@@ -1126,7 +1127,11 @@ var MyShowAppsIconMenu = class DashToDock_MyShowAppsIconMenu extends MyAppIconMe
         let item = this._appendMenuItem(name);
 
         item.connect('activate', function () {
-            Util.spawn(["gnome-shell-extension-prefs", Me.metadata.uuid]);
+            if (typeof ExtensionUtils.openPrefs === 'function') {
+                ExtensionUtils.openPrefs();
+            } else {
+                Util.spawn(["gnome-shell-extension-prefs", Me.metadata.uuid]);
+            }
         });
     }
 };


### PR DESCRIPTION
Gnome Shell 3.36 changed the API to open the settings. From 3.36.2 on
it also provides a convenience function to make that easier - use it
if available.

See also https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/1163

Complementary to https://github.com/micheleg/dash-to-dock/pull/1097

---

Note: I'm not very experienced in js, so any suggestions to make this more elegant are welcome :)