### PR TITLE
Option to centre the icons whenenver the dock is extended.

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -119,7 +119,7 @@ var IndicatorBase = class DashToDock_IndicatorBase {
         this._source = source;
         this._signalsHandler = new Utils.GlobalSignalsHandler();
 
-        this._sourceDestroyId = this._source.actor.connect('destroy', () => {
+        this._sourceDestroyId = this._source.connect('destroy', () => {
             this._signalsHandler.destroy();
         });
     }
@@ -128,7 +128,7 @@ var IndicatorBase = class DashToDock_IndicatorBase {
     }
 
     destroy() {
-        this._source.actor.disconnect(this._sourceDestroyId);
+        this._source.disconnect(this._sourceDestroyId);
         this._signalsHandler.destroy();
     }
 };
@@ -180,17 +180,17 @@ var RunningIndicatorBase = class DashToDock_RunningIndicatorBase extends Indicat
         for (let i = 1; i <= MAX_WINDOWS_CLASSES; i++) {
             let className = 'running' + i;
             if (i != this._nWindows)
-                this._source.actor.remove_style_class_name(className);
+                this._source.remove_style_class_name(className);
             else
-                this._source.actor.add_style_class_name(className);
+                this._source.add_style_class_name(className);
         }
     }
 
     _updateFocusClass() {
         if (this._isFocused)
-            this._source.actor.add_style_class_name('focused');
+            this._source.add_style_class_name('focused');
         else
-            this._source.actor.remove_style_class_name('focused');
+            this._source.remove_style_class_name('focused');
     }
 
     _updateDefaultDot() {
@@ -256,11 +256,11 @@ var RunningIndicatorDefault = class DashToDock_RunningIndicatorDefault extends R
 
     constructor(source) {
         super(source);
-        this._source.actor.add_style_class_name('default');
+        this._source.add_style_class_name('default');
     }
 
     destroy() {
-        this._source.actor.remove_style_class_name('default');
+        this._source.remove_style_class_name('default');
         super.destroy();
     }
 };
@@ -597,11 +597,11 @@ var RunningIndicatorMetro = class DashToDock_RunningIndicatorMetro extends Runni
 
     constructor(source) {
         super(source);
-        this._source.actor.add_style_class_name('metro');
+        this._source.add_style_class_name('metro');
     }
 
     destroy() {
-        this._source.actor.remove_style_class_name('metro');
+        this._source.remove_style_class_name('metro');
         super.destroy();
     }
 

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -659,7 +659,8 @@ var UnityIndicator = class DashToDock_UnityIndicator extends IndicatorBase {
         this._notificationBadgeLabel = new St.Label();
         this._notificationBadgeBin = new St.Bin({
             child: this._notificationBadgeLabel,
-            x_align: St.Align.END, y_align: St.Align.START,
+            x_align: Clutter.ActorAlign.END,
+            y_align: Clutter.ActorAlign.START,
             x_expand: true, y_expand: true
         });
         this._notificationBadgeLabel.add_style_class_name('notification-badge');

--- a/appIcons.js
+++ b/appIcons.js
@@ -783,6 +783,11 @@ const MyAppIconMenu = class DashToDock_MyAppIconMenu extends AppDisplay.AppIconM
     }
 
     _redisplay() {
+        // This will be removed by 3.36.1
+        return this._rebuildMenu();
+    }
+
+    _rebuildMenu() {
         this.removeAll();
 
         if (Docking.DockManager.settings.get_boolean('show-windows-preview')) {
@@ -880,7 +885,10 @@ const MyAppIconMenu = class DashToDock_MyAppIconMenu extends AppDisplay.AppIconM
             }
 
         } else {
-            super._redisplay();
+            if (super._rebuildMenu)
+                super._rebuildMenu();
+            else
+                super._redisplay();
         }
 
         // quit menu
@@ -1035,6 +1043,10 @@ var MyShowAppsIcon = GObject.registerClass({
         this.toggleButton.connect('clicked',
             this._removeMenuTimeout.bind(this));
 
+        this.reactive = true;
+        this.toggleButton.popupMenu = () => this.popupMenu.call(this);
+        this.toggleButton._removeMenuTimeout = () => this._removeMenuTimeout.call(this);
+
         this._menu = null;
         this._menuManager = new PopupMenu.PopupMenuManager(this);
         this._menuTimeoutId = 0;
@@ -1042,20 +1054,20 @@ var MyShowAppsIcon = GObject.registerClass({
 
     vfunc_leave_event(leaveEvent)
     {
-        return AppDisplay.AppIcon.prototype.vfunc_leave_event.apply(this,
-            leaveEvent);
+        return AppDisplay.AppIcon.prototype.vfunc_leave_event.call(
+            this.toggleButton, leaveEvent);
     }
 
     vfunc_button_press_event(buttonPressEvent)
     {
-        return AppDisplay.AppIcon.prototype.vfunc_button_press_event.apply(this,
-            buttonPressEvent);
+        return AppDisplay.AppIcon.prototype.vfunc_button_press_event.call(
+            this.toggleButton, buttonPressEvent);
     }
 
     vfunc_touch_event(touchEvent)
     {
-        return AppDisplay.AppIcon.prototype.vfunc_touch_event.apply(this,
-            touchEvent);
+        return AppDisplay.AppIcon.prototype.vfunc_touch_event.call(
+            this.toggleButton, touchEvent);
     }
 
     showLabel() {
@@ -1110,6 +1122,11 @@ var MyShowAppsIcon = GObject.registerClass({
  */
 var MyShowAppsIconMenu = class DashToDock_MyShowAppsIconMenu extends MyAppIconMenu {
     _redisplay() {
+        // This will be removed by 3.36.1
+        return this._rebuildMenu();
+    }
+
+    _rebuildMenu() {
         this.removeAll();
 
         /* Translators: %s is "Settings", which is automatically translated. You

--- a/appIcons.js
+++ b/appIcons.js
@@ -5,7 +5,6 @@ const GdkPixbuf = imports.gi.GdkPixbuf
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
-const Gtk = imports.gi.Gtk;
 const Signals = imports.signals;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;

--- a/appIcons.js
+++ b/appIcons.js
@@ -310,7 +310,7 @@ class MyAppIcon extends Dash.DashIcon {
                                            position == St.Side.BOTTOM);
                     // If horizontal also remove the height of the dash
                     let fixedDock = Docking.DockManager.settings.get_boolean('dock-fixed');
-                    let additional_margin = this._isHorizontal && !fixedDock ? Main.overview._dash.height : 0;
+                    let additional_margin = this._isHorizontal && !fixedDock ? Main.overview.dash.height : 0;
                     let verticalMargins = this._menu.actor.margin_top + this._menu.actor.margin_bottom;
                     // Also set a max width to the menu, so long labels (long windows title) get truncated
                     this._menu.actor.style = ('max-height: ' + Math.round(workArea.height - additional_margin - verticalMargins) + 'px;' +

--- a/appIcons.js
+++ b/appIcons.js
@@ -87,7 +87,6 @@ class MyAppIcon extends Dash.DashIcon {
         this._location = appInfo ? appInfo.get_string('XdtdUri') : null;
 
         this._updateIndicatorStyle();
-        this._optionalScrollCycleWindows();
 
         // Monitor windows-changes instead of app state.
         // Keep using the same Id and function callback (that is extended)
@@ -139,12 +138,6 @@ class MyAppIcon extends Dash.DashIcon {
             ]);
         }
 
-        this._signalsHandler.add([
-            Docking.DockManager.settings,
-            'changed::scroll-action',
-            this._optionalScrollCycleWindows.bind(this)
-        ]);
-
         this._numberOverlay();
 
         this._previewMenuManager = null;
@@ -191,20 +184,11 @@ class MyAppIcon extends Dash.DashIcon {
             this.onWindowsChanged();
     }
 
-    _optionalScrollCycleWindows() {
-        if (this._scrollEventHandler) {
-            this.disconnect(this._scrollEventHandler);
-            this._scrollEventHandler = 0;
-        }
-
+    vfunc_scroll_event(scrollEvent) {
         let settings = Docking.DockManager.settings;
         let isEnabled = settings.get_enum('scroll-action') === scrollAction.CYCLE_WINDOWS;
-        if (!isEnabled) return;
-        this._scrollEventHandler = this.connect('scroll-event',
-            this.onScrollEvent.bind(this));
-    }
-
-    onScrollEvent(actor, event) {
+        if (!isEnabled)
+            return Clutter.EVENT_PROPAGATE;
 
         // We only activate windows of running applications, i.e. we never open new windows
         // We check if the app is running, and that the # of windows is > 0 in
@@ -213,10 +197,10 @@ class MyAppIcon extends Dash.DashIcon {
             && this.getInterestingWindows().length > 0;
 
         if (!appIsRunning)
-            return false
+            return Clutter.EVENT_PROPAGATE;
 
         if (this._optionalScrollCycleWindowsDeadTimeId)
-            return false;
+            return Clutter.EVENT_PROPAGATE;
         else
             this._optionalScrollCycleWindowsDeadTimeId = GLib.timeout_add(
                 GLib.PRIORITY_DEFAULT, 250, () => {
@@ -225,7 +209,7 @@ class MyAppIcon extends Dash.DashIcon {
 
         let direction = null;
 
-        switch (event.get_scroll_direction()) {
+        switch (scrollEvent.direction) {
         case Clutter.ScrollDirection.UP:
             direction = Meta.MotionDirection.UP;
             break;
@@ -233,7 +217,7 @@ class MyAppIcon extends Dash.DashIcon {
             direction = Meta.MotionDirection.DOWN;
             break;
         case Clutter.ScrollDirection.SMOOTH:
-            let [dx, dy] = event.get_scroll_delta();
+            let [, dy] = Clutter.get_current_event().get_scroll_delta();
             if (dy < 0)
                 direction = Meta.MotionDirection.UP;
             else if (dy > 0)
@@ -257,7 +241,7 @@ class MyAppIcon extends Dash.DashIcon {
         }
         else
             this.app.activate();
-        return true;
+        return Clutter.EVENT_STOP;
     }
 
     onWindowsChanged() {

--- a/appIcons.js
+++ b/appIcons.js
@@ -614,7 +614,8 @@ class MyAppIcon extends Dash.DashIcon {
         this._numberOverlayLabel = new St.Label();
         this._numberOverlayBin = new St.Bin({
             child: this._numberOverlayLabel,
-            x_align: St.Align.START, y_align: St.Align.START,
+            x_align: Clutter.ActorAlign.START,
+            y_align: Clutter.ActorAlign.START,
             x_expand: true, y_expand: true
         });
         this._numberOverlayLabel.add_style_class_name('number-overlay');

--- a/dash.js
+++ b/dash.js
@@ -433,16 +433,14 @@ var MyDash = GObject.registerClass({
 
     _createAppItem(app) {
         let appIcon = new AppIcons.MyAppIcon(this._remoteModel, app,
-                                             this._monitorIndex,
-                                             { setSizeManually: true,
-                                               showLabel: false });
+            this._monitorIndex);
 
         if (appIcon._draggable) {
             appIcon._draggable.connect('drag-begin', () => {
-                appIcon.actor.opacity = 50;
+                appIcon.opacity = 50;
             });
             appIcon._draggable.connect('drag-end', () => {
-                appIcon.actor.opacity = 255;
+                appIcon.opacity = 255;
             });
         }
 
@@ -451,13 +449,13 @@ var MyDash = GObject.registerClass({
         });
 
         let item = new MyDashItemContainer();
-        item.setChild(appIcon.actor);
+        item.setChild(appIcon);
 
-        appIcon.actor.connect('notify::hover', () => {
-            if (appIcon.actor.hover) {
+        appIcon.connect('notify::hover', () => {
+            if (appIcon.hover) {
                 this._ensureAppIconVisibilityTimeoutId = GLib.timeout_add(
                     GLib.PRIORITY_DEFAULT, 100, () => {
-                    ensureActorVisibleInScrollView(this._scrollView, appIcon.actor);
+                    ensureActorVisibleInScrollView(this._scrollView, appIcon);
                     this._ensureAppIconVisibilityTimeoutId = 0;
                     return GLib.SOURCE_REMOVE;
                 });
@@ -470,11 +468,11 @@ var MyDash = GObject.registerClass({
             }
         });
 
-        appIcon.actor.connect('clicked', (actor) => {
+        appIcon.connect('clicked', (actor) => {
             ensureActorVisibleInScrollView(this._scrollView, actor);
         });
 
-        appIcon.actor.connect('key-focus-in', (actor) => {
+        appIcon.connect('key-focus-in', (actor) => {
             let [x_shift, y_shift] = ensureActorVisibleInScrollView(this._scrollView, actor);
 
             // This signal is triggered also by mouse click. The popup menu is opened at the original
@@ -487,7 +485,7 @@ var MyDash = GObject.registerClass({
 
         // Override default AppIcon label_actor, now the
         // accessible_name is set at DashItemContainer.setLabelText
-        appIcon.actor.label_actor = null;
+        appIcon.label_actor = null;
         item.setLabelText(app.get_name());
 
         appIcon.icon.setIconSize(this.iconSize);

--- a/dash.js
+++ b/dash.js
@@ -85,7 +85,7 @@ class DashToDock_MyDashActor extends St.Widget {
 
     vfunc_allocate(box, flags) {
         this.set_allocation(box, flags);
-        let contentBox = box;
+        let contentBox = this.get_theme_node().get_content_box(box);
         let availWidth = contentBox.x2 - contentBox.x1;
         let availHeight = contentBox.y2 - contentBox.y1;
 

--- a/dash.js
+++ b/dash.js
@@ -216,10 +216,11 @@ var MyDash = GObject.registerClass({
 
         this._scrollView.connect('scroll-event', this._onScrollEvent.bind(this));
 
+        let rtl = Clutter.get_default_text_direction() == Clutter.TextDirection.RTL;
         this._box = new St.BoxLayout({
             vertical: !this._isHorizontal,
             clip_to_allocation: false,
-            x_align: Clutter.ActorAlign.START,
+            x_align: rtl ? Clutter.ActorAlign.END : Clutter.ActorAlign.START,
             y_align: Clutter.ActorAlign.START
         });
         this._box._delegate = this;
@@ -237,11 +238,10 @@ var MyDash = GObject.registerClass({
 
         this._container.add_actor(this._showAppsIcon);
 
-        let rtl = Clutter.get_default_text_direction() == Clutter.TextDirection.RTL;
         super._init({
             child: this._container,
+            x_align: Clutter.ActorAlign.START,
             y_align: Clutter.ActorAlign.START,
-            x_align: rtl ? Clutter.ActorAlign.END : Clutter.ActorAlign.START,
         });
 
         if (this._isHorizontal) {

--- a/dash.js
+++ b/dash.js
@@ -69,7 +69,7 @@ class DashToDock_MyDashActor extends St.Widget {
         super._init({
             name: 'dash',
             layout_manager: layout,
-            clip_to_allocation: true
+            clip_to_allocation: true,
         });
 
         // Since we are usually visible but not usually changing, make sure
@@ -235,8 +235,8 @@ var MyDash = GObject.registerClass({
         let rtl = Clutter.get_default_text_direction() == Clutter.TextDirection.RTL;
         super._init({
             child: this._container,
-            y_align: St.Align.START,
-            x_align: rtl ? St.Align.END : St.Align.START
+            y_align: Clutter.ActorAlign.START,
+            x_align: rtl ? Clutter.ActorAlign.END : Clutter.ActorAlign.START,
         });
 
         if (this._isHorizontal) {

--- a/dash.js
+++ b/dash.js
@@ -84,14 +84,15 @@ class DashToDock_MyDashActor extends St.Widget {
     }
 
     vfunc_allocate(box, flags) {
-        this.set_allocation(box, flags);
         let contentBox = this.get_theme_node().get_content_box(box);
         let availWidth = contentBox.x2 - contentBox.x1;
         let availHeight = contentBox.y2 - contentBox.y1;
 
+        this.set_allocation(box, flags);
+
         let [appIcons, showAppsButton] = this.get_children();
-        let [showAppsMinHeight, showAppsNatHeight] = showAppsButton.get_preferred_height(availWidth);
-        let [showAppsMinWidth, showAppsNatWidth] = showAppsButton.get_preferred_width(availHeight);
+        let [, showAppsNatHeight] = showAppsButton.get_preferred_height(availWidth);
+        let [, showAppsNatWidth] = showAppsButton.get_preferred_width(availHeight);
 
         let offset_x = this._isHorizontal?showAppsNatWidth:0;
         let offset_y = this._isHorizontal?0:showAppsNatHeight;

--- a/dash.js
+++ b/dash.js
@@ -547,17 +547,13 @@ var MyDash = GObject.registerClass({
         let firstButton = iconChildren[0].child;
         let firstIcon = firstButton.icon;
 
-        let minHeight, natHeight, minWidth, natWidth;
-
         // Enforce the current icon size during the size request
         firstIcon.setIconSize(this.iconSize);
-        [minHeight, natHeight] = firstButton.get_preferred_height(-1);
-        [minWidth, natWidth] = firstButton.get_preferred_width(-1);
+        let [, natHeight] = firstButton.get_preferred_height(-1);
+        let [, natWidth] = firstButton.get_preferred_width(-1);
 
         let scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
-        let iconSizes = this._availableIconSizes.map(function(s) {
-            return s * scaleFactor;
-        });
+        let iconSizes = this._availableIconSizes.map(s => s * scaleFactor);
 
         // Subtract icon padding and box spacing from the available height
         if (this._isHorizontal)
@@ -605,7 +601,6 @@ var MyDash = GObject.registerClass({
             icon.icon.set_size(icon.icon.width * scale,
                                icon.icon.height * scale);
 
-            icon.icon.remove_all_transitions();
             icon.icon.ease({
                 width: targetWidth,
                 height: targetHeight,

--- a/dash.js
+++ b/dash.js
@@ -4,8 +4,6 @@ const Clutter = imports.gi.Clutter;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
-const Gtk = imports.gi.Gtk;
-const Signals = imports.signals;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
@@ -200,8 +198,8 @@ var MyDash = GObject.registerClass({
         this._container = new MyDashActor();
         this._scrollView = new St.ScrollView({
             name: 'dashtodockDashScrollview',
-            hscrollbar_policy: Gtk.PolicyType.NEVER,
-            vscrollbar_policy: Gtk.PolicyType.NEVER,
+            hscrollbar_policy: St.PolicyType.NEVER,
+            vscrollbar_policy: St.PolicyType.NEVER,
             enable_mouse_scrolling: false
         });
 

--- a/dash.js
+++ b/dash.js
@@ -509,13 +509,12 @@ var MyDash = GObject.registerClass({
         // the animation)
         let iconChildren = this._box.get_children().filter(function(actor) {
             return actor.child &&
-                   actor.child._delegate &&
-                   actor.child._delegate.icon &&
+                   actor.child.icon &&
                    !actor.animatingOut;
         });
 
         let appIcons = iconChildren.map(function(actor) {
-            return actor.child._delegate;
+            return actor.child;
         });
 
       return appIcons;
@@ -598,8 +597,7 @@ var MyDash = GObject.registerClass({
         // the animation)
         let iconChildren = this._box.get_children().filter(function(actor) {
             return actor.child &&
-                   actor.child._delegate &&
-                   actor.child._delegate.icon &&
+                   actor.child.icon &&
                    !actor.animatingOut;
         });
 
@@ -629,7 +627,7 @@ var MyDash = GObject.registerClass({
         let spacing = themeNode.get_length('spacing');
 
         let firstButton = iconChildren[0].child;
-        let firstIcon = firstButton._delegate.icon;
+        let firstIcon = firstButton.icon;
 
         let minHeight, natHeight, minWidth, natWidth;
 
@@ -669,7 +667,7 @@ var MyDash = GObject.registerClass({
 
         let scale = oldIconSize / newIconSize;
         for (let i = 0; i < iconChildren.length; i++) {
-            let icon = iconChildren[i].child._delegate.icon;
+            let icon = iconChildren[i].child.icon || iconChildren[i].icon;
 
             // Set the new size immediately, to keep the icons' sizes
             // in sync with this.iconSize
@@ -717,12 +715,11 @@ var MyDash = GObject.registerClass({
 
         let children = this._box.get_children().filter(function(actor) {
             return actor.child &&
-                   actor.child._delegate &&
-                   actor.child._delegate.app;
+                   actor.child.app;
         });
         // Apps currently in the dash
         let oldApps = children.map(function(actor) {
-            return actor.child._delegate.app;
+            return actor.child.app;
         });
         // Apps supposed to be in the dash
         let newApps = [];
@@ -834,7 +831,7 @@ var MyDash = GObject.registerClass({
             // App moved
             let insertHere = newApps[newIndex + 1] && (newApps[newIndex + 1] == oldApps[oldIndex]);
             let alreadyRemoved = removedActors.reduce(function(result, actor) {
-                let removedApp = actor.child._delegate.app;
+                let removedApp = actor.child.app;
                 return result || removedApp == newApps[newIndex];
             }, false);
 
@@ -950,8 +947,7 @@ var MyDash = GObject.registerClass({
     resetAppIcons() {
         let children = this._box.get_children().filter(function(actor) {
             return actor.child &&
-                actor.child._delegate &&
-                actor.child._delegate.icon;
+                actor.child.icon;
         });
         for (let i = 0; i < children.length; i++) {
             let item = children[i];
@@ -1102,7 +1098,7 @@ var MyDash = GObject.registerClass({
             if (this._dragPlaceholder && (children[i] == this._dragPlaceholder))
                 continue;
 
-            let childId = children[i].child._delegate.app.get_id();
+            let childId = children[i].child.app.get_id();
             if (childId == id)
                 continue;
             if (childId in favorites)

--- a/dash.js
+++ b/dash.js
@@ -112,8 +112,7 @@ class DashToDock_MyDashActor extends St.Widget {
             childBox.x2 = contentBox.x1 + showAppsNatWidth;
             childBox.y2 = contentBox.y1 + showAppsNatHeight;
             showAppsButton.allocate(childBox, flags);
-        }
-        else {
+        } else {
             childBox.x1 = contentBox.x1;
             childBox.y1 = contentBox.y1;
             childBox.x2 = contentBox.x2 - offset_x;
@@ -129,33 +128,24 @@ class DashToDock_MyDashActor extends St.Widget {
     }
 
     vfunc_get_preferred_width(forHeight) {
-        // We want to request the natural height of all our children
-        // as our natural height, so we chain up to StWidget (which
+        // We want to request the natural width of all our children
+        // as our natural width, so we chain up to StWidget (which
         // then calls BoxLayout), but we only request the showApps
         // button as the minimum size
 
-        let [, natWidth] = this.layout_manager.get_preferred_width(this, forHeight);
+        let [, natWidth] = super.vfunc_get_preferred_width(forHeight);
 
         let themeNode = this.get_theme_node();
+        let adjustedForHeight = themeNode.adjust_for_height(forHeight);
         let [, showAppsButton] = this.get_children();
-        let [minWidth, ] = showAppsButton.get_preferred_height(forHeight);
+        let [minWidth] = showAppsButton.get_preferred_width(adjustedForHeight);
+        [minWidth] = themeNode.adjust_preferred_width(minWidth, natWidth);
 
         return [minWidth, natWidth];
     }
 
     vfunc_get_preferred_height(forWidth) {
-        // We want to request the natural height of all our children
-        // as our natural height, so we chain up to StWidget (which
-        // then calls BoxLayout), but we only request the showApps
-        // button as the minimum size
-
-        let [, natHeight] = this.layout_manager.get_preferred_height(this, forWidth);
-
-        let themeNode = this.get_theme_node();
-        let [, showAppsButton] = this.get_children();
-        let [minHeight, ] = showAppsButton.get_preferred_height(forWidth);
-
-        return [minHeight, natHeight];
+        return Dash.DashActor.prototype.vfunc_get_preferred_height.call(this, forWidth);
     }
 });
 

--- a/dash.js
+++ b/dash.js
@@ -70,6 +70,11 @@ class DashToDock_MyDashActor extends St.Widget {
             name: 'dash',
             layout_manager: layout,
             clip_to_allocation: true,
+            ...(this._isHorizontal ? {
+                x_align: Clutter.ActorAlign.CENTER,
+            } : {
+                y_align: Clutter.ActorAlign.CENTER,
+            })
         });
 
         // Since we are usually visible but not usually changing, make sure

--- a/dash.js
+++ b/dash.js
@@ -309,6 +309,58 @@ var MyDash = GObject.registerClass({
         this._signalsHandler.destroy();
     }
 
+    _onDragBegin() {
+        return Dash.Dash.prototype._onDragBegin.call(this, ...arguments);
+    }
+
+    _onDragCancelled() {
+        return Dash.Dash.prototype._onDragCancelled.call(this, ...arguments);
+    }
+
+    _onDragEnd() {
+        return Dash.Dash.prototype._onDragEnd.call(this, ...arguments);
+    }
+
+    _endDrag() {
+        return Dash.Dash.prototype._endDrag.call(this, ...arguments);
+    }
+
+    _onDragMotion() {
+        return Dash.Dash.prototype._onDragMotion.call(this, ...arguments);
+    }
+
+    _appIdListToHash() {
+        return Dash.Dash.prototype._appIdListToHash.call(this, ...arguments);
+    }
+
+    _queueRedisplay() {
+        return Dash.Dash.prototype._queueRedisplay.call(this, ...arguments);
+    }
+
+    _hookUpLabel() {
+        return Dash.Dash.prototype._hookUpLabel.call(this, ...arguments);
+    }
+
+    _syncLabel() {
+        return Dash.Dash.prototype._syncLabel.call(this, ...arguments);
+    }
+
+    _clearDragPlaceholder() {
+        return Dash.Dash.prototype._clearDragPlaceholder.call(this, ...arguments);
+    }
+
+    _clearEmptyDropTarget() {
+        return Dash.Dash.prototype._clearEmptyDropTarget.call(this, ...arguments);
+    }
+
+    handleDragOver() {
+        return Dash.Dash.prototype.handleDragOver.call(this, ...arguments);
+    }
+
+    acceptDrop() {
+        return Dash.Dash.prototype.acceptDrop.call(this, ...arguments);
+    }
+
     _onScrollEvent(actor, event) {
         // If scroll is not used because the icon is resized, let the scroll event propagate.
         if (!Docking.DockManager.settings.get_boolean('icon-size-fixed'))
@@ -352,88 +404,6 @@ var MyDash = GObject.registerClass({
         adjustment.set_value(adjustment.get_value() + delta);
 
         return Clutter.EVENT_STOP;
-    }
-
-    _onDragBegin() {
-        this._dragCancelled = false;
-        this._dragMonitor = {
-            dragMotion: this._onDragMotion.bind(this)
-        };
-        DND.addDragMonitor(this._dragMonitor);
-
-        if (this._box.get_n_children() == 0) {
-            this._emptyDropTarget = new Dash.EmptyDropTargetItem();
-            this._box.insert_child_at_index(this._emptyDropTarget, 0);
-            this._emptyDropTarget.show(true);
-        }
-    }
-
-    _onDragCancelled() {
-        this._dragCancelled = true;
-        this._endDrag();
-    }
-
-    _onDragEnd() {
-        if (this._dragCancelled)
-            return;
-
-        this._endDrag();
-    }
-
-    _endDrag() {
-        this._clearDragPlaceholder();
-        this._clearEmptyDropTarget();
-        this._showAppsIcon.setDragApp(null);
-        DND.removeDragMonitor(this._dragMonitor);
-    }
-
-    _onDragMotion(dragEvent) {
-        let app = Dash.getAppFromSource(dragEvent.source);
-        if (app == null)
-            return DND.DragMotionResult.CONTINUE;
-
-        let showAppsHovered = this._showAppsIcon.contains(dragEvent.targetActor);
-
-        if (!this._box.contains(dragEvent.targetActor) || showAppsHovered)
-            this._clearDragPlaceholder();
-
-        if (showAppsHovered)
-            this._showAppsIcon.setDragApp(app);
-        else
-            this._showAppsIcon.setDragApp(null);
-
-        return DND.DragMotionResult.CONTINUE;
-    }
-
-    _appIdListToHash(apps) {
-        let ids = {};
-        for (let i = 0; i < apps.length; i++)
-            ids[apps[i].get_id()] = apps[i];
-        return ids;
-    }
-
-    _queueRedisplay() {
-        Main.queueDeferredWork(this._workId);
-    }
-
-    _hookUpLabel(item, appIcon) {
-        item.child.connect('notify::hover', () => {
-            this._syncLabel(item, appIcon);
-        });
-
-        let id = Main.overview.connect('hiding', () => {
-            this._labelShowing = false;
-            item.hideLabel();
-        });
-        item.child.connect('destroy', function() {
-            Main.overview.disconnect(id);
-        });
-
-        if (appIcon) {
-            appIcon.connect('sync-tooltip', () => {
-                this._syncLabel(item, appIcon);
-            });
-        }
     }
 
     _createAppItem(app) {
@@ -528,65 +498,13 @@ var MyDash = GObject.registerClass({
     }
 
     _itemMenuStateChanged(item, opened) {
-        // When the menu closes, it calls sync_hover, which means
-        // that the notify::hover handler does everything we need to.
-        if (opened) {
-            if (this._showLabelTimeoutId > 0) {
-                GLib.source_remove(this._showLabelTimeoutId);
-                this._showLabelTimeoutId = 0;
-            }
+        Dash.Dash.prototype.acceptDrop.call(this, item, opened);
 
-            item.label.opacity = 0;
-            item.label.hide();
-        }
-        else {
+        if (!opened) {
             // I want to listen from outside when a menu is closed. I used to
             // add a custom signal to the appIcon, since gnome 3.8 the signal
             // calling this callback was added upstream.
             this.emit('menu-closed');
-        }
-    }
-
-    _syncLabel(item, appIcon) {
-        let shouldShow = appIcon ? appIcon.shouldShowTooltip() : item.child.get_hover();
-
-        if (shouldShow) {
-            if (this._showLabelTimeoutId == 0) {
-                let timeout = this._labelShowing ? 0 : DASH_ITEM_HOVER_TIMEOUT;
-                let actor = (item instanceof Clutter.Actor) ? item : item.actor;
-                let destroyId = actor.connect('destroy', () => {
-                    if (this._showLabelTimeoutId)
-                        GLib.source_remove(this._showLabelTimeoutId);
-                });
-                this._showLabelTimeoutId = GLib.timeout_add(
-                    GLib.PRIORITY_DEFAULT, timeout, () => {
-                    this._showLabelTimeoutId = 0;
-                    actor.disconnect(destroyId);
-                    this._labelShowing = true;
-                    item.showLabel();
-                    return GLib.SOURCE_REMOVE;
-                });
-                GLib.Source.set_name_by_id(this._showLabelTimeoutId, '[gnome-shell] item.showLabel');
-                if (this._resetHoverTimeoutId > 0) {
-                    GLib.source_remove(this._resetHoverTimeoutId);
-                    this._resetHoverTimeoutId = 0;
-                }
-            }
-        }
-        else {
-            if (this._showLabelTimeoutId > 0)
-                GLib.source_remove(this._showLabelTimeoutId);
-            this._showLabelTimeoutId = 0;
-            item.hideLabel();
-            if (this._labelShowing) {
-                this._resetHoverTimeoutId = GLib.timeout_add(
-                    GLib.PRIORITY_DEFAULT, DASH_ITEM_HOVER_TIMEOUT, () => {
-                    this._labelShowing = false;
-                    this._resetHoverTimeoutId = 0;
-                    return GLib.SOURCE_REMOVE;
-                });
-                GLib.Source.set_name_by_id(this._resetHoverTimeoutId, '[gnome-shell] this._labelShowing');
-            }
         }
     }
 
@@ -958,168 +876,6 @@ var MyDash = GObject.registerClass({
         this._shownInitially = false;
         this._redisplay();
 
-    }
-
-    _clearDragPlaceholder() {
-        if (this._dragPlaceholder) {
-            this._animatingPlaceholdersCount++;
-            this._dragPlaceholder.animateOutAndDestroy();
-            this._dragPlaceholder.connect('destroy', () => {
-                this._animatingPlaceholdersCount--;
-            });
-            this._dragPlaceholder = null;
-        }
-        this._dragPlaceholderPos = -1;
-    }
-
-    _clearEmptyDropTarget() {
-        if (this._emptyDropTarget) {
-            this._emptyDropTarget.animateOutAndDestroy();
-            this._emptyDropTarget = null;
-        }
-    }
-
-    handleDragOver(source, actor, x, y, time) {
-        let app = Dash.getAppFromSource(source);
-
-        // Don't allow favoriting of transient apps
-        if (app == null || app.is_window_backed())
-            return DND.DragMotionResult.NO_DROP;
-
-        if (!this._shellSettings.is_writable('favorite-apps') ||
-            !Docking.DockManager.settings.get_boolean('show-favorites'))
-            return DND.DragMotionResult.NO_DROP;
-
-        let favorites = AppFavorites.getAppFavorites().getFavorites();
-        let numFavorites = favorites.length;
-
-        let favPos = favorites.indexOf(app);
-
-        let children = this._box.get_children();
-        let numChildren = children.length;
-        let boxHeight = 0;
-        for (let i = 0; i < numChildren; i++)
-            boxHeight += this._isHorizontal?children[i].width:children[i].height;
-
-        // Keep the placeholder out of the index calculation; assuming that
-        // the remove target has the same size as "normal" items, we don't
-        // need to do the same adjustment there.
-        if (this._dragPlaceholder) {
-            boxHeight -= this._isHorizontal?this._dragPlaceholder.width:this._dragPlaceholder.height;
-            numChildren--;
-        }
-
-        let pos;
-        if (!this._emptyDropTarget) {
-            pos = Math.floor((this._isHorizontal?x:y) * numChildren / boxHeight);
-            if (pos >  numChildren)
-                pos = numChildren;
-        }
-        else
-            pos = 0; // always insert at the top when dash is empty
-
-        // Take into account childredn position in rtl
-        if (this._isHorizontal && (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL))
-            pos = numChildren - pos;
-
-        if ((pos != this._dragPlaceholderPos) && (pos <= numFavorites) && (this._animatingPlaceholdersCount == 0)) {
-            this._dragPlaceholderPos = pos;
-
-            // Don't allow positioning before or after self
-            if ((favPos != -1) && (pos == favPos || pos == favPos + 1)) {
-                this._clearDragPlaceholder();
-                return DND.DragMotionResult.CONTINUE;
-            }
-
-            // If the placeholder already exists, we just move
-            // it, but if we are adding it, expand its size in
-            // an animation
-            let fadeIn;
-            if (this._dragPlaceholder) {
-                this._dragPlaceholder.destroy();
-                fadeIn = false;
-            }
-            else
-                fadeIn = true;
-
-            this._dragPlaceholder = new Dash.DragPlaceholderItem();
-            this._dragPlaceholder.child.set_width (this.iconSize);
-            this._dragPlaceholder.child.set_height (this.iconSize / 2);
-            this._box.insert_child_at_index(this._dragPlaceholder,
-                                            this._dragPlaceholderPos);
-            this._dragPlaceholder.show(fadeIn);
-            // Ensure the next and previous icon are visible when moving the placeholder
-            // (I assume there's room for both of them)
-            if (this._dragPlaceholderPos > 1)
-                ensureActorVisibleInScrollView(this._scrollView, this._box.get_children()[this._dragPlaceholderPos-1]);
-            if (this._dragPlaceholderPos < this._box.get_children().length-1)
-                ensureActorVisibleInScrollView(this._scrollView, this._box.get_children()[this._dragPlaceholderPos+1]);
-        }
-
-        // Remove the drag placeholder if we are not in the
-        // "favorites zone"
-        if (pos > numFavorites)
-            this._clearDragPlaceholder();
-
-        if (!this._dragPlaceholder)
-            return DND.DragMotionResult.NO_DROP;
-
-        let srcIsFavorite = (favPos != -1);
-
-        if (srcIsFavorite)
-            return DND.DragMotionResult.MOVE_DROP;
-
-        return DND.DragMotionResult.COPY_DROP;
-    }
-
-    /**
-     * Draggable target interface
-     */
-    acceptDrop(source, actor, x, y, time) {
-        let app = Dash.getAppFromSource(source);
-
-        // Don't allow favoriting of transient apps
-        if (app == null || app.is_window_backed())
-            return false;
-
-        if (!this._shellSettings.is_writable('favorite-apps') ||
-            !Docking.DockManager.settings.get_boolean('show-favorites'))
-            return false;
-
-        let id = app.get_id();
-
-        let favorites = AppFavorites.getAppFavorites().getFavoriteMap();
-
-        let srcIsFavorite = (id in favorites);
-
-        let favPos = 0;
-        let children = this._box.get_children();
-        for (let i = 0; i < this._dragPlaceholderPos; i++) {
-            if (this._dragPlaceholder && (children[i] == this._dragPlaceholder))
-                continue;
-
-            let childId = children[i].child.app.get_id();
-            if (childId == id)
-                continue;
-            if (childId in favorites)
-                favPos++;
-        }
-
-        // No drag placeholder means we don't wan't to favorite the app
-        // and we are dragging it to its original position
-        if (!this._dragPlaceholder)
-            return true;
-
-        Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
-            let appFavorites = AppFavorites.getAppFavorites();
-            if (srcIsFavorite)
-                appFavorites.moveFavoriteToPos(id, favPos);
-            else
-                appFavorites.addFavoriteAtPos(id, favPos);
-            return false;
-        });
-
-        return true;
     }
 
     get showAppsButton() {

--- a/docking.js
+++ b/docking.js
@@ -232,7 +232,6 @@ var DockedDash = GObject.registerClass({
             reactive: false,
             style_class: positionStyleClass[this._position],
         });
-        this._delegate = this;
 
         // This is the sliding actor whose allocation is to be tracked for input regions
         this._slider = new DashSlideContainer({
@@ -1296,13 +1295,12 @@ var DockedDash = GObject.registerClass({
     _activateApp(appIndex) {
         let children = this.dash._box.get_children().filter(function(actor) {
                 return actor.child &&
-                       actor.child._delegate &&
-                       actor.child._delegate.app;
+                       actor.child.app;
         });
 
         // Apps currently in the dash
         let apps = children.map(function(actor) {
-                return actor.child._delegate;
+                return actor.child;
             });
 
         // Activate with button = 1, i.e. same as left click

--- a/docking.js
+++ b/docking.js
@@ -1772,11 +1772,8 @@ var DockManager = class DashToDock_DockManager {
         this._keyboardShortcuts.destroy();
 
         // Delete all docks
-        let nDocks = this._allDocks.length;
-        for (let i = nDocks-1; i >= 0; i--) {
-            this._allDocks[i].destroy();
-            this._allDocks.pop();
-        }
+        this._allDocks.forEach(d => d.destroy());
+        this._allDocks = [];
     }
 
     _restoreDash() {

--- a/docking.js
+++ b/docking.js
@@ -231,15 +231,18 @@ var DockedDash = GObject.registerClass({
             name: 'dashtodockContainer',
             reactive: false,
             style_class: positionStyleClass[this._position],
-            x_align: this._isHorizontal ? Clutter.ActorAlign.CENTER : Clutter.ActorAlign.START,
-            y_align: this._isHorizontal ? Clutter.ActorAlign.START : Clutter.ActorAlign.CENTER,
         });
         this._delegate = this;
 
         // This is the sliding actor whose allocation is to be tracked for input regions
         this._slider = new DashSlideContainer({
             side: this._position,
-            slidex: 0
+            slidex: 0,
+            ...(this._isHorizontal ? {
+                x_align: Clutter.ActorAlign.CENTER,
+            } : {
+                y_align: Clutter.ActorAlign.CENTER,
+            })
         });
 
         // This is the actor whose hover status us tracked for autohide

--- a/docking.js
+++ b/docking.js
@@ -1303,8 +1303,7 @@ const DashToDock_KeyboardShortcuts_NUM_HOTKEYS = 10;
 
 var KeyboardShortcuts = class DashToDock_KeyboardShortcuts {
 
-    constructor(allDocks){
-        this._allDocks = allDocks;
+    constructor() {
         this._signalsHandler = new Utils.GlobalSignalsHandler();
 
         this._hotKeysEnabled = false;
@@ -1418,8 +1417,7 @@ var KeyboardShortcuts = class DashToDock_KeyboardShortcuts {
     }
 
     _showOverlay() {
-        for (let i = 0; i < this._allDocks.length; i++) {
-            let dock = this._allDocks[i];
+        for (let dock of DockManager.allDocks) {
             if (DockManager.settings.get_boolean('hotkeys-overlay'))
                 dock.dash.toggleNumberOverlay(true);
 
@@ -1456,10 +1454,9 @@ var KeyboardShortcuts = class DashToDock_KeyboardShortcuts {
  */
 var WorkspaceIsolation = class DashToDock_WorkspaceIsolation {
 
-    constructor(allDocks) {
+    constructor() {
 
         let settings = DockManager.settings;
-        this._allDocks = allDocks;
 
         this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._injectionsHandler = new Utils.InjectionsHandler();
@@ -1468,9 +1465,8 @@ var WorkspaceIsolation = class DashToDock_WorkspaceIsolation {
             settings,
             'changed::isolate-workspaces',
             () => {
-                    this._allDocks.forEach(function(dock) {
-                        dock.dash.resetAppIcons();
-                    });
+                    DockManager.allDocks.forEach((dock) =>
+                        dock.dash.resetAppIcons());
                     if (settings.get_boolean('isolate-workspaces') ||
                         settings.get_boolean('isolate-monitors'))
                         this._enable.bind(this)();
@@ -1481,9 +1477,8 @@ var WorkspaceIsolation = class DashToDock_WorkspaceIsolation {
             settings,
             'changed::isolate-monitors',
             () => {
-                    this._allDocks.forEach(function(dock) {
-                        dock.dash.resetAppIcons();
-                    });
+                    DockManager.allDocks.forEach((dock) =>
+                        dock.dash.resetAppIcons());
                     if (settings.get_boolean('isolate-workspaces') ||
                         settings.get_boolean('isolate-monitors'))
                         this._enable.bind(this)();
@@ -1504,7 +1499,7 @@ var WorkspaceIsolation = class DashToDock_WorkspaceIsolation {
         // although it should never happen
         this._disable();
 
-        this._allDocks.forEach(function(dock) {
+        DockManager.allDocks.forEach((dock) => {
             this._signalsHandler.addWithLabel('isolation', [
                 global.display,
                 'restacked',
@@ -1589,6 +1584,10 @@ var DockManager = class DashToDock_DockManager {
 
     static getDefault() {
         return Me.imports.extension.dockManager
+    }
+
+    static get allDocks() {
+        return DockManager.getDefault()._allDocks;
     }
 
     static get settings() {
@@ -1719,8 +1718,8 @@ var DockManager = class DashToDock_DockManager {
 
         // Load optional features. We load *after* the docks are created, since
         // we need to connect the signals to all dock instances.
-        this._workspaceIsolation = new WorkspaceIsolation(this._allDocks);
-        this._keyboardShortcuts = new KeyboardShortcuts(this._allDocks);
+        this._workspaceIsolation = new WorkspaceIsolation();
+        this._keyboardShortcuts = new KeyboardShortcuts();
     }
 
     _prepareMainDash() {

--- a/docking.js
+++ b/docking.js
@@ -125,7 +125,7 @@ var DashSlideContainer = GObject.registerClass({
      * Just the child width but taking into account the slided out part
      */
     vfunc_get_preferred_width(forHeight) {
-        let [minWidth, natWidth] = this.child.get_preferred_width(forHeight);
+        let [minWidth, natWidth] = super.vfunc_get_preferred_width(forHeight);
         if ((this.side ==  St.Side.LEFT) || (this.side == St.Side.RIGHT)) {
             minWidth = (minWidth - this._slideoutSize) * this._slidex + this._slideoutSize;
             natWidth = (natWidth - this._slideoutSize) * this._slidex + this._slideoutSize;
@@ -137,7 +137,7 @@ var DashSlideContainer = GObject.registerClass({
      * Just the child height but taking into account the slided out part
      */
     vfunc_get_preferred_height(forWidth) {
-        let [minHeight, natHeight] = this.child.get_preferred_height(forWidth);
+        let [minHeight, natHeight] = super.vfunc_get_preferred_height(forWidth);
         if ((this.side ==  St.Side.TOP) || (this.side ==  St.Side.BOTTOM)) {
             minHeight = (minHeight - this._slideoutSize) * this._slidex + this._slideoutSize;
             natHeight = (natHeight - this._slideoutSize) * this._slidex + this._slideoutSize;

--- a/docking.js
+++ b/docking.js
@@ -1804,7 +1804,12 @@ var DockManager = class DashToDock_DockManager {
 
         // Pretend I'm the dash: meant to make appgrid swarm animation come from
         // the right position of the appShowButton.
-        Main.overview._overview._controls.dash = this.mainDock.dash;
+        let overviewControls = Main.overview._overview._controls;
+        overviewControls.dash = this.mainDock.dash;
+
+        this._oldDashSpacer = overviewControls._dashSpacer;
+        this._oldDashSpacer.hide();
+        overviewControls._dashSpacer = this.mainDock._dashSpacer;
     }
 
     _deleteDocks() {
@@ -1830,8 +1835,12 @@ var DockManager = class DashToDock_DockManager {
 
         this._signalsHandler.removeWithLabel('old-dash-changes');
 
-        Main.overview._overview._controls.dash = this._oldDash;
+        let overviewControls = Main.overview._overview._controls;
+        overviewControls._dashSpacer = this._oldDashSpacer;
+        overviewControls.dash = this._oldDash;
+        this._oldDashSpacer = null;
 
+        overviewControls._dashSpacer.show();
         Main.overview.dash.show();
         Main.overview.dash.set_width(-1); //reset default dash size
         // This force the recalculation of the icon size

--- a/docking.js
+++ b/docking.js
@@ -1345,7 +1345,7 @@ var KeyboardShortcuts = class DashToDock_KeyboardShortcuts {
                                       Meta.KeyBindingFlags.NONE,
                                       Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
                                       () => {
-                                          this._allDocks[0]._activateApp(appNum);
+                                          DockManager.getDefault().mainDock._activateApp(appNum);
                                           this._showOverlay();
                                       });
             }
@@ -1599,6 +1599,10 @@ var DockManager = class DashToDock_DockManager {
         return this._fm1Client;
     }
 
+    get mainDock() {
+        return this._allDocks.length ? this._allDocks[0] : null;
+    }
+
     _ensureFileManagerClient() {
         let supportsLocations = ['show-trash', 'show-mounts'].some((s) => {
             return this._settings.get_boolean(s);
@@ -1729,7 +1733,7 @@ var DockManager = class DashToDock_DockManager {
         Object.defineProperty(Main.overview, 'dash', {
             configurable: true,
             get: () => Main.overview.isDummy ?
-                this._allDocks[0].dash : defaultDashGetter.call(Main.overview),
+                this.mainDock.dash : defaultDashGetter.call(Main.overview),
         });
 
         if (Main.overview.isDummy)
@@ -1760,7 +1764,7 @@ var DockManager = class DashToDock_DockManager {
 
         // Pretend I'm the dash: meant to make appgrid swarm animation come from
         // the right position of the appShowButton.
-        Main.overview._overview._controls.dash = this._allDocks[0].dash;
+        Main.overview._overview._controls.dash = this.mainDock.dash;
     }
 
     _deleteDocks() {
@@ -1843,7 +1847,7 @@ var DockManager = class DashToDock_DockManager {
                             Main.overview.disconnect(overviewShownId);
                             Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
                                 grid.opacity = 255;
-                                grid.animateSpring(IconGrid.AnimationDirection.IN, this._allDocks[0].dash.showAppsButton);
+                                grid.animateSpring(IconGrid.AnimationDirection.IN, this.mainDock.dash.showAppsButton);
                             });
                         });
                     }

--- a/docking.js
+++ b/docking.js
@@ -251,13 +251,6 @@ var DockedDash = GObject.registerClass({
         });
         this._box.connect('notify::hover', this._hoverChanged.bind(this));
 
-        // Create and apply height constraint to the dash. It's controlled by this.height
-        this.constrainSize = new Clutter.BindConstraint({
-            source: this,
-            coordinate: this._isHorizontal?Clutter.BindCoordinate.WIDTH:Clutter.BindCoordinate.HEIGHT
-        });
-        this.dash.add_constraint(this.constrainSize);
-
         this._signalsHandler.add([
             // update when workarea changes, for instance if  other extensions modify the struts
             //(like moving th panel at the bottom)
@@ -377,6 +370,15 @@ var DockedDash = GObject.registerClass({
         }
         else
             Main.layoutManager._trackActor(this._slider);
+
+        // Create and apply height/width constraint to the dash.
+        // It's controlled by this.height or this.width
+        this._constrainSize = new Clutter.BindConstraint({
+            source: this,
+            coordinate: this._isHorizontal ?
+                Clutter.BindCoordinate.WIDTH : Clutter.BindCoordinate.HEIGHT
+        });
+        this.dash.add_constraint(this._constrainSize);
 
         // Set initial position
         this._resetPosition();

--- a/docking.js
+++ b/docking.js
@@ -1089,8 +1089,6 @@ var DockedDash = GObject.registerClass({
                 this.remove_style_class_name('extended');
             }
         }
-
-        this._y0 = this.y;
     }
 
     _updateStaticBox() {

--- a/docking.js
+++ b/docking.js
@@ -275,11 +275,6 @@ var DockedDash = GObject.registerClass({
             'status-changed',
             this._updateDashVisibility.bind(this)
         ], [
-            // Keep dragged icon consistent in size with this dash
-            this.dash,
-            'icon-size-changed',
-            () => { Main.overview.dash.iconSize = this.dash.iconSize; }
-        ], [
             // sync hover after a popupmenu is closed
             this.dash,
             'menu-closed',
@@ -321,15 +316,6 @@ var DockedDash = GObject.registerClass({
                 Main.overview.viewSelector._showAppsButton,
                 'notify::checked',
                 this._syncShowAppsButtonToggled.bind(this)
-            ], [
-                // This duplicate the similar signal which is in owerview.js.
-                // Being connected and thus executed later this effectively
-                // overwrite any attempt to use the size of the default dash
-                //which given the customization is usually much smaller.
-                // I can't easily disconnect the original signal
-                Main.overview.dash,
-                'icon-size-changed',
-                () => { Main.overview.dash.iconSize = this.dash.iconSize; }
             ]);
         }
 
@@ -1795,9 +1781,6 @@ var DockManager = class DashToDock_DockManager {
         Main.overview.dash.set_width(-1); //reset default dash size
         // This force the recalculation of the icon size
         Main.overview.dash._maxHeight = -1;
-
-        // reset stored icon size  to the default dash
-        Main.overview.dash.iconSize = Main.overview.dash.iconSize;
     }
 
     _onShowAppsButtonToggled(button) {

--- a/docking.js
+++ b/docking.js
@@ -3,7 +3,6 @@
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
-const Gtk = imports.gi.Gtk;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
@@ -1142,7 +1141,7 @@ var DockedDash = GObject.registerClass({
      * Show dock and give key focus to it
      */
     _onAccessibilityFocus() {
-        this._box.navigate_focus(null, Gtk.DirectionType.TAB_FORWARD, false);
+        this._box.navigate_focus(null, St.DirectionType.TAB_FORWARD, false);
         this._animateIn(DockManager.settings.get_double('animation-time'), 0);
     }
 

--- a/docking.js
+++ b/docking.js
@@ -276,7 +276,7 @@ var DockedDash = GObject.registerClass({
             // Keep dragged icon consistent in size with this dash
             this.dash,
             'icon-size-changed',
-            () => { Main.overview.dashIconSize = this.dash.iconSize; }
+            () => { Main.overview.dash.iconSize = this.dash.iconSize; }
         ], [
             // sync hover after a popupmenu is closed
             this.dash,
@@ -325,9 +325,9 @@ var DockedDash = GObject.registerClass({
                 // overwrite any attempt to use the size of the default dash
                 //which given the customization is usually much smaller.
                 // I can't easily disconnect the original signal
-                Main.overview._controls.dash,
+                Main.overview.dash,
                 'icon-size-changed',
-                () => { Main.overview.dashIconSize = this.dash.iconSize; }
+                () => { Main.overview.dash.iconSize = this.dash.iconSize; }
             ]);
         }
 
@@ -361,15 +361,15 @@ var DockedDash = GObject.registerClass({
         this._dashSpacer.setDashActor(this._box);
 
         if (!Main.overview.isDummy) {
-            const { _controls, _overview } = Main.overview;
+            const overviewActor = Main.overview._overview;
             if (this._position == St.Side.LEFT)
-                _controls._group.insert_child_at_index(this._dashSpacer, this._rtl ? -1 : 0); // insert on first
+                overviewActor._controls._group.insert_child_at_index(this._dashSpacer, this._rtl ? -1 : 0); // insert on first
             else if (this._position ==  St.Side.RIGHT)
-                _controls._group.insert_child_at_index(this._dashSpacer, this._rtl ? 0 : -1); // insert on last
+                overviewActor._controls._group.insert_child_at_index(this._dashSpacer, this._rtl ? 0 : -1); // insert on last
             else if (this._position == St.Side.TOP)
-                _overview.insert_child_at_index(this._dashSpacer, 0);
+                overviewActor.insert_child_at_index(this._dashSpacer, 0);
             else if (this._position == St.Side.BOTTOM)
-                _overview.insert_child_at_index(this._dashSpacer, -1);
+                overviewActor.insert_child_at_index(this._dashSpacer, -1);
         }
 
         // Add dash container actor and the container to the Chrome.
@@ -1140,7 +1140,7 @@ var DockedDash = GObject.registerClass({
          * Moreover, hiding the spacer ensure the appGrid allocaton is triggered.
          * This matter as the appview spring animation is triggered by to first reallocaton of the appGrid,
          * (See appDisplay.js, line 202 on GNOME Shell 3.14:
-         *                             this._grid.actor.connect('notify::allocation', ...)
+         *                             this._grid.connect('notify::allocation', ...)
          * which in turn seems to be triggered by changes in the other actors in the overview.
          * Normally, as far as I could understand, either the dashSpacer being hidden or the workspacesThumbnails
          * sliding out would trigger the allocation. However, with no stock dash
@@ -1734,13 +1734,13 @@ var DockManager = class DashToDock_DockManager {
         Main.overview._dash = this._allDocks[0].dash;
 
         // set stored icon size  to the new dash
-        Main.overview.dashIconSize = this._allDocks[0].dash.iconSize;
+        Main.overview.dash.iconSize = this._allDocks[0].dash.iconSize;
 
         if (Main.overview.isDummy)
             return;
 
         // Hide usual Dash
-        Main.overview._controls.dash.actor.hide();
+        Main.overview.dash.hide();
 
         // Also set dash width to 1, so it's almost not taken into account by code
         // calculaing the reserved space in the overview. The reason to keep it at 1 is
@@ -1748,7 +1748,7 @@ var DockManager = class DashToDock_DockManager {
         // in turn is triggergin the appsIcon spring animation, required when no other
         // actors has this effect, i.e in horizontal mode and without the workspaceThumnails
         // 1 static workspace only)
-        Main.overview._controls.dash.actor.set_width(1);
+        Main.overview.dash.set_width(1);
     }
 
     _deleteDocks() {
@@ -1768,13 +1768,13 @@ var DockManager = class DashToDock_DockManager {
         if (Main.overview.isDummy)
             return;
 
-        Main.overview._controls.dash.actor.show();
-        Main.overview._controls.dash.actor.set_width(-1); //reset default dash size
+        Main.overview.dash.show();
+        Main.overview.dash.set_width(-1); //reset default dash size
         // This force the recalculation of the icon size
-        Main.overview._controls.dash._maxHeight = -1;
+        Main.overview.dash._maxHeight = -1;
 
         // reset stored icon size  to the default dash
-        Main.overview.dashIconSize = Main.overview._controls.dash.iconSize;
+        Main.overview.dash.iconSize = Main.overview.dash.iconSize;
 
         Main.overview._dash = this._oldDash;
     }
@@ -1793,7 +1793,7 @@ var DockManager = class DashToDock_DockManager {
             // find visible view
             let visibleView;
             Main.overview.viewSelector.appDisplay._views.every(function(v, index) {
-                if (v.view.actor.visible) {
+                if (v.view.visible) {
                     visibleView = index;
                     return false;
                 }
@@ -1906,16 +1906,16 @@ var DockManager = class DashToDock_DockManager {
                              this._preferredMonitorIndex == Main.layoutManager.primaryIndex;
 
         if (!isHorizontal && dockOnPrimary && extendHeight && fixedIsEnabled) {
-            Main.panel._rightCorner.actor.hide();
-            Main.panel._leftCorner.actor.hide();
+            Main.panel._rightCorner.hide();
+            Main.panel._leftCorner.hide();
         }
         else
             this._revertPanelCorners();
     }
 
     _revertPanelCorners() {
-        Main.panel._leftCorner.actor.show();
-        Main.panel._rightCorner.actor.show();
+        Main.panel._leftCorner.show();
+        Main.panel._rightCorner.show();
     }
 };
 Signals.addSignalMethods(DockManager.prototype);

--- a/docking.js
+++ b/docking.js
@@ -160,6 +160,39 @@ var DashSlideContainer = GObject.registerClass({
     }
 });
 
+let DockBindConstraint = Clutter.BindConstraint;
+if (imports.system.version > 16501) {
+    DockBindConstraint = GObject.registerClass(
+    class DockBindConstraint extends Clutter.BindConstraint {
+
+        vfunc_update_preferred_size(_actor, direction, forSize, minimumSize, naturalSize) {
+            let getPreferredSize = null;
+
+            if (direction == Clutter.Orientation.HORIZONTAL) {
+                if (this.coordinate != Clutter.BindCoordinate.HEIGHT) {
+                    getPreferredSize = this.source.get_preferred_width.bind(
+                        this.source);
+                    }
+            } else if (direction == Clutter.Orientation.VERTICAL) {
+                if (this.coordinate != Clutter.BindCoordinate.WIDTH) {
+                    getPreferredSize = this.source.get_preferred_height.bind(
+                        this.source);
+                    }
+            }
+
+            if (getPreferredSize) {
+                let [prefMinimum, prefNatural] = getPreferredSize(forSize);
+                if (naturalSize < prefNatural)
+                    return [minimumSize, naturalSize];
+                else
+                    return [prefMinimum, prefNatural];
+            }
+
+            return super.vfunc_update_preferred_size(...arguments);
+        }
+    });
+}
+
 var DockedDash = GObject.registerClass({
     Signals: {
         'showing': {},
@@ -374,7 +407,7 @@ var DockedDash = GObject.registerClass({
 
         // Create and apply height/width constraint to the dash.
         // It's controlled by this.height or this.width
-        this._constrainSize = new Clutter.BindConstraint({
+        this._constrainSize = new DockBindConstraint({
             source: this,
             coordinate: this._isHorizontal ?
                 Clutter.BindCoordinate.WIDTH : Clutter.BindCoordinate.HEIGHT

--- a/docking.js
+++ b/docking.js
@@ -231,8 +231,8 @@ var DockedDash = GObject.registerClass({
             name: 'dashtodockContainer',
             reactive: false,
             style_class: positionStyleClass[this._position],
-            x_align: this._isHorizontal?St.Align.MIDDLE:St.Align.START,
-            y_align: this._isHorizontal?St.Align.START:St.Align.MIDDLE
+            x_align: this._isHorizontal ? Clutter.ActorAlign.CENTER : Clutter.ActorAlign.START,
+            y_align: this._isHorizontal ? Clutter.ActorAlign.START : Clutter.ActorAlign.CENTER,
         });
         this._delegate = this;
 

--- a/docking.js
+++ b/docking.js
@@ -1341,7 +1341,7 @@ var KeyboardShortcuts = class DashToDock_KeyboardShortcuts {
             for (let i = 0; i < DashToDock_KeyboardShortcuts_NUM_HOTKEYS; i++) {
                 let appNum = i;
                 Main.wm.addKeybinding(key + (i + 1), DockManager.settings,
-                                      Meta.KeyBindingFlags.NONE,
+                                      Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
                                       Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
                                       () => {
                                           DockManager.getDefault().mainDock._activateApp(appNum);
@@ -1402,7 +1402,7 @@ var KeyboardShortcuts = class DashToDock_KeyboardShortcuts {
     _enableExtraShortcut() {
         if (!this._shortcutIsSet) {
             Main.wm.addKeybinding('shortcut', DockManager.settings,
-                                  Meta.KeyBindingFlags.NONE,
+                                  Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
                                   Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
                                   this._showOverlay.bind(this));
             this._shortcutIsSet = true;

--- a/docking.js
+++ b/docking.js
@@ -79,13 +79,14 @@ var DashSlideContainer = GObject.registerClass({
     }
 
     vfunc_allocate(box, flags) {
+        let contentBox = this.get_theme_node().get_content_box(box);
         this.set_allocation(box, flags);
 
         if (this.child == null)
             return;
 
-        let availWidth = box.x2 - box.x1;
-        let availHeight = box.y2 - box.y1;
+        let availWidth = contentBox.x2 - contentBox.x1;
+        let availHeight = contentBox.y2 - contentBox.y1;
         let [, , natChildWidth, natChildHeight] =
             this.child.get_preferred_size();
 

--- a/docking.js
+++ b/docking.js
@@ -1618,10 +1618,16 @@ var DockManager = class DashToDock_DockManager {
     }
 
     _toggle() {
-        this._restoreDash();
-        this._deleteDocks();
-        this._createDocks();
-        this.emit('toggled');
+        if (this._toggleLater)
+            Meta.later_remove(this._toggleLater);
+
+        this._toggleLater = Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
+            delete this._toggleLater;
+            this._restoreDash();
+            this._deleteDocks();
+            this._createDocks();
+            this.emit('toggled');
+        });
     }
 
     _bindSettingsChanges() {
@@ -1899,6 +1905,10 @@ var DockManager = class DashToDock_DockManager {
 
     destroy() {
         this._signalsHandler.destroy();
+        if (this._toggleLater) {
+            Meta.later_remove(this._toggleLater);
+            delete this._toggleLater;
+        }
         this._restoreDash();
         this._deleteDocks();
         this._revertPanelCorners();

--- a/launcherAPI.js
+++ b/launcherAPI.js
@@ -78,8 +78,9 @@ var LauncherEntryRemoteModel = class DashToDock_LauncherEntryRemoteModel {
 
     _acquireUnityDBus() {
         if (!this._unity_bus_id) {
-            Gio.DBus.session.own_name('com.canonical.Unity',
-                Gio.BusNameOwnerFlags.ALLOW_REPLACEMENT, null, null);
+            this._unity_bus_id = Gio.DBus.session.own_name('com.canonical.Unity',
+                Gio.BusNameOwnerFlags.ALLOW_REPLACEMENT | Gio.BusNameOwnerFlags.REPLACE,
+                null, () => this._unity_bus_id = 0);
         }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
 "shell-version": [
-    "3.34"
+    "3.36"
 ],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",

--- a/theming.js
+++ b/theming.js
@@ -3,7 +3,6 @@
 const Clutter = imports.gi.Clutter;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
-const Gtk = imports.gi.Gtk;
 const Signals = imports.signals;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;

--- a/utils.js
+++ b/utils.js
@@ -22,9 +22,8 @@ const BasicHandler = class DashToDock_BasicHandler {
 
     add(/* unlimited 3-long array arguments */) {
         // Convert arguments object to array, concatenate with generic
-        let args = Array.concat('generic', Array.slice(arguments));
         // Call addWithLabel with ags as if they were passed arguments
-        this.addWithLabel.apply(this, args);
+        this.addWithLabel('generic', ...arguments);
     }
 
     destroy() {

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -349,7 +349,8 @@ class DashToDock_WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
         let label = new St.Label({ text: window.get_title()});
         label.set_style('max-width: '+PREVIEW_MAX_WIDTH +'px');
         let labelBin = new St.Bin({ child: label,
-                                    x_align: St.Align.MIDDLE});
+            x_align: Clutter.ActorAlign.CENTER,
+        });
 
         this._windowTitleId = this._window.connect('notify::title', () => {
                                   label.set_text(this._window.get_title());

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -485,9 +485,8 @@ class DashToDock_WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
     }
 
     _onLeave() {
-        if (!this._cloneBin.has_pointer &&
-            !this.closeButton.has_pointer)
-            this._hideCloseButton();
+        this._hideCloseButton();
+    }
 
         return Clutter.EVENT_PROPAGATE;
     }
@@ -495,9 +494,7 @@ class DashToDock_WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
     _idleToggleCloseButton() {
         this._idleToggleCloseId = 0;
 
-        if (!this._cloneBin.has_pointer &&
-            !this.closeButton.has_pointer)
-            this._hideCloseButton();
+        this._hideCloseButton();
 
         return GLib.SOURCE_REMOVE;
     }
@@ -516,6 +513,10 @@ class DashToDock_WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
     }
 
     _hideCloseButton() {
+        if (this.closeButton.has_pointer ||
+            this.get_children().some(a => a.has_pointer))
+            return;
+
         this.closeButton.remove_all_transitions();
         this.closeButton.ease({
             opacity: 0,

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -9,7 +9,6 @@ const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const St = imports.gi.St;
 const Main = imports.ui.main;
-const Gtk = imports.gi.Gtk;
 
 const Params = imports.misc.params;
 const PopupMenu = imports.ui.popupMenu;
@@ -71,7 +70,7 @@ var WindowPreviewMenu = class DashToDock_WindowPreviewMenu extends PopupMenu.Pop
         if (windows.length > 0) {
             this._redisplay();
             this.open();
-            this.actor.navigate_focus(null, Gtk.DirectionType.TAB_FORWARD, false);
+            this.actor.navigate_focus(null, St.DirectionType.TAB_FORWARD, false);
             this._source.emit('sync-tooltip');
         }
     }
@@ -89,10 +88,12 @@ var WindowPreviewList = class DashToDock_WindowPreviewList extends PopupMenu.Pop
 
     constructor(source) {
         super();
-        this.actor = new St.ScrollView({ name: 'dashtodockWindowScrollview',
-                                               hscrollbar_policy: Gtk.PolicyType.NEVER,
-                                               vscrollbar_policy: Gtk.PolicyType.NEVER,
-                                               enable_mouse_scrolling: true });
+        this.actor = new St.ScrollView({
+            name: 'dashtodockWindowScrollview',
+            hscrollbar_policy: St.PolicyType.NEVER,
+            vscrollbar_policy: St.PolicyType.NEVER,
+            enable_mouse_scrolling: true
+        });
 
         this.actor.connect('scroll-event', this._onScrollEvent.bind(this));
 
@@ -276,7 +277,8 @@ var WindowPreviewList = class DashToDock_WindowPreviewList extends PopupMenu.Pop
         // when we *don't* need it, so turn off the scrollbar when that's true.
         // Dynamic changes in whether we need it aren't handled properly.
         let needsScrollbar = this._needsScrollbar();
-        let scrollbar_policy =  needsScrollbar ? Gtk.PolicyType.AUTOMATIC : Gtk.PolicyType.NEVER;
+        let scrollbar_policy = needsScrollbar ?
+            St.PolicyType.AUTOMATIC : St.PolicyType.NEVER;
         if (this.isHorizontal)
             this.actor.hscrollbar_policy =  scrollbar_policy;
         else

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -363,11 +363,6 @@ class DashToDock_WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
         box.add(labelBin);
         this.add_actor(box);
 
-        this.connect('enter-event', this._onEnter.bind(this));
-        this.connect('leave-event', this._onLeave.bind(this));
-        this.connect('key-focus-in', this._onEnter.bind(this));
-        this.connect('key-focus-out', this._onLeave.bind(this));
-
         this._cloneTexture(window);
 
         this.connect('destroy', this._onDestroy.bind(this));
@@ -479,16 +474,24 @@ class DashToDock_WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
         return n>0;
     }
 
-    _onEnter() {
+    vfunc_key_focus_in() {
+        super.vfunc_key_focus_in();
         this._showCloseButton();
-        return Clutter.EVENT_PROPAGATE;
     }
 
-    _onLeave() {
+    vfunc_key_focus_out() {
+        super.vfunc_key_focus_out();
         this._hideCloseButton();
     }
 
-        return Clutter.EVENT_PROPAGATE;
+    vfunc_enter_event(crossingEvent) {
+        this._showCloseButton();
+        return super.vfunc_enter_event(crossingEvent);
+    }
+
+    vfunc_leave_event(crossingEvent) {
+        this._hideCloseButton();
+        return super.vfunc_leave_event(crossingEvent);
     }
 
     _idleToggleCloseButton() {

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -27,7 +27,7 @@ var WindowPreviewMenu = class DashToDock_WindowPreviewMenu extends PopupMenu.Pop
 
     constructor(source) {
         let side = Utils.getPosition();
-        super(source.actor, 0.5, side);
+        super(source, 0.5, side);
 
         // We want to keep the item hovered while the menu is up
         this.blockSourceEvents = true;
@@ -42,11 +42,11 @@ var WindowPreviewMenu = class DashToDock_WindowPreviewMenu extends PopupMenu.Pop
         this.actor.hide();
 
         // Chain our visibility and lifecycle to that of the source
-        this._mappedId = this._source.actor.connect('notify::mapped', () => {
-            if (!this._source.actor.mapped)
+        this._mappedId = this._source.connect('notify::mapped', () => {
+            if (!this._source.mapped)
                 this.close();
         });
-        this._destroyId = this._source.actor.connect('destroy', this.destroy.bind(this));
+        this._destroyId = this._source.connect('destroy', this.destroy.bind(this));
 
         Main.uiGroup.add_actor(this.actor);
 
@@ -78,10 +78,10 @@ var WindowPreviewMenu = class DashToDock_WindowPreviewMenu extends PopupMenu.Pop
 
     _onDestroy() {
         if (this._mappedId)
-            this._source.actor.disconnect(this._mappedId);
+            this._source.disconnect(this._mappedId);
 
         if (this._destroyId)
-            this._source.actor.disconnect(this._destroyId);
+            this._source.disconnect(this._destroyId);
     }
 };
 


### PR DESCRIPTION
It would be nice to have the option to centre all the icons when the dock is extended to edge of the screen, instead of grouping them in the top. I believe that Windows 10 and ChromeOS have that option. Kindly preview the following mockup: https://i.imgur.com/guZrBRz.png