### PR TITLE
implement "minimize or overview" with only current app windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ BASE_MODULES = extension.js \
                README.md \
                $(NULL)
 
-EXTRA_MODULES = dash.js \
+EXTRA_MODULES = \
+                appSpread.js \
+                dash.js \
                 docking.js \
                 appIcons.js \
                 appIconIndicators.js \

--- a/Settings.ui
+++ b/Settings.ui
@@ -78,6 +78,7 @@
                           <item translatable="yes">Show window previews</item>
                           <item translatable="yes">Minimize or show previews</item>
                           <item translatable="yes">Focus or show previews</item>
+                          <item translatable="yes">Focus or app spread</item>
                           <item translatable="yes">Focus, minimize or show previews</item>
                           <item translatable="yes">Focus, minimize or app spread</item>
                           <item translatable="yes">Quit</item>
@@ -149,6 +150,7 @@
                           <item translatable="yes">Show window previews</item>
                           <item translatable="yes">Minimize or show previews</item>
                           <item translatable="yes">Focus or show previews</item>
+                          <item translatable="yes">Focus or app spread</item>
                           <item translatable="yes">Focus, minimize or show previews</item>
                           <item translatable="yes">Focus, minimize or app spread</item>
                           <item translatable="yes">Quit</item>
@@ -220,6 +222,7 @@
                           <item translatable="yes">Show window previews</item>
                           <item translatable="yes">Minimize or show previews</item>
                           <item translatable="yes">Focus or show previews</item>
+                          <item translatable="yes">Focus or app spread</item>
                           <item translatable="yes">Focus, minimize or show previews</item>
                           <item translatable="yes">Focus, minimize or app spread</item>
                           <item translatable="yes">Quit</item>
@@ -1492,6 +1495,7 @@
                                       <item translatable="yes">Show window previews</item>
                                       <item translatable="yes">Minimize or show previews</item>
                                       <item translatable="yes">Focus or show previews</item>
+                                      <item translatable="yes">Focus or app spread</item>
                                       <item translatable="yes">Focus, minimize or show previews</item>
                                       <item translatable="yes">Focus, minimize or app spread</item>
                                     </items>

--- a/Settings.ui
+++ b/Settings.ui
@@ -79,6 +79,7 @@
                           <item translatable="yes">Minimize or show previews</item>
                           <item translatable="yes">Focus or show previews</item>
                           <item translatable="yes">Focus, minimize or show previews</item>
+                          <item translatable="yes">Focus, minimize or app spread</item>
                           <item translatable="yes">Quit</item>
                         </items>
                         <layout>
@@ -149,6 +150,7 @@
                           <item translatable="yes">Minimize or show previews</item>
                           <item translatable="yes">Focus or show previews</item>
                           <item translatable="yes">Focus, minimize or show previews</item>
+                          <item translatable="yes">Focus, minimize or app spread</item>
                           <item translatable="yes">Quit</item>
                         </items>
                         <layout>
@@ -219,6 +221,7 @@
                           <item translatable="yes">Minimize or show previews</item>
                           <item translatable="yes">Focus or show previews</item>
                           <item translatable="yes">Focus, minimize or show previews</item>
+                          <item translatable="yes">Focus, minimize or app spread</item>
                           <item translatable="yes">Quit</item>
                         </items>
                         <layout>
@@ -1490,6 +1493,7 @@
                                       <item translatable="yes">Minimize or show previews</item>
                                       <item translatable="yes">Focus or show previews</item>
                                       <item translatable="yes">Focus, minimize or show previews</item>
+                                      <item translatable="yes">Focus, minimize or app spread</item>
                                     </items>
                                   </object>
                                 </child>

--- a/appIcons.js
+++ b/appIcons.js
@@ -473,6 +473,18 @@ var DockAbstractAppIcon = GObject.registerClass({
                 buttonAction = settings.clickAction;
         }
 
+        switch (buttonAction) {
+            case clickAction.FOCUS_OR_APP_SPREAD:
+                if (!Docking.DockManager.getDefault().appSpread.supported)
+                    buttonAction = clickAction.FOCUS_OR_PREVIEWS;
+                break;
+
+            case clickAction.FOCUS_MINIMIZE_OR_APP_SPREAD:
+                if (!Docking.DockManager.getDefault().appSpread.supported)
+                    buttonAction = clickAction.FOCUS_MINIMIZE_OR_PREVIEWS;
+                break;
+        }
+
         // We check if the app is running, and that the # of windows is > 0 in
         // case we use workspace isolation.
         let windows = this.getInterestingWindows();

--- a/appIcons.js
+++ b/appIcons.js
@@ -36,7 +36,6 @@ const Docking = Me.imports.docking;
 const Locations = Me.imports.locations;
 const Utils = Me.imports.utils;
 const WindowPreview = Me.imports.windowPreview;
-const AppSpread = Me.imports.appSpread;
 const AppIconIndicators = Me.imports.appIconIndicators;
 const DbusmenuUtils = Me.imports.dbusmenuUtils;
 
@@ -114,7 +113,6 @@ var DockAbstractAppIcon = GObject.registerClass({
         // a prefix is required to avoid conflicting with the parent class variable
         this.monitorIndex = monitorIndex;
         this._signalsHandler = new Utils.GlobalSignalsHandler(this);
-        this.appSpread = new AppSpread.AppSpread();
         this.iconAnimator = iconAnimator;
         this._indicator = new AppIconIndicators.AppIconIndicator(this);
 
@@ -519,7 +517,7 @@ var DockAbstractAppIcon = GObject.registerClass({
                     const isClickedIconFocusedApp = this.app === tracker.focus_app;
                     if (isClickedIconFocusedApp) {
                         shouldHideOverview = false;
-                        this.appSpread.toggleAppSpread(windows);
+                        Docking.DockManager.getDefault().appSpread.toggle(windows);
                     } else {
                         // Clicked on another app or all app windows are minimized -> focus that
                         Main.activateWindow(windows[0]);

--- a/appIcons.js
+++ b/appIcons.js
@@ -522,22 +522,6 @@ var DockAbstractAppIcon = GObject.registerClass({
                 }
                 break;
 
-            case clickAction.FOCUS_OR_APP_SPREAD:
-            case clickAction.FOCUS_MINIMIZE_OR_APP_SPREAD:
-                const appSpreadCandidate = windows.length !== 1 || !!modifiers || button !== 1;
-                if (appSpreadCandidate) {
-                    const isClickedIconFocusedApp = this.app === tracker.focus_app;
-                    if (isClickedIconFocusedApp) {
-                        shouldHideOverview = false;
-                        Docking.DockManager.getDefault().appSpread.toggle(this.app);
-                    } else {
-                        // Clicked on another app or all app windows are minimized -> focus that
-                        Main.activateWindow(windows[0]);
-                    }
-                    break;
-                }
-                // fallthrough
-
             case clickAction.MINIMIZE_OR_OVERVIEW:
                 // When a single window is present, toggle minimization
                 // If only one windows is present toggle minimization, but only when triggered with the
@@ -638,6 +622,28 @@ var DockAbstractAppIcon = GObject.registerClass({
                     }
                 } else {
                     this.app.activate();
+                }
+                break;
+
+            case clickAction.FOCUS_OR_APP_SPREAD:
+                if (this.focused && !singleOrUrgentWindows && !modifiers && button === 1) {
+                    shouldHideOverview = false;
+                    Docking.DockManager.getDefault().appSpread.toggle(this.app);
+                } else {
+                    // Activate the first window
+                    Main.activateWindow(windows[0]);
+                }
+                break;
+
+            case clickAction.FOCUS_MINIMIZE_OR_APP_SPREAD:
+                if (this.focused && !singleOrUrgentWindows && !modifiers && button === 1) {
+                    shouldHideOverview = false;
+                    Docking.DockManager.getDefault().appSpread.toggle(this.app);
+                } else if (!this.focused) {
+                    // Activate the first window
+                    Main.activateWindow(windows[0]);
+                } else {
+                    this._minimizeWindow();
                 }
                 break;
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -529,7 +529,7 @@ var DockAbstractAppIcon = GObject.registerClass({
                     const isClickedIconFocusedApp = this.app === tracker.focus_app;
                     if (isClickedIconFocusedApp) {
                         shouldHideOverview = false;
-                        Docking.DockManager.getDefault().appSpread.toggle(windows);
+                        Docking.DockManager.getDefault().appSpread.toggle(this.app);
                     } else {
                         // Clicked on another app or all app windows are minimized -> focus that
                         Main.activateWindow(windows[0]);
@@ -1259,7 +1259,7 @@ function getInterestingWindows(windows, monitorIndex) {
         });
     }
 
-    if (settings.isolateMonitors) {
+    if (settings.isolateMonitors && monitorIndex >= 0) {
         windows = windows.filter(function(w) {
             return w.get_monitor() === monitorIndex;
         });

--- a/appIcons.js
+++ b/appIcons.js
@@ -47,7 +47,7 @@ const Labels = Object.freeze({
     URGENT_WINDOWS: Symbol('urgent-windows'),
 });
 
-const clickAction = {
+const clickAction = Object.freeze({
     SKIP: 0,
     MINIMIZE: 1,
     LAUNCH: 2,
@@ -56,16 +56,17 @@ const clickAction = {
     PREVIEWS: 5,
     MINIMIZE_OR_PREVIEWS: 6,
     FOCUS_OR_PREVIEWS: 7,
-    FOCUS_MINIMIZE_OR_PREVIEWS: 8,
-    APP_SPREAD: 9,
-    QUIT: 10
-};
+    FOCUS_OR_APP_SPREAD: 8,
+    FOCUS_MINIMIZE_OR_PREVIEWS: 9,
+    FOCUS_MINIMIZE_OR_APP_SPREAD: 10,
+    QUIT: 11,
+});
 
-const scrollAction = {
+const scrollAction = Object.freeze({
     DO_NOTHING: 0,
     CYCLE_WINDOWS: 1,
     SWITCH_WORKSPACE: 2
-};
+});
 
 let recentlyClickedAppLoopId = 0;
 let recentlyClickedApp = null;
@@ -511,17 +512,17 @@ var DockAbstractAppIcon = GObject.registerClass({
                 }
                 break;
 
-            case clickAction.APP_SPREAD:
-                const appSpreadCandidate = windows.length != 1 || !!modifiers || button != 1;
+            case clickAction.FOCUS_OR_APP_SPREAD:
+            case clickAction.FOCUS_MINIMIZE_OR_APP_SPREAD:
+                const appSpreadCandidate = windows.length !== 1 || !!modifiers || button !== 1;
                 if (appSpreadCandidate) {
-                    const isClickedIconFocusedApp = this.app == tracker.focus_app;
+                    const isClickedIconFocusedApp = this.app === tracker.focus_app;
                     if (isClickedIconFocusedApp) {
                         shouldHideOverview = false;
                         this.appSpread.toggleAppSpread(windows);
                     } else {
                         // Clicked on another app or all app windows are minimized -> focus that
-                        let w = windows[0];
-                        Main.activateWindow(w);
+                        Main.activateWindow(windows[0]);
                     }
                     break;
                 }
@@ -534,8 +535,10 @@ var DockAbstractAppIcon = GObject.registerClass({
                 if (singleOrUrgentWindows && !modifiers && button == 1) {
                     let w = windows[0];
                     if (this.focused) {
-                        // Window is raised, minimize it
-                        this._minimizeWindow(w);
+                        if (buttonAction !== clickAction.FOCUS_OR_APP_SPREAD) {
+                            // Window is raised, minimize it
+                            this._minimizeWindow(w);
+                        }
                     } else {
                         // Window is minimized, raise it
                         Main.activateWindow(w);

--- a/appIcons.js
+++ b/appIcons.js
@@ -36,6 +36,7 @@ const Docking = Me.imports.docking;
 const Locations = Me.imports.locations;
 const Utils = Me.imports.utils;
 const WindowPreview = Me.imports.windowPreview;
+const AppSpread = Me.imports.appSpread;
 const AppIconIndicators = Me.imports.appIconIndicators;
 const DbusmenuUtils = Me.imports.dbusmenuUtils;
 
@@ -56,7 +57,8 @@ const clickAction = {
     MINIMIZE_OR_PREVIEWS: 6,
     FOCUS_OR_PREVIEWS: 7,
     FOCUS_MINIMIZE_OR_PREVIEWS: 8,
-    QUIT: 9
+    APP_SPREAD: 9,
+    QUIT: 10
 };
 
 const scrollAction = {
@@ -111,6 +113,7 @@ var DockAbstractAppIcon = GObject.registerClass({
         // a prefix is required to avoid conflicting with the parent class variable
         this.monitorIndex = monitorIndex;
         this._signalsHandler = new Utils.GlobalSignalsHandler(this);
+        this.appSpread = new AppSpread.AppSpread();
         this.iconAnimator = iconAnimator;
         this._indicator = new AppIconIndicators.AppIconIndicator(this);
 
@@ -508,9 +511,25 @@ var DockAbstractAppIcon = GObject.registerClass({
                 }
                 break;
 
+            case clickAction.APP_SPREAD:
+                const appSpreadCandidate = windows.length != 1 || !!modifiers || button != 1;
+                if (appSpreadCandidate) {
+                    const isClickedIconFocusedApp = this.app == tracker.focus_app;
+                    if (isClickedIconFocusedApp) {
+                        shouldHideOverview = false;
+                        this.appSpread.toggleAppSpread(windows);
+                    } else {
+                        // Clicked on another app or all app windows are minimized -> focus that
+                        let w = windows[0];
+                        Main.activateWindow(w);
+                    }
+                    break;
+                }
+                // fallthrough
+
             case clickAction.MINIMIZE_OR_OVERVIEW:
                 // When a single window is present, toggle minimization
-                // If only one windows is present toggle minimization, but only when trigggered with the
+                // If only one windows is present toggle minimization, but only when triggered with the
                 // simple click action (no modifiers, no middle click).
                 if (singleOrUrgentWindows && !modifiers && button == 1) {
                     let w = windows[0];

--- a/appSpread.js
+++ b/appSpread.js
@@ -29,7 +29,7 @@ var AppSpread = class AppSpread {
         }
     }
 
-    toggleAppSpread(appSpreadMetaWindows) {
+    toggle(appSpreadMetaWindows) {
         if (Main.overview._shown) {
             Main.overview.hide(); // also triggers hook 'hidden'
         } else {

--- a/appSpread.js
+++ b/appSpread.js
@@ -1,0 +1,111 @@
+/* exported AppSpread */
+
+const { GObject } = imports.gi;
+const Main = imports.ui.main;
+const SearchController = imports.ui.searchController;
+const Workspace = imports.ui.workspace;
+const WorkspaceThumbnail = imports.ui.workspaceThumbnail;
+
+var AppSpread = GObject.registerClass(
+class AppSpread extends GObject.Object {
+    _init() {
+        this.isInAppSpread = false;
+        // gnome shell functions to temporarily replace while in app spread
+        this.originalWorkspaceIsOverviewWindow = Workspace?.Workspace?.prototype._isOverviewWindow;
+        this.originalThumbnailIsOverviewWindow = WorkspaceThumbnail?.WorkspaceThumbnail?.prototype._isOverviewWindow;
+        this.originalShouldTriggerSearch = SearchController?.SearchController?.prototype._shouldTriggerSearch;
+        // fail early and do nothing, if mandatory gnome shell functions are missing
+        if (!this.originalWorkspaceIsOverviewWindow || !this.originalThumbnailIsOverviewWindow) {
+            log('Dash to dock: Unable to temporarily replace shell functions for app spread - app spread will have no effect');
+            return;
+        }
+
+        // we need to hook into overview 'hidden' like this, in case appspread overview is hidden by choosing another app
+        // it should then do its cleanup too
+        this._hideOverviewHandlerId = Main.overview.connect('hidden', this._hideAppSpread.bind(this));
+    }
+
+    disconnect() {
+        if (this._hideOverviewHandlerId) {
+            Main.overview.disconnect(this._hideOverviewHandlerId);
+        }
+    }
+
+    toggleAppSpread(appSpreadMetaWindows) {
+        if (Main.overview._shown) {
+            Main.overview.hide(); // also triggers hook 'hidden'
+        } else {
+            this._showAppSpread(appSpreadMetaWindows);
+        }
+    }
+
+    _showAppSpread(appSpreadMetaWindows) {
+        // Checked in overview "hide" event handler _hideAppSpread
+        this.isInAppSpread = true;
+        this.appSpreadMetaWindows = appSpreadMetaWindows;
+
+        // Filter workspaces to only show current app windows
+        const originalWorkspaceIsOverviewWindow = this.originalWorkspaceIsOverviewWindow;
+        Workspace.Workspace.prototype._isOverviewWindow = function(metaWindow) {
+            const originalResult = originalWorkspaceIsOverviewWindow(metaWindow);
+            return originalResult && appSpreadMetaWindows.indexOf(metaWindow) > -1;
+        };
+
+        // Filter thumbnails to only show current app windows
+        const originalThumbnailIsOverviewWindow = this.originalThumbnailIsOverviewWindow;
+        WorkspaceThumbnail.WorkspaceThumbnail.prototype._isOverviewWindow = function(metaWindowActor) {
+            const originalResult = originalThumbnailIsOverviewWindow(metaWindowActor);
+            return originalResult && appSpreadMetaWindows.indexOf(metaWindowActor.meta_window) > -1;
+        };
+
+        // If closing windows in AppSpread, and only one window left: exit app spread and focus remaining window (handled in _hideAppSpread)
+        this.destroyWindowId = global.window_manager.connect('destroy', (_, windowActor) => {
+            const metaWindow = windowActor.get_meta_window();
+            const index = appSpreadMetaWindows.indexOf(metaWindow);
+            if (index > -1) {
+                appSpreadMetaWindows.splice(index, 1);
+            }
+            if (appSpreadMetaWindows.length === 1) {
+                Main.overview.hide();
+            }
+        });
+
+        Main.overview.show();
+        // this._disableSearch();
+    }
+
+    _hideAppSpread() {
+        if (!this.isInAppSpread)
+            return;
+
+        this.isInAppSpread = false;
+        // Restore original behaviour
+        // this._enableSearch();
+        Workspace.Workspace.prototype._isOverviewWindow = this.originalWorkspaceIsOverviewWindow;
+        WorkspaceThumbnail.WorkspaceThumbnail.prototype._isOverviewWindow = this.originalThumbnailIsOverviewWindow;
+        global.window_manager.disconnect(this.destroyWindowId);
+        // Check reason for leaving AppSpread was closing app windows and only one window left..
+        if (this.appSpreadMetaWindows.length === 1)
+            Main.activateWindow(this.appSpreadMetaWindows[0]);
+    }
+
+    _disableSearch() {
+        if (Main.overview.searchEntry)
+            Main.overview.searchEntry.opacity = 0;
+
+        if (this.originalShouldTriggerSearch) {
+            SearchController.SearchController.prototype._shouldTriggerSearch = function() {
+                return false;
+            };
+        }
+    }
+
+    _enableSearch() {
+        if (Main.overview.searchEntry)
+            Main.overview.searchEntry.opacity = 255;
+
+        if (this.originalShouldTriggerSearch) {
+            SearchController.SearchController.prototype._shouldTriggerSearch = this.originalShouldTriggerSearch;
+        }
+    }
+});

--- a/appSpread.js
+++ b/appSpread.js
@@ -15,7 +15,8 @@ var AppSpread = class AppSpread {
         this.windows = [];
 
         // fail early and do nothing, if mandatory gnome shell functions are missing
-        if (!Workspace?.Workspace?.prototype._isOverviewWindow ||
+        if (Main.overview.isDummy ||
+            !Workspace?.Workspace?.prototype._isOverviewWindow ||
             !WorkspaceThumbnail?.WorkspaceThumbnail?.prototype._isOverviewWindow) {
             log('Dash to dock: Unable to temporarily replace shell functions for app spread - using previews instead');
             this.supported = false;

--- a/appSpread.js
+++ b/appSpread.js
@@ -6,7 +6,6 @@ const Workspace = imports.ui.workspace;
 const WorkspaceThumbnail = imports.ui.workspaceThumbnail;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const AppIcons = Me.imports.appIcons;
 const Utils = Me.imports.utils;
 
 var AppSpread = class AppSpread {
@@ -47,7 +46,7 @@ var AppSpread = class AppSpread {
     }
 
     _updateWindows() {
-        this.windows = AppIcons.getInterestingWindows(this.app.get_windows(), -1);
+        this.windows = this.app.get_windows();
     }
 
     _showAppSpread(app) {

--- a/appSpread.js
+++ b/appSpread.js
@@ -50,6 +50,25 @@ var AppSpread = class AppSpread {
         this.windows = this.app.get_windows();
     }
 
+    _restoreDefaultWindows() {
+        const { workspaceManager } = global;
+
+        for (let i = 0; i < workspaceManager.nWorkspaces; i++) {
+            const metaWorkspace = workspaceManager.get_workspace_by_index(i);
+            metaWorkspace.list_windows().forEach(w => metaWorkspace.emit('window-added', w));
+        }
+    }
+
+    _filterWindows() {
+        const { workspaceManager } = global;
+
+        for (let i = 0; i < workspaceManager.nWorkspaces; i++) {
+            const metaWorkspace = workspaceManager.get_workspace_by_index(i);
+            metaWorkspace.list_windows().filter(w => !this.windows.includes(w)).forEach(
+                w => metaWorkspace.emit('window-removed', w));
+        }
+    }
+
     _showAppSpread(app) {
         if (this.isInAppSpread)
             return;
@@ -80,6 +99,13 @@ var AppSpread = class AppSpread {
                 return isOverviewWindow && appSpread.windows.includes(windowActor.metaWindow);
             }
         ]);
+
+        this._signalHandlers.add(Main.overview.dash.showAppsButton, 'notify::checked', () => {
+            if (Main.overview.dash.showAppsButton.checked) {
+                this._hideAppSpread();
+                this._restoreDefaultWindows();
+            }
+        });
 
         // If closing windows in AppSpread, and only one window left:
         // exit app spread and focus remaining window (handled in _hideAppSpread)

--- a/appSpread.js
+++ b/appSpread.js
@@ -1,14 +1,12 @@
 /* exported AppSpread */
 
-const { GObject } = imports.gi;
 const Main = imports.ui.main;
 const SearchController = imports.ui.searchController;
 const Workspace = imports.ui.workspace;
 const WorkspaceThumbnail = imports.ui.workspaceThumbnail;
 
-var AppSpread = GObject.registerClass(
-class AppSpread extends GObject.Object {
-    _init() {
+var AppSpread = class AppSpread {
+    constructor() {
         this.isInAppSpread = false;
         // gnome shell functions to temporarily replace while in app spread
         this.originalWorkspaceIsOverviewWindow = Workspace?.Workspace?.prototype._isOverviewWindow;
@@ -108,4 +106,4 @@ class AppSpread extends GObject.Object {
             SearchController.SearchController.prototype._shouldTriggerSearch = this.originalShouldTriggerSearch;
         }
     }
-});
+};

--- a/appSpread.js
+++ b/appSpread.js
@@ -5,108 +5,119 @@ const SearchController = imports.ui.searchController;
 const Workspace = imports.ui.workspace;
 const WorkspaceThumbnail = imports.ui.workspaceThumbnail;
 
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Utils = Me.imports.utils;
+
 var AppSpread = class AppSpread {
     constructor() {
         this.isInAppSpread = false;
         this.supported = true;
+        this.windows = [];
 
-        // gnome shell functions to temporarily replace while in app spread
-        this.originalWorkspaceIsOverviewWindow = Workspace?.Workspace?.prototype._isOverviewWindow;
-        this.originalThumbnailIsOverviewWindow = WorkspaceThumbnail?.WorkspaceThumbnail?.prototype._isOverviewWindow;
-        this.originalShouldTriggerSearch = SearchController?.SearchController?.prototype._shouldTriggerSearch;
         // fail early and do nothing, if mandatory gnome shell functions are missing
-        if (!this.originalWorkspaceIsOverviewWindow || !this.originalThumbnailIsOverviewWindow) {
+        if (!Workspace?.Workspace?.prototype._isOverviewWindow ||
+            !WorkspaceThumbnail?.WorkspaceThumbnail?.prototype._isOverviewWindow) {
             log('Dash to dock: Unable to temporarily replace shell functions for app spread - using previews instead');
             this.supported = false;
             return;
         }
 
-        // we need to hook into overview 'hidden' like this, in case appspread overview is hidden by choosing another app
-        // it should then do its cleanup too
-        this._hideOverviewHandlerId = Main.overview.connect('hidden', this._hideAppSpread.bind(this));
+        this._signalHandlers = new Utils.GlobalSignalsHandler();
+        this._methodInjections = new Utils.InjectionsHandler();
     }
 
-    disconnect() {
-        if (this._hideOverviewHandlerId) {
-            Main.overview.disconnect(this._hideOverviewHandlerId);
-        }
+    destroy() {
+        this._hideAppSpread();
+        this._signalHandlers.destroy();
+        this._methodInjections.destroy();
     }
 
-    toggle(appSpreadMetaWindows) {
+    toggle(windows) {
         if (Main.overview._shown) {
             Main.overview.hide(); // also triggers hook 'hidden'
         } else {
-            this._showAppSpread(appSpreadMetaWindows);
+            this._showAppSpread(windows);
         }
     }
 
-    _showAppSpread(appSpreadMetaWindows) {
+    _showAppSpread(windows) {
+        if (this.isInAppSpread)
+            return;
+
         // Checked in overview "hide" event handler _hideAppSpread
         this.isInAppSpread = true;
-        this.appSpreadMetaWindows = appSpreadMetaWindows;
+        this.windows = windows;
+        const appSpread = this;
 
-        // Filter workspaces to only show current app windows
-        const originalWorkspaceIsOverviewWindow = this.originalWorkspaceIsOverviewWindow;
-        Workspace.Workspace.prototype._isOverviewWindow = function(metaWindow) {
-            const originalResult = originalWorkspaceIsOverviewWindow(metaWindow);
-            return originalResult && appSpreadMetaWindows.indexOf(metaWindow) > -1;
-        };
+        // we need to hook into overview 'hidden' like this, in case app spread
+        // overview is hidden by choosing another app it should then do its
+        // cleanup too
+        this._signalHandlers.add(Main.overview, 'hidden', () => this._hideAppSpread());
 
-        // Filter thumbnails to only show current app windows
-        const originalThumbnailIsOverviewWindow = this.originalThumbnailIsOverviewWindow;
-        WorkspaceThumbnail.WorkspaceThumbnail.prototype._isOverviewWindow = function(metaWindowActor) {
-            const originalResult = originalThumbnailIsOverviewWindow(metaWindowActor);
-            return originalResult && appSpreadMetaWindows.indexOf(metaWindowActor.meta_window) > -1;
-        };
-
-        // If closing windows in AppSpread, and only one window left: exit app spread and focus remaining window (handled in _hideAppSpread)
-        this.destroyWindowId = global.window_manager.connect('destroy', (_, windowActor) => {
-            const metaWindow = windowActor.get_meta_window();
-            const index = appSpreadMetaWindows.indexOf(metaWindow);
-            if (index > -1) {
-                appSpreadMetaWindows.splice(index, 1);
+        this._methodInjections.add([
+            // Filter workspaces to only show current app windows
+            Workspace.Workspace.prototype, '_isOverviewWindow',
+            function (originalMethod, window) {
+                const isOverviewWindow = originalMethod.call(this, window);
+                return isOverviewWindow && appSpread.windows.includes(window);
             }
-            if (appSpreadMetaWindows.length === 1) {
+        ],
+        [
+            // Filter thumbnails to only show current app windows
+            WorkspaceThumbnail.WorkspaceThumbnail.prototype, '_isOverviewWindow',
+            function (originalMethod, windowActor) {
+                const isOverviewWindow = originalMethod.call(this, windowActor);
+                return isOverviewWindow && appSpread.windows.includes(windowActor.metaWindow);
+            }
+        ]);
+
+        // If closing windows in AppSpread, and only one window left:
+        // exit app spread and focus remaining window (handled in _hideAppSpread)
+        this._signalHandlers.add(global.window_manager, 'destroy', (_, windowActor) => {
+            const index = appSpread.windows.indexOf(windowActor.metaWindow);
+            if (index > -1)
+                appSpread.windows.splice(index, 1);
+
+            if (appSpread.windows.length <= 1)
                 Main.overview.hide();
-            }
         });
 
+        this._disableSearch();
+
         Main.overview.show();
-        // this._disableSearch();
     }
 
     _hideAppSpread() {
         if (!this.isInAppSpread)
             return;
 
-        this.isInAppSpread = false;
         // Restore original behaviour
-        // this._enableSearch();
-        Workspace.Workspace.prototype._isOverviewWindow = this.originalWorkspaceIsOverviewWindow;
-        WorkspaceThumbnail.WorkspaceThumbnail.prototype._isOverviewWindow = this.originalThumbnailIsOverviewWindow;
-        global.window_manager.disconnect(this.destroyWindowId);
-        // Check reason for leaving AppSpread was closing app windows and only one window left..
-        if (this.appSpreadMetaWindows.length === 1)
-            Main.activateWindow(this.appSpreadMetaWindows[0]);
+        this.isInAppSpread = false;
+        this._enableSearch();
+        this._methodInjections.clear();
+        this._signalHandlers.clear();
+
+        // Check reason for leaving AppSpread was closing app windows and only one window left...
+        if (this.windows.length === 1)
+            Main.activateWindow(this.windows[0]);
+
+        this.windows = [];
     }
 
     _disableSearch() {
+        if (!SearchController.SearchController.prototype._shouldTriggerSearch)
+            return;
+
         if (Main.overview.searchEntry)
             Main.overview.searchEntry.opacity = 0;
 
-        if (this.originalShouldTriggerSearch) {
-            SearchController.SearchController.prototype._shouldTriggerSearch = function() {
-                return false;
-            };
-        }
+        this._methodInjections.add(
+            SearchController.SearchController.prototype,
+            '_shouldTriggerSearch', () => false);
     }
 
     _enableSearch() {
         if (Main.overview.searchEntry)
             Main.overview.searchEntry.opacity = 255;
-
-        if (this.originalShouldTriggerSearch) {
-            SearchController.SearchController.prototype._shouldTriggerSearch = this.originalShouldTriggerSearch;
-        }
     }
 };

--- a/appSpread.js
+++ b/appSpread.js
@@ -8,13 +8,16 @@ const WorkspaceThumbnail = imports.ui.workspaceThumbnail;
 var AppSpread = class AppSpread {
     constructor() {
         this.isInAppSpread = false;
+        this.supported = true;
+
         // gnome shell functions to temporarily replace while in app spread
         this.originalWorkspaceIsOverviewWindow = Workspace?.Workspace?.prototype._isOverviewWindow;
         this.originalThumbnailIsOverviewWindow = WorkspaceThumbnail?.WorkspaceThumbnail?.prototype._isOverviewWindow;
         this.originalShouldTriggerSearch = SearchController?.SearchController?.prototype._shouldTriggerSearch;
         // fail early and do nothing, if mandatory gnome shell functions are missing
         if (!this.originalWorkspaceIsOverviewWindow || !this.originalThumbnailIsOverviewWindow) {
-            log('Dash to dock: Unable to temporarily replace shell functions for app spread - app spread will have no effect');
+            log('Dash to dock: Unable to temporarily replace shell functions for app spread - using previews instead');
+            this.supported = false;
             return;
         }
 

--- a/docking.js
+++ b/docking.js
@@ -27,6 +27,7 @@ const WorkspaceThumbnail = imports.ui.workspaceThumbnail;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+const AppSpread = Me.imports.appSpread;
 const Utils = Me.imports.utils;
 const Intellihide = Me.imports.intellihide;
 const Theming = Me.imports.theming;
@@ -1614,6 +1615,7 @@ var DockManager = class DashToDock_DockManager {
         this._desktopIconsUsableArea = new DesktopIconsIntegration.DesktopIconsUsableAreaClass();
         this._oldDash = Main.overview.isDummy ? null : Main.overview.dash;
         this._discreteGpuAvailable = AppDisplay.discreteGpuAvailable;
+        this._appSpread = new AppSpread.AppSpread();
 
         if (this._discreteGpuAvailable === undefined) {
             const updateDiscreteGpuAvailable = () => {
@@ -1698,6 +1700,10 @@ var DockManager = class DashToDock_DockManager {
 
     get discreteGpuAvailable() {
         return AppDisplay.discreteGpuAvailable || this._discreteGpuAvailable;
+    }
+
+    get appSpread() {
+        return this._appSpread;
     }
 
     getDockByMonitor(monitorIndex) {

--- a/docking.js
+++ b/docking.js
@@ -2414,6 +2414,7 @@ var DockManager = class DashToDock_DockManager {
             this._fm1Client.destroy();
             this._fm1Client = null;
         }
+        this._appSpread.destroy();
         this._trash?.destroy();
         this._trash = null;
         Locations.unWrapFileManagerApp();

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -10,7 +10,8 @@
     <value value='6' nick='minimize-or-previews'/>
     <value value='7' nick='focus-or-previews'/>
     <value value='8' nick='focus-minimize-or-previews'/>
-    <value value='9' nick='quit'/>
+    <value value='9' nick='focus-minimize-or-appspread'/>
+    <value value='10' nick='quit'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-dock.scrollAction'>
     <value value='0' nick='do-nothing'/>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -9,9 +9,10 @@
     <value value='5' nick='previews'/>
     <value value='6' nick='minimize-or-previews'/>
     <value value='7' nick='focus-or-previews'/>
-    <value value='8' nick='focus-minimize-or-previews'/>
-    <value value='9' nick='focus-minimize-or-appspread'/>
-    <value value='10' nick='quit'/>
+    <value value='8' nick='focus-or-appspread'/>
+    <value value='9' nick='focus-minimize-or-previews'/>
+    <value value='10' nick='focus-minimize-or-appspread'/>
+    <value value='11' nick='quit'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-dock.scrollAction'>
     <value value='0' nick='do-nothing'/>


### PR DESCRIPTION
or "Application Spread" as it was called back with Unity7.


https://user-images.githubusercontent.com/4941802/172016701-2032f8a2-2ebb-4f8e-b955-8347873a3661.mp4



---

This is a manual rebase of #519, which is by now almost exactly 3 years old. I also slightly reduced changes to `appIcons.js`. I hope it is enough for @micheleg to review this..
