### PR TITLE
Fix regression (wrong sign when computing position).

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1126,8 +1126,8 @@ var DockedDash = GObject.registerClass({
                             let [, y] = overviewControls.get_transformed_position();
                             let [, height] = overviewControls.get_transformed_size();
                             let monitor = Main.layoutManager.primaryMonitor;
-                            let contentY2 = monitor.y + y + height;
-                            let offset = Math.max(0, contentY2 - monitor.height);
+                            let contentY2 = y + height;
+                            let offset = Math.max(0, contentY2 - (monitor.y + monitor.height));
 
                             if (this._marginLater)
                                 Meta.later_remove(this._marginLater);


### PR DESCRIPTION
Introduced in 4a40b1de64ba83656f0df40cc8c91eb34cd4d302. The problem was
occurring only when monitor.y !=0 (and with extended mode with execute
the code).