### PR TITLE
locations: Handle emblemed mount icons

### DIFF
--- a/locations.js
+++ b/locations.js
@@ -142,6 +142,9 @@ var Removables = class DashToDock_Removables {
     }
 
     _getWorkingIconName(icon) {
+        if (icon instanceof Gio.EmblemedIcon) {
+            icon = icon.get_icon();
+        }
         if (icon instanceof Gio.ThemedIcon) {
             let iconTheme = Gtk.IconTheme.get_default();
             let names = icon.get_names();


### PR DESCRIPTION
Drive icons could potentially have an emblem applied to them, meaning
that we need to be aware of the emblemed icon type and how to resolve
an icon for us to use.

Fixes #1175.