### PR TITLE
Add support to GNOME 3.38

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -81,12 +81,12 @@ class DashToDock_MyDashActor extends St.Widget {
         this.set_offscreen_redirect(Clutter.OffscreenRedirect.ALWAYS);
     }
 
-    vfunc_allocate(box, flags) {
+    vfunc_allocate(box) {
         let contentBox = this.get_theme_node().get_content_box(box);
         let availWidth = contentBox.x2 - contentBox.x1;
         let availHeight = contentBox.y2 - contentBox.y1;
 
-        this.set_allocation(box, flags);
+        this.set_allocation(box);
 
         let [appIcons, showAppsButton] = this.get_children();
         let [, showAppsNatHeight] = showAppsButton.get_preferred_height(availWidth);
@@ -104,25 +104,25 @@ class DashToDock_MyDashActor extends St.Widget {
             childBox.y1 = contentBox.y1 + offset_y;
             childBox.x2 = contentBox.x2;
             childBox.y2 = contentBox.y2;
-            appIcons.allocate(childBox, flags);
+            appIcons.allocate(childBox);
 
             childBox.y1 = contentBox.y1;
             childBox.x1 = contentBox.x1;
             childBox.x2 = contentBox.x1 + showAppsNatWidth;
             childBox.y2 = contentBox.y1 + showAppsNatHeight;
-            showAppsButton.allocate(childBox, flags);
+            showAppsButton.allocate(childBox);
         } else {
             childBox.x1 = contentBox.x1;
             childBox.y1 = contentBox.y1;
             childBox.x2 = contentBox.x2 - offset_x;
             childBox.y2 = contentBox.y2 - offset_y;
-            appIcons.allocate(childBox, flags);
+            appIcons.allocate(childBox);
 
             childBox.x2 = contentBox.x2;
             childBox.y2 = contentBox.y2;
             childBox.x1 = contentBox.x2 - showAppsNatWidth;
             childBox.y1 = contentBox.y2 - showAppsNatHeight;
-            showAppsButton.allocate(childBox, flags);
+            showAppsButton.allocate(childBox);
         }
     }
 

--- a/dash.js
+++ b/dash.js
@@ -81,12 +81,13 @@ class DashToDock_MyDashActor extends St.Widget {
         this.set_offscreen_redirect(Clutter.OffscreenRedirect.ALWAYS);
     }
 
-    vfunc_allocate(box) {
+    vfunc_allocate(box, flags) {
         let contentBox = this.get_theme_node().get_content_box(box);
         let availWidth = contentBox.x2 - contentBox.x1;
         let availHeight = contentBox.y2 - contentBox.y1;
 
-        this.set_allocation(box);
+        Docking.DockManager.useNewAllocation ?
+            this.set_allocation(box) : this.set_allocation(box, flags);
 
         let [appIcons, showAppsButton] = this.get_children();
         let [, showAppsNatHeight] = showAppsButton.get_preferred_height(availWidth);
@@ -104,25 +105,29 @@ class DashToDock_MyDashActor extends St.Widget {
             childBox.y1 = contentBox.y1 + offset_y;
             childBox.x2 = contentBox.x2;
             childBox.y2 = contentBox.y2;
-            appIcons.allocate(childBox);
+            Docking.DockManager.useNewAllocation ?
+                appIcons.allocate(childBox) : appIcons.allocate(childBox, flags);
 
             childBox.y1 = contentBox.y1;
             childBox.x1 = contentBox.x1;
             childBox.x2 = contentBox.x1 + showAppsNatWidth;
             childBox.y2 = contentBox.y1 + showAppsNatHeight;
-            showAppsButton.allocate(childBox);
+            Docking.DockManager.useNewAllocation ?
+                showAppsButton.allocate(childBox) : showAppsButton.allocate(childBox, flags);
         } else {
             childBox.x1 = contentBox.x1;
             childBox.y1 = contentBox.y1;
             childBox.x2 = contentBox.x2 - offset_x;
             childBox.y2 = contentBox.y2 - offset_y;
-            appIcons.allocate(childBox);
+            Docking.DockManager.useNewAllocation ?
+                appIcons.allocate(childBox) : appIcons.allocate(childBox, flags);
 
             childBox.x2 = contentBox.x2;
             childBox.y2 = contentBox.y2;
             childBox.x1 = contentBox.x2 - showAppsNatWidth;
             childBox.y1 = contentBox.y2 - showAppsNatHeight;
-            showAppsButton.allocate(childBox);
+            Docking.DockManager.useNewAllocation ?
+                showAppsButton.allocate(childBox) : showAppsButton.allocate(childBox, flags);
         }
     }
 

--- a/docking.js
+++ b/docking.js
@@ -1857,24 +1857,23 @@ var DockManager = class DashToDock_DockManager {
         let selector = Main.overview.viewSelector;
 
         if (selector._showAppsButton.checked !== button.checked) {
-            // find visible view
             let visibleView;
-            Main.overview.viewSelector.appDisplay._views.every(function(v, index) {
-                if (v.view.visible) {
-                    visibleView = index;
-                    return false;
-                }
-                else
-                    return true;
-            });
+            let overviewViews = Main.overview.viewSelector.appDisplay._views;
+
+            if (overviewViews) {
+                // find visible view in gnome-shell pre 3.38
+                visibleView = overviewViews.find(v => v.view.visible);
+                visibleView = visibleView ? visibleView.view : null;
+            } else {
+                visibleView = Main.overview.viewSelector.appDisplay;
+            }
 
             if (button.checked) {
                 // force spring animation triggering.By default the animation only
                 // runs if we are already inside the overview.
                 if (!Main.overview._shown) {
                     this._forcedOverview = true;
-                    let view = Main.overview.viewSelector.appDisplay._views[visibleView].view;
-                    let grid = view._grid;
+                    let grid = visibleView._grid;
                     if (animate) {
                         // Animate in the the appview, hide the appGrid to avoiud flashing
                         // Go to the appView before entering the overview, skipping the workspaces.
@@ -1919,8 +1918,7 @@ var DockManager = class DashToDock_DockManager {
                         // Manually trigger springout animation without activating the
                         // workspaceView to avoid the zoomout animation. Hide the appPage
                         // onComplete to avoid ugly flashing of original icons.
-                        let view = Main.overview.viewSelector.appDisplay._views[visibleView].view;
-                        view.animate(IconGrid.AnimationDirection.OUT, () => {
+                        visibleView.animate(IconGrid.AnimationDirection.OUT, () => {
                             Main.overview.viewSelector._appsPage.hide();
                             Main.overview.hide();
                             selector._showAppsButton.checked = false;

--- a/docking.js
+++ b/docking.js
@@ -31,6 +31,8 @@ const FileManager1API = Me.imports.fileManager1API;
 
 const DOCK_DWELL_CHECK_INTERVAL = 100;
 
+let USE_NEW_ALLOCATION;
+
 var State = {
     HIDDEN:  0,
     SHOWING: 1,
@@ -78,9 +80,11 @@ var DashSlideContainer = GObject.registerClass({
         this._slideoutSize = 0; // minimum size when slided out
     }
 
-    vfunc_allocate(box) {
+    vfunc_allocate(box, flags) {
         let contentBox = this.get_theme_node().get_content_box(box);
-        this.set_allocation(box);
+
+        DockManager.useNewAllocation ?
+            this.set_allocation(box) : this.set_allocation(box, flags);
 
         if (this.child == null)
             return;
@@ -116,7 +120,9 @@ var DashSlideContainer = GObject.registerClass({
             childBox.y2 = slideoutSize + this._slidex * (childHeight - slideoutSize);
         }
 
-        this.child.allocate(childBox);
+        DockManager.useNewAllocation ?
+            this.child.allocate(childBox) : this.child.allocate(childBox, flags);
+
         this.child.set_clip(-childBox.x1, -childBox.y1,
                             -childBox.x1+availWidth, -childBox.y1 + availHeight);
     }
@@ -1096,7 +1102,7 @@ var DockedDash = GObject.registerClass({
             this._signalsHandler.removeWithLabel('verticalOffsetChecker');
 
             if (extendHeight) {
-                if (overviewControls && Main.overview.viewSelector.appDisplay._views) {
+                if (overviewControls && !DockManager.useNewAllocation) {
                     // This is a workaround for bug #1007, only in versions before 3.38
                     this._signalsHandler.addWithLabel('verticalOffsetChecker', [
                         overviewControls.layout_manager,
@@ -1622,6 +1628,18 @@ var DockManager = class DashToDock_DockManager {
 
     static get settings() {
         return DockManager.getDefault()._settings;
+    }
+
+    static get useNewAllocation() {
+        /* Remove this when version prior to 3.38 are not supported anymore */
+        if (USE_NEW_ALLOCATION === undefined) {
+            /* We only support 3.36 and 3.38 right now, so no much to check */
+            USE_NEW_ALLOCATION = ExtensionUtils.versionCheck(
+                ['3.37.91', '3.37.92', '3.38'],
+                imports.misc.config.PACKAGE_VERSION);
+        }
+
+        return USE_NEW_ALLOCATION;
     }
 
     get fm1Client() {

--- a/docking.js
+++ b/docking.js
@@ -1096,8 +1096,8 @@ var DockedDash = GObject.registerClass({
             this._signalsHandler.removeWithLabel('verticalOffsetChecker');
 
             if (extendHeight) {
-                if (overviewControls) {
-                    // This is a workaround for bug #1007
+                if (overviewControls && Main.overview.viewSelector.appDisplay._views) {
+                    // This is a workaround for bug #1007, only in versions before 3.38
                     this._signalsHandler.addWithLabel('verticalOffsetChecker', [
                         overviewControls.layout_manager,
                         'notify::allocation',

--- a/docking.js
+++ b/docking.js
@@ -386,6 +386,11 @@ var DockedDash = GObject.registerClass({
             });
         }
 
+        if (this._position == St.Side.RIGHT)
+            this.connect('notify::width', () => this.translation_x = -this.width);
+        else if (this._position == St.Side.BOTTOM)
+            this.connect('notify::height', () => this.translation_y = -this.height);
+
         // Set initial position
         this._resetPosition();
 
@@ -1049,22 +1054,13 @@ var DockedDash = GObject.registerClass({
         else if ((fraction < 0) || (fraction > 1))
             fraction = 0.95;
 
-        let anchor_point;
-
         if (this._isHorizontal) {
             this.width = Math.round(fraction * workArea.width);
 
-            let pos_y;
-            if (this._position == St.Side.BOTTOM) {
-                pos_y =  this._monitor.y + this._monitor.height;
-                anchor_point = Clutter.Gravity.SOUTH_WEST;
-            }
-            else {
-                pos_y = this._monitor.y;
-                anchor_point = Clutter.Gravity.NORTH_WEST;
-            }
+            let pos_y = this._monitor.y;
+            if (this._position == St.Side.BOTTOM)
+                pos_y += this._monitor.height;
 
-            this.move_anchor_point_from_gravity(anchor_point);
             this.x = workArea.x + Math.round((1 - fraction) / 2 * workArea.width);
             this.y = pos_y;
 
@@ -1080,17 +1076,10 @@ var DockedDash = GObject.registerClass({
         else {
             this.height = Math.round(fraction * workArea.height);
 
-            let pos_x;
-            if (this._position == St.Side.RIGHT) {
-                pos_x =  this._monitor.x + this._monitor.width;
-                anchor_point = Clutter.Gravity.NORTH_EAST;
-            }
-            else {
-                pos_x =  this._monitor.x;
-                anchor_point = Clutter.Gravity.NORTH_WEST;
-            }
+            let pos_x = this._monitor.x;
+            if (this._position == St.Side.RIGHT)
+                pos_x += this._monitor.width;
 
-            this.move_anchor_point_from_gravity(anchor_point);
             this.x = pos_x;
             this.y = workArea.y + Math.round((1 - fraction) / 2 * workArea.height);
 

--- a/docking.js
+++ b/docking.js
@@ -78,9 +78,9 @@ var DashSlideContainer = GObject.registerClass({
         this._slideoutSize = 0; // minimum size when slided out
     }
 
-    vfunc_allocate(box, flags) {
+    vfunc_allocate(box) {
         let contentBox = this.get_theme_node().get_content_box(box);
-        this.set_allocation(box, flags);
+        this.set_allocation(box);
 
         if (this.child == null)
             return;
@@ -116,7 +116,7 @@ var DashSlideContainer = GObject.registerClass({
             childBox.y2 = slideoutSize + this._slidex * (childHeight - slideoutSize);
         }
 
-        this.child.allocate(childBox, flags);
+        this.child.allocate(childBox);
         this.child.set_clip(-childBox.x1, -childBox.y1,
                             -childBox.x1+availWidth, -childBox.y1 + availHeight);
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,7 @@
 {
 "shell-version": [
-    "3.36"
+    "3.36",
+    "3.38"
 ],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",


### PR DESCRIPTION
Add support to GNOME 3.38, ensuring that we keep compatibility with 3.36 (at least a cycle it looks like we can do it easily).

Added few different versioned codepaths and few cleanups.