### PR TITLE
Gnome 3.38: Mutter: Fix allocation-changed signal from Clutter 

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -317,7 +317,10 @@ var DockedDash = GObject.registerClass({
         this.connect('notify::allocation',
                      Main.layoutManager._queueUpdateRegions.bind(Main.layoutManager));
 
-        this.dash._container.connect('allocation-changed', this._updateStaticBox.bind(this));
+
+        // Since Clutter has no longer ClutterAllocationFlags,
+        // "allocation-changed" signal has been removed. MR !1245
+        this.dash._container.connect('notify::allocation', this._updateStaticBox.bind(this));
         this._slider.connect(this._isHorizontal ? 'notify::x' : 'notify::y', this._updateStaticBox.bind(this));
 
         // Load optional features that need to be activated for one dock only
@@ -1096,7 +1099,7 @@ var DockedDash = GObject.registerClass({
                     // This is a workaround for bug #1007
                     this._signalsHandler.addWithLabel('verticalOffsetChecker', [
                         overviewControls.layout_manager,
-                        'allocation-changed',
+                        'notify::allocation',
                         () => {
                             let [, y] = overviewControls.get_transformed_position();
                             let [, height] = overviewControls.get_transformed_size();

--- a/intellihide.js
+++ b/intellihide.js
@@ -128,7 +128,7 @@ var Intellihide = class DashToDock_Intellihide {
     _addWindowSignals(wa) {
         if (!this._handledWindow(wa))
             return;
-        let signalId = wa.connect('allocation-changed', this._checkOverlap.bind(this));
+        let signalId = wa.connect('notify::allocation', this._checkOverlap.bind(this));
         this._trackedWindows.set(wa, signalId);
         wa.connect('destroy', this._removeWindowSignals.bind(this));
     }

--- a/theming.js
+++ b/theming.js
@@ -423,7 +423,7 @@ var Transparency = class DashToDock_Transparency {
 
     _onWindowActorAdded(container, metaWindowActor) {
         let signalIds = [];
-        ['allocation-changed', 'notify::visible'].forEach(s => {
+        ['notify::allocation', 'notify::visible'].forEach(s => {
             signalIds.push(metaWindowActor.connect(s, this._updateSolidStyle.bind(this)));
         });
         this._trackedWindows.set(metaWindowActor, signalIds);


### PR DESCRIPTION
This PR replaces the `alocation-changed` signal by the original notification allocation.  Clutter has no longer `allocation-changed` signal since they do not have from now allocation flags. This change is part of **Gnome 3.38 milestone,** u can check that out here: [MR !1245](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1245/commits?commit_id=e50e14af8283582882b198f79ca8ed01de220e94)

This PR should not affect anything in Gnome 3.36, because allocation notifications already exists in this version, u can merge it safely.

Also the Show Applications button does not work any more, in Gnome 3.37.2, I believe they have changed something in the Bus API, I just can't find the piece of code in your extension to check that, could you please tell me which functions perform the action to open the applications menu? So I can fix that out.

Sorry for my grammar.
And thx for this amazing extension!