### PR TITLE
Support more Unity features (quicklist, urgent properties)

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -683,6 +683,10 @@ var UnityIndicator = class DashToDock_UnityIndicator extends IndicatorBase {
             (sender, { progress, progress_visible }) =>
                 this.setProgress(progress_visible ? progress : -1)
         ], [
+            remoteEntry,
+            'urgent-changed',
+            (sender, { urgent }) => this.setUrgent(urgent)
+        ], [
             St.ThemeContext.get_for_stage(global.stage),
             'changed',
             this.updateNotificationBadgeStyle.bind(this)
@@ -691,6 +695,8 @@ var UnityIndicator = class DashToDock_UnityIndicator extends IndicatorBase {
             'notify::size',
             this.updateNotificationBadgeStyle.bind(this)
         ]);
+
+        this._isUrgent = false;
     }
 
     updateNotificationBadgeStyle() {
@@ -856,6 +862,23 @@ var UnityIndicator = class DashToDock_UnityIndicator extends IndicatorBase {
         } else {
             this._progress = Math.min(progress, 1.0);
             this._showProgressOverlay();
+        }
+    }
+
+    setUrgent(urgent) {
+        const icon = this._source.icon._iconBin;
+        if (urgent) {
+            if (!this._isUrgent) {
+                icon.set_pivot_point(0.5, 0.5);
+                this._source.iconAnimator.addAnimation(icon, 'dance');
+                this._isUrgent = true;
+            }
+        } else {
+            if (this._isUrgent) {
+                this._source.iconAnimator.removeAnimation(icon, 'dance');
+                this._isUrgent = false;
+            }
+            icon.rotation_angle_z = 0;
         }
     }
 }

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -666,27 +666,22 @@ var UnityIndicator = class DashToDock_UnityIndicator extends IndicatorBase {
         });
         this._notificationBadgeLabel.add_style_class_name('notification-badge');
         this._notificationBadgeLabel.clutter_text.ellipsize = Pango.EllipsizeMode.MIDDLE;
-        this._notificationBadgeCount = 0;
         this._notificationBadgeBin.hide();
 
         this._source._iconContainer.add_child(this._notificationBadgeBin);
         this.updateNotificationBadgeStyle();
 
-        this._remoteEntries = [];
-        this._source.remoteModel.lookupById(this._source.app.id).forEach(
-            (entry) => {
-                this.insertEntryRemote(entry);
-            }
-        );
-
+        const remoteEntry = this._source.remoteModel.lookupById(this._source.app.id);
         this._signalsHandler.add([
-            this._source.remoteModel,
-            'entry-added',
-            this._onLauncherEntryRemoteAdded.bind(this)
+            remoteEntry,
+            ['count-changed', 'count-visible-changed'],
+            (sender, { count, count_visible }) =>
+                this.setNotificationCount(count_visible ? count : 0)
         ], [
-            this._source.remoteModel,
-            'entry-removed',
-            this._onLauncherEntryRemoteRemoved.bind(this)
+            remoteEntry,
+            ['progress-changed', 'progress-visible-changed'],
+            (sender, { progress, progress_visible }) =>
+                this.setProgress(progress_visible ? progress : -1)
         ], [
             St.ThemeContext.get_for_stage(global.stage),
             'changed',
@@ -695,24 +690,7 @@ var UnityIndicator = class DashToDock_UnityIndicator extends IndicatorBase {
             this._source._iconContainer,
             'notify::size',
             this.updateNotificationBadgeStyle.bind(this)
-        ])
-    }
-
-    _onLauncherEntryRemoteAdded(remoteModel, entry) {
-        if (!entry || !entry.appId())
-            return;
-        if (this._source && this._source.app && this._source.app.id == entry.appId()) {
-            this.insertEntryRemote(entry);
-        }
-    }
-
-    _onLauncherEntryRemoteRemoved(remoteModel, entry) {
-        if (!entry || !entry.appId())
-            return;
-
-        if (this._source && this._source.app && this._source.app.id == entry.appId()) {
-            this.removeEntryRemote(entry);
-        }
+        ]);
     }
 
     updateNotificationBadgeStyle() {
@@ -759,17 +737,14 @@ var UnityIndicator = class DashToDock_UnityIndicator extends IndicatorBase {
         }
     }
 
-    setNotificationBadge(count) {
-        this._notificationBadgeCount = count;
-        let text = this._notificationBadgeCountToText(count);
-        this._notificationBadgeLabel.set_text(text);
-    }
-
-    toggleNotificationBadge(activate) {
-        if (activate && this._notificationBadgeCount > 0)
+    setNotificationCount(count) {
+        if (count > 0) {
+            let text = this._notificationBadgeCountToText(count);
+            this._notificationBadgeLabel.set_text(text);
             this._notificationBadgeBin.show();
-        else
+        } else {
             this._notificationBadgeBin.hide();
+        }
     }
 
     _showProgressOverlay() {
@@ -876,80 +851,12 @@ var UnityIndicator = class DashToDock_UnityIndicator extends IndicatorBase {
     }
 
     setProgress(progress) {
-        this._progress = Math.min(Math.max(progress, 0.0), 1.0);
-        this._updateProgressOverlay();
-    }
-
-    toggleProgressOverlay(activate) {
-        if (activate) {
+        if (progress < 0) {
+            this._hideProgressOverlay();
+        } else {
+            this._progress = Math.min(progress, 1.0);
             this._showProgressOverlay();
         }
-        else {
-            this._hideProgressOverlay();
-        }
-    }
-
-    insertEntryRemote(remote) {
-        if (!remote || this._remoteEntries.indexOf(remote) !== -1)
-            return;
-
-        this._remoteEntries.push(remote);
-        this._selectEntryRemote(remote);
-    }
-
-    removeEntryRemote(remote) {
-        if (!remote || this._remoteEntries.indexOf(remote) == -1)
-            return;
-
-        this._remoteEntries.splice(this._remoteEntries.indexOf(remote), 1);
-
-        if (this._remoteEntries.length > 0) {
-            this._selectEntryRemote(this._remoteEntries[this._remoteEntries.length-1]);
-        } else {
-            this.setNotificationBadge(0);
-            this.toggleNotificationBadge(false);
-            this.setProgress(0);
-            this.toggleProgressOverlay(false);
-        }
-    }
-
-    _selectEntryRemote(remote) {
-        if (!remote)
-            return;
-
-        this._signalsHandler.removeWithLabel('entry-remotes');
-
-        this._signalsHandler.addWithLabel('entry-remotes',
-        [
-            remote,
-            'count-changed',
-            (remote, value) => {
-                this.setNotificationBadge(value);
-            }
-        ], [
-            remote,
-            'count-visible-changed',
-            (remote, value) => {
-                this.toggleNotificationBadge(value);
-            }
-        ], [
-            remote,
-            'progress-changed',
-            (remote, value) => {
-                this.setProgress(value);
-            }
-        ], [
-            remote,
-            'progress-visible-changed',
-            (remote, value) => {
-                this.toggleProgressOverlay(value);
-            }
-        ]);
-
-        this.setNotificationBadge(remote.count());
-        this.toggleNotificationBadge(remote.countVisible());
-        this.setProgress(remote.progress());
-        this.toggleProgressOverlay(remote.progressVisible());
     }
 }
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -75,13 +75,14 @@ let recentlyClickedAppMonitor = -1;
 var MyAppIcon = GObject.registerClass(
 class MyAppIcon extends Dash.DashIcon {
     // settings are required inside.
-    _init(remoteModel, app, monitorIndex) {
+    _init(remoteModel, app, monitorIndex, iconAnimator) {
         super._init(app);
 
         // a prefix is required to avoid conflicting with the parent class variable
         this.monitorIndex = monitorIndex;
         this._signalsHandler = new Utils.GlobalSignalsHandler();
         this.remoteModel = remoteModel;
+        this.iconAnimator = iconAnimator;
         this._indicator = null;
 
         let appInfo = app.get_app_info();

--- a/dash.js
+++ b/dash.js
@@ -172,7 +172,7 @@ var MyDash = GObject.registerClass({
     }
 }, class DashToDock_MyDash extends St.Bin {
 
-    _init(remoteModel, monitorIndex) {
+    _init(remoteModel, monitorIndex, iconAnimator) {
         // Initialize icon variables and size
         this._maxHeight = -1;
         this.iconSize = Docking.DockManager.settings.get_int('dash-max-icon-size');
@@ -246,6 +246,8 @@ var MyDash = GObject.registerClass({
         });
 
         this._appSystem = Shell.AppSystem.get_default();
+
+        this._iconAnimator = iconAnimator;
 
         this._signalsHandler.add([
             this._appSystem,
@@ -469,7 +471,7 @@ var MyDash = GObject.registerClass({
 
     _createAppItem(app) {
         let appIcon = new AppIcons.MyAppIcon(this._remoteModel, app,
-            this._monitorIndex);
+            this._monitorIndex, this._iconAnimator);
 
         if (appIcon._draggable) {
             appIcon._draggable.connect('drag-begin', () => {

--- a/dbusmenuUtils.js
+++ b/dbusmenuUtils.js
@@ -1,0 +1,261 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Atk = imports.gi.Atk;
+const Clutter = imports.gi.Clutter;
+const Dbusmenu = imports.gi.Dbusmenu;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const St = imports.gi.St;
+
+const PopupMenu = imports.ui.popupMenu;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Utils = Me.imports.utils;
+
+// Dbusmenu features not (yet) supported:
+//
+//   * The CHILD_DISPLAY property
+//
+//     This seems to have only one possible value in the Dbusmenu API, so
+//     there's little point in depending on it--the code in libdbusmenu sets it
+//     if and only if an item has children, so for our purposes it's simpler
+//     and more intuitive to just check children.length. (This does ignore the
+//     possibility of a program not using libdbusmenu and setting CHILD_DISPLAY
+//     independently, perhaps to indicate that an childless menu item should
+//     nevertheless be displayed like a submenu.)
+//
+//   * Children more than two levels deep
+//
+//     PopupMenu doesn't seem to support submenus in submenus.
+//
+//   * Shortcut keys
+//
+//     If these keys are supposed to be installed as global shortcuts, we'd
+//     have to query these aggressively and not wait for the DBus menu to be
+//     mapped to a popup menu. A shortcut key that only works once the popup
+//     menu is open and has key focus is possibly of marginal value.
+
+
+function makePopupMenuItem(dbusmenuItem, deep) {
+    // These are the only properties guaranteed to be available when the root
+    // item is first announced. Other properties might be loaded already, but
+    // be sure to connect to Dbusmenu.MENUITEM_SIGNAL_PROPERTY_CHANGED to get
+    // the most up-to-date values in case they aren't.
+    const itemType = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_TYPE);
+    const label = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_LABEL);
+    const visible = dbusmenuItem.property_get_bool(Dbusmenu.MENUITEM_PROP_VISIBLE);
+    const enabled = dbusmenuItem.property_get_bool(Dbusmenu.MENUITEM_PROP_ENABLED);
+    const accessibleDesc = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_ACCESSIBLE_DESC);
+    //const childDisplay = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_CHILD_DISPLAY);
+
+    let item;
+    const signalsHandler = new Utils.GlobalSignalsHandler();
+    const wantIcon = itemType === Dbusmenu.CLIENT_TYPES_IMAGE;
+
+    // If the basic type of the menu item needs to change, call this.
+    const recreateItem = () => {
+        const newItem = makePopupMenuItem(dbusmenuItem, deep);
+        const parentMenu = item._parent;
+        parentMenu.addMenuItem(newItem);
+        // Reminder: Clutter thinks of later entries in the child list as
+        // "above" earlier ones, so "above" here means "below" in terms of the
+        // menu's vertical order.
+        parentMenu.actor.set_child_above_sibling(newItem.actor, item.actor);
+        if (newItem.menu) {
+            parentMenu.actor.set_child_above_sibling(newItem.menu.actor, newItem.actor);
+        }
+        parentMenu.actor.remove_child(item.actor);
+        item.destroy();
+        item = null;
+    };
+
+    const updateDisposition = () => {
+        const disposition = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_DISPOSITION);
+        let icon_name = null;
+        switch (disposition) {
+            case Dbusmenu.MENUITEM_DISPOSITION_ALERT:
+            case Dbusmenu.MENUITEM_DISPOSITION_WARNING:
+                icon_name = 'dialog-warning-symbolic';
+                break;
+            case Dbusmenu.MENUITEM_DISPOSITION_INFORMATIVE:
+                icon_name = 'dialog-information-symbolic';
+                break;
+        }
+        if (icon_name) {
+            item._dispositionIcon = new St.Icon({
+                icon_name,
+                style_class: 'popup-menu-icon',
+                y_align: Clutter.ActorAlign.CENTER,
+                y_expand: true,
+            });
+            let expander;
+            for (let child = item.label.get_next_sibling();; child = child.get_next_sibling()) {
+                if (!child) {
+                    expander = new St.Bin({
+                        style_class: 'popup-menu-item-expander',
+                        x_expand: true,
+                    });
+                    item.actor.add_child(expander);
+                    break;
+                } else if (child instanceof St.Widget && child.has_style_class_name('popup-menu-item-expander')) {
+                    expander = child;
+                    break;
+                }
+            }
+            item.actor.insert_child_above(item._dispositionIcon, expander);
+        } else if (item._dispositionIcon) {
+            item.actor.remove_child(item._dispositionIcon);
+            item._dispositionIcon = null;
+        }
+    };
+
+    const updateIcon = () => {
+        if (!wantIcon) {
+            return;
+        }
+        const iconData = dbusmenuItem.property_get_byte_array(Dbusmenu.MENUITEM_PROP_ICON_DATA);
+        const iconName = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_ICON_NAME);
+        if (iconName) {
+            item.icon.icon_name = iconName;
+        } else if (iconData.length) {
+            item.icon.gicon = Gio.BytesIcon.new(iconData);
+        }
+    };
+
+    const updateOrnament = () => {
+        const toggleType = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_TOGGLE_TYPE);
+        switch (toggleType) {
+            case Dbusmenu.MENUITEM_TOGGLE_CHECK:
+                item.actor.accessible_role = Atk.Role.CHECK_MENU_ITEM;
+                break;
+            case Dbusmenu.MENUITEM_TOGGLE_RADIO:
+                item.actor.accessible_role = Atk.Role.RADIO_MENU_ITEM;
+                break;
+            default:
+                item.actor.accessible_role = Atk.Role.MENU_ITEM;
+        }
+        let ornament = PopupMenu.Ornament.NONE;
+        const state = dbusmenuItem.property_get_int(Dbusmenu.MENUITEM_PROP_TOGGLE_STATE);
+        if (state === Dbusmenu.MENUITEM_TOGGLE_STATE_UNKNOWN) {
+            // PopupMenu doesn't natively support an "unknown" ornament, but we
+            // can hack one in:
+            item.setOrnament(ornament);
+            item.actor.add_accessible_state(Atk.StateType.INDETERMINATE);
+            item._ornamentLabel.text = '\u2501';
+            item.actor.remove_style_pseudo_class('checked');
+        } else {
+            item.actor.remove_accessible_state(Atk.StateType.INDETERMINATE);
+            if (state === Dbusmenu.MENUITEM_TOGGLE_STATE_CHECKED) {
+                if (toggleType === Dbusmenu.MENUITEM_TOGGLE_CHECK) {
+                    ornament = PopupMenu.Ornament.CHECK;
+                } else if (toggleType === Dbusmenu.MENUITEM_TOGGLE_RADIO) {
+                    ornament = PopupMenu.Ornament.DOT;
+                }
+                item.actor.add_style_pseudo_class('checked');
+            } else {
+                item.actor.remove_style_pseudo_class('checked');
+            }
+            item.setOrnament(ornament);
+        }
+    };
+
+    const onPropertyChanged = (dbusmenuItem, name, value) => {
+        // `value` is null when a property is cleared, so handle those cases
+        // with sensible defaults.
+        switch (name) {
+            case Dbusmenu.MENUITEM_PROP_TYPE:
+                recreateItem();
+                break;
+            case Dbusmenu.MENUITEM_PROP_ENABLED:
+                item.setSensitive(value ? value.unpack() : false);
+                break;
+            case Dbusmenu.MENUITEM_PROP_LABEL:
+                item.label.text = value ? value.unpack() : '';
+                break;
+            case Dbusmenu.MENUITEM_PROP_VISIBLE:
+                item.actor.visible = value ? value.unpack() : false;
+                break;
+            case Dbusmenu.MENUITEM_PROP_DISPOSITION:
+                updateDisposition();
+                break;
+            case Dbusmenu.MENUITEM_PROP_ACCESSIBLE_DESC:
+                item.actor.get_accessible().accessible_description = value && value.unpack() || '';
+                break;
+            case Dbusmenu.MENUITEM_PROP_ICON_DATA:
+            case Dbusmenu.MENUITEM_PROP_ICON_NAME:
+                updateIcon();
+                break;
+            case Dbusmenu.MENUITEM_PROP_TOGGLE_TYPE:
+            case Dbusmenu.MENUITEM_PROP_TOGGLE_STATE:
+                updateOrnament();
+                break;
+        }
+    };
+
+
+    // Start actually building the menu item.
+    const children = dbusmenuItem.get_children();
+    if (children.length && !deep) {
+        // Make a submenu.
+        item = new PopupMenu.PopupSubMenuMenuItem(label, wantIcon);
+        const updateChildren = () => {
+            const children = dbusmenuItem.get_children();
+            if (!children.length) {
+                return recreateItem();
+            }
+            item.menu.removeAll();
+            children.forEach(remoteChild =>
+                item.menu.addMenuItem(makePopupMenuItem(remoteChild, true)));
+        };
+        updateChildren();
+        signalsHandler.add(
+            [dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_CHILD_ADDED, updateChildren],
+            [dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_CHILD_MOVED, updateChildren],
+            [dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_CHILD_REMOVED, updateChildren]);
+
+    } else {
+        // Don't make a submenu.
+        if (!deep) {
+            // We only have the potential to get a submenu if we aren't deep.
+            signalsHandler.add(
+                [dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_CHILD_ADDED, recreateItem],
+                [dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_CHILD_MOVED, recreateItem],
+                [dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_CHILD_REMOVED, recreateItem]);
+        }
+
+        if (itemType === Dbusmenu.CLIENT_TYPES_SEPARATOR) {
+            item = new PopupMenu.PopupSeparatorMenuItem();
+        } else if (wantIcon) {
+            item = new PopupMenu.PopupImageMenuItem(label, null);
+            item.icon = item._icon;
+        } else {
+            item = new PopupMenu.PopupMenuItem(label);
+        }
+    }
+
+    // Set common initial properties.
+    item.actor.visible = visible;
+    item.setSensitive(enabled);
+    if (accessibleDesc) {
+        item.actor.get_accessible().accessible_description = accessibleDesc;
+    }
+    updateDisposition();
+    updateIcon();
+    updateOrnament();
+
+    // Prevent an initial resize flicker.
+    if (wantIcon) {
+        item.icon.icon_size = 16;
+    }
+
+    signalsHandler.add([dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_PROPERTY_CHANGED, onPropertyChanged]);
+
+    // Connections on item will be lost when item is disposed; there's no need
+    // to add them to signalsHandler.
+    item.connect('activate', () => {
+        dbusmenuItem.handle_event(Dbusmenu.MENUITEM_EVENT_ACTIVATED, new GLib.Variant('i', 0), Math.floor(Date.now()/1000));
+    });
+    item.connect('destroy', () => signalsHandler.destroy());
+
+    return item;
+}

--- a/launcherAPI.js
+++ b/launcherAPI.js
@@ -1,21 +1,23 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
+const Dbusmenu = imports.gi.Dbusmenu;
 const Gio = imports.gi.Gio;
-const Signals = imports.signals;
 
 var LauncherEntryRemoteModel = class DashToDock_LauncherEntryRemoteModel {
 
     constructor() {
-        this._entriesByDBusName = {};
+        this._entrySourceStacks = new Map();
+        this._remoteMaps = new Map();
 
         this._launcher_entry_dbus_signal_id =
             Gio.DBus.session.signal_subscribe(null, // sender
                 'com.canonical.Unity.LauncherEntry', // iface
-                null, // member
+                'Update', // member
                 null, // path
                 null, // arg0
                 Gio.DBusSignalFlags.NONE,
-                this._onEntrySignalReceived.bind(this));
+                (connection, sender_name, object_path, interface_name, signal_name, parameters) =>
+                    this._onUpdate(sender_name, ...parameters.deep_unpack()));
 
         this._dbus_name_owner_changed_signal_id =
             Gio.DBus.session.signal_subscribe('org.freedesktop.DBus',  // sender
@@ -24,7 +26,8 @@ var LauncherEntryRemoteModel = class DashToDock_LauncherEntryRemoteModel {
                 '/org/freedesktop/DBus', // path
                 null,                    // arg0
                 Gio.DBusSignalFlags.NONE,
-                this._onDBusNameOwnerChanged.bind(this));
+                (connection, sender_name, object_path, interface_name, signal_name, parameters) =>
+                    this._onDBusNameChange(...parameters.deep_unpack().slice(1)));
 
         this._acquireUnityDBus();
     }
@@ -41,39 +44,16 @@ var LauncherEntryRemoteModel = class DashToDock_LauncherEntryRemoteModel {
         this._releaseUnityDBus();
     }
 
-    size() {
-        return Object.keys(this._entriesByDBusName).length;
-    }
-
-    lookupByDBusName(dbusName) {
-        return this._entriesByDBusName.hasOwnProperty(dbusName) ? this._entriesByDBusName[dbusName] : null;
+    _lookupStackById(appId) {
+        let sourceStack = this._entrySourceStacks.get(appId);
+        if (!sourceStack) {
+            this._entrySourceStacks.set(appId, sourceStack = new PropertySourceStack(new LauncherEntry(), launcherEntryDefaults));
+        }
+        return sourceStack;
     }
 
     lookupById(appId) {
-        let ret = [];
-        for (let dbusName in this._entriesByDBusName) {
-            let entry = this._entriesByDBusName[dbusName];
-            if (entry && entry.appId() == appId) {
-                ret.push(entry);
-            }
-        }
-
-        return ret;
-    }
-
-    addEntry(entry) {
-        let existingEntry = this.lookupByDBusName(entry.dbusName());
-        if (existingEntry) {
-            existingEntry.update(entry);
-        } else {
-            this._entriesByDBusName[entry.dbusName()] = entry;
-            this.emit('entry-added', entry);
-        }
-    }
-
-    removeEntry(entry) {
-        delete this._entriesByDBusName[entry.dbusName()]
-        this.emit('entry-removed', entry);
+        return this._lookupStackById(appId).target;
     }
 
     _acquireUnityDBus() {
@@ -91,150 +71,177 @@ var LauncherEntryRemoteModel = class DashToDock_LauncherEntryRemoteModel {
         }
     }
 
-    _onEntrySignalReceived(connection, sender_name, object_path,
-        interface_name, signal_name, parameters, user_data) {
-        if (!parameters || !signal_name)
-            return;
-
-        if (signal_name == 'Update') {
-            if (!sender_name) {
-                return;
-            }
-
-            this._handleUpdateRequest(sender_name, parameters);
-        }
-    }
-
-    _onDBusNameOwnerChanged(connection, sender_name, object_path,
-        interface_name, signal_name, parameters, user_data) {
-        if (!parameters || !this.size())
-            return;
-
-        let [name, before, after] = parameters.deep_unpack();
-
-        if (!after) {
-            if (this._entriesByDBusName.hasOwnProperty(before)) {
-                this.removeEntry(this._entriesByDBusName[before]);
-            }
-        }
-    }
-
-    _handleUpdateRequest(senderName, parameters) {
-        if (!senderName || !parameters) {
+    _onDBusNameChange(before, after) {
+        if (!before || !this._remoteMaps.size) {
             return;
         }
-
-        let [appUri, properties] = parameters.deep_unpack();
-        let appId = appUri.replace(/(^\w+:|^)\/\//, '');
-        let entry = this.lookupByDBusName(senderName);
-
-        if (entry) {
-            entry.setDBusName(senderName);
-            entry.update(properties);
+        const remoteMap = this._remoteMaps.get(before);
+        if (!remoteMap) {
+            return;
+        }
+        this._remoteMaps.delete(before);
+        if (after && !this._remoteMaps.has(after)) {
+            this._remoteMaps.set(after, remoteMap);
         } else {
-            let entry = new LauncherEntryRemote(senderName, appId, properties);
-            this.addEntry(entry);
-        }
-    }
-};
-Signals.addSignalMethods(LauncherEntryRemoteModel.prototype);
-
-var LauncherEntryRemote = class DashToDock_LauncherEntryRemote {
-
-    constructor(dbusName, appId, properties) {
-        this._dbusName = dbusName;
-        this._appId = appId;
-        this._count = 0;
-        this._countVisible = false;
-        this._progress = 0.0;
-        this._progressVisible = false;
-        this.update(properties);
-    }
-
-    appId() {
-        return this._appId;
-    }
-
-    dbusName() {
-        return this._dbusName;
-    }
-
-    count() {
-        return this._count;
-    }
-
-    setCount(count) {
-        if (this._count != count) {
-            this._count = count;
-            this.emit('count-changed', this._count);
-        }
-    }
-
-    countVisible() {
-        return this._countVisible;
-    }
-
-    setCountVisible(countVisible) {
-        if (this._countVisible != countVisible) {
-            this._countVisible = countVisible;
-            this.emit('count-visible-changed', this._countVisible);
-        }
-    }
-
-    progress() {
-        return this._progress;
-    }
-
-    setProgress(progress) {
-        if (this._progress != progress) {
-            this._progress = progress;
-            this.emit('progress-changed', this._progress);
-        }
-    }
-
-    progressVisible() {
-        return this._progressVisible;
-    }
-
-    setProgressVisible(progressVisible) {
-        if (this._progressVisible != progressVisible) {
-            this._progressVisible = progressVisible;
-            this.emit('progress-visible-changed', this._progressVisible);
-        }
-    }
-
-    setDBusName(dbusName) {
-        if (this._dbusName != dbusName) {
-            let oldName = this._dbusName;
-            this._dbusName = dbusName;
-            this.emit('dbus-name-changed', oldName);
-        }
-    }
-
-    update(other) {
-        if (other instanceof LauncherEntryRemote) {
-            this.setDBusName(other.dbusName())
-            this.setCount(other.count());
-            this.setCountVisible(other.countVisible());
-            this.setProgress(other.progress());
-            this.setProgressVisible(other.progressVisible())
-        } else {
-            for (let property in other) {
-                if (other.hasOwnProperty(property)) {
-                    if (property == 'count') {
-                        this.setCount(other[property].get_int64());
-                    } else if (property == 'count-visible') {
-                        this.setCountVisible(other[property].get_boolean());
-                    } if (property == 'progress') {
-                        this.setProgress(other[property].get_double());
-                    } else if (property == 'progress-visible') {
-                        this.setProgressVisible(other[property].get_boolean());
-                    } else {
-                        // Not implemented yet
-                    }
+            for (const [appId, remote] of remoteMap) {
+                const sourceStack = this._entrySourceStacks.get(appId);
+                const changed = sourceStack.remove(remote);
+                if (changed) {
+                    sourceStack.target._emitChangedEvents(changed);
                 }
             }
         }
     }
+
+    _onUpdate(senderName, appUri, properties) {
+        if (!senderName) {
+            return;
+        }
+
+        const appId = appUri.replace(/(^\w+:|^)\/\//, '');
+        if (!appId) {
+            return;
+        }
+
+        let remoteMap = this._remoteMaps.get(senderName);
+        if (!remoteMap) {
+            this._remoteMaps.set(senderName, remoteMap = new Map());
+        }
+        let remote = remoteMap.get(appId);
+        if (!remote) {
+            remoteMap.set(appId, remote = Object.assign({}, launcherEntryDefaults));
+        }
+        for (const name in properties) {
+            remote[name] = properties[name].unpack();
+        }
+
+        const sourceStack = this._lookupStackById(appId);
+        sourceStack.target._emitChangedEvents(sourceStack.update(remote));
+    }
 };
-Signals.addSignalMethods(LauncherEntryRemote.prototype);
+
+const launcherEntryDefaults = {
+    count: 0,
+    progress: 0,
+    'count-visible': false,
+    'progress-visible': false,
+};
+
+const LauncherEntry = class DashToDock_LauncherEntry {
+    constructor() {
+        this._connections = new Map();
+        this._handlers = new Map();
+        this._nextId = 0;
+    }
+
+    connect(eventNames, callback) {
+        if (typeof eventNames === 'string') {
+            eventNames = [eventNames];
+        }
+        callback(this, this);
+        const id = this._nextId++;
+        const handler = { id, callback };
+        eventNames.forEach(name => {
+            let handlerList = this._handlers.get(name);
+            if (!handlerList) {
+                this._handlers.set(name, handlerList = []);
+            }
+            handlerList.push(handler);
+        });
+        this._connections.set(id, eventNames);
+        return id;
+    }
+
+    disconnect(id) {
+        const eventNames = this._connections.get(id);
+        if (!eventNames) {
+            return;
+        }
+        this._connections.delete(id);
+        eventNames.forEach(name => {
+            const handlerList = this._handlers.get(name);
+            if (handlerList) {
+                for (let i = 0, iMax = handlerList.length; i < iMax; i++) {
+                    if (handlerList[i].id === id) {
+                        handlerList.splice(i, 1);
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    _emitChangedEvents(propertyNames) {
+        const handlers = new Set();
+        propertyNames.forEach(name => {
+            const handlerList = this._handlers.get(name + '-changed');
+            if (handlerList) {
+                for (let i = 0, iMax = handlerList.length; i < iMax; i++) {
+                    handlers.add(handlerList[i]);
+                }
+            }
+        });
+        Array.from(handlers).sort((x, y) => x.id - y.id).forEach(handler => handler.callback(this, this));
+    }
+}
+
+for (const name in launcherEntryDefaults) {
+    const jsName = name.replace(/-/g, '_');
+    LauncherEntry.prototype[jsName] = launcherEntryDefaults[name];
+    if (jsName !== name) {
+        Object.defineProperty(LauncherEntry.prototype, name, {
+            get() {
+                return this[jsName];
+            },
+            set(value) {
+                this[jsName] = value;
+            },
+        });
+    }
+}
+
+const PropertySourceStack = class DashToDock_PropertySourceStack {
+    constructor(target, bottom) {
+        this.target = target;
+        this._bottom = bottom;
+        this._stack = [];
+    }
+
+    isTop(source) {
+        return this._stack.length > 0 && this._stack[this._stack.length - 1] === source;
+    }
+
+    update(source) {
+        if (!this.isTop(source)) {
+            this.remove(source);
+            this._stack.push(source);
+        }
+        return this._assignFrom(source);
+    }
+
+    remove(source) {
+        const stack = this._stack;
+        const top = stack[stack.length - 1];
+        if (top === source) {
+            stack.length--;
+            return this._assignFrom(stack.length > 0 ? stack[stack.length - 1] : this._bottom);
+        }
+        for (let i = 0, iMax = stack.length; i < iMax; i++) {
+            if (stack[i] === source) {
+                stack.splice(i, 1);
+                break;
+            }
+        }
+    }
+
+    _assignFrom(source) {
+        const changedProperties = [];
+        for (const name in source) {
+            if (this.target[name] !== source[name]) {
+                this.target[name] = source[name];
+                changedProperties.push(name);
+            }
+        }
+        return changedProperties;
+    }
+}

--- a/launcherAPI.js
+++ b/launcherAPI.js
@@ -151,6 +151,7 @@ var LauncherEntryRemoteModel = class DashToDock_LauncherEntryRemoteModel {
 const launcherEntryDefaults = {
     count: 0,
     progress: 0,
+    urgent: false,
     quicklist: null,
     'count-visible': false,
     'progress-visible': false,

--- a/utils.js
+++ b/utils.js
@@ -281,3 +281,28 @@ function drawRoundedLine(cr, x, y, width, height, isRoundLeft, isRoundRight, str
         cr.setSource(stroke);
     cr.stroke();
 }
+
+/**
+ * Convert a signal handler with n value parameters (that is, excluding the
+ * signal source parameter) to an array of n handlers that are each responsible
+ * for receiving one of the n values and calling the original handler with the
+ * most up-to-date arguments.
+ */
+function splitHandler(handler) {
+    if (handler.length > 30) {
+        throw new Error("too many parameters");
+    }
+    const count = handler.length - 1;
+    let missingValueBits = (1 << count) - 1;
+    const values = Array.from({ length: count });
+    return values.map((_ignored, i) => {
+        const mask = ~(1 << i);
+        return (obj, value) => {
+            values[i] = value;
+            missingValueBits &= mask;
+            if (missingValueBits === 0) {
+                handler(obj, ...values);
+            }
+        };
+    });
+}


### PR DESCRIPTION
This adds support for the two properties of a libunity LauncherEntry object not yet supported: "quicklist" and "urgent". Quicklist entries are added to the right-click menu of the launcher as dynamic menu items. The urgent flag, if set, gives the icon a short dancing animation to call attention to it. These features don't seem to be widely used by applications, but there's a bit of a chicken-and-egg problem here; why would application authors spend time writing code to use them if they aren't supported by the desktop?

I encountered some trouble with the libunity communication, and I also had some trouble understanding the intent of the original libunity integrating code, so I took the liberty of refactoring it into a pattern that, among other advantages, is more robust to multiple DBus applications contending for the same LauncherEntry. Hopefully you see it as an improvement too; I can try to back it out if not, but it did make adding these two features much easier.

I've been using this branch for the better part of a year now, and tested the new features with my own custom applications; it all has been working quite well for me. I hope it does some good for someone else.