### PR TITLE
Fix JS error when the dash has no icons

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -608,6 +608,10 @@ var MyDash = GObject.registerClass({
         let firstButton = iconChildren[0].child;
         let firstIcon = firstButton.icon;
 
+        // if no icons there's nothing to adjust
+        if (!firstIcon)
+        	return;
+
         // Enforce the current icon size during the size request
         firstIcon.setIconSize(this.iconSize);
         let [, natHeight] = firstButton.get_preferred_height(-1);


### PR DESCRIPTION
This pull request fixes the JS error reported in here https://github.com/micheleg/dash-to-dock/issues/1188

The approach is quite simple, if there is no "first icon", it means there's no icons at all and there's nothing to to anymore, so simply return. I hope the approach is fine, I tested it on my installation and it fixes the problem reported in the issue.

Fixes #1188 