### PR TITLE
Remove padding the dock ends in panel mode.

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -82,14 +82,18 @@ position. In the other cases the border are taken dynamically from the theme */
 
 #dashtodockContainer.extended.top #dash,
 #dashtodockContainer.extended.bottom #dash {
-    border-left:0px;
-    border-right:0px;
+    border-left: 0px;
+    border-right: 0px;
+    padding-top: 0px;
+    padding-bottom: 0px;
 }
 
 #dashtodockContainer.extended.right #dash,
 #dashtodockContainer.extended.left #dash {
-    border-top:0px;
-    border-bottom:0px;
+    border-top: 0px;
+    border-bottom: 0px;
+    padding-top: 0px;
+    padding-bottom: 0px;
 }
 
 /* Running and focused application style */


### PR DESCRIPTION
This is to make the showapps button cover the screen corner where the
mouse is likely to land when trying to activate it.

This slightly modifies the rendering of the dash (removing some
padding), restoring the look and behaviour of previous gnome-shell
releases.

Fix #1167.