### PR TITLE
Fix getWindows for a location in the dock

### DIFF
--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -81,8 +81,14 @@ var FileManager1Client = class DashToDock_FileManager1Client {
      */
     getWindows(location) {
         let ret = new Set();
+    	let locationEsc = location;
+	    
+    	if (!location.endsWith('/')) { 
+		locationEsc += '/'; 
+	}
+	    
         for (let [k,v] of this._locationMap) {
-            if ((k + '/').startsWith(location + '/')) {
+            if ((k + '/').startsWith(locationEsc)) {
                 for (let l of v) {
                     ret.add(l);
                 }

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -82,7 +82,7 @@ var FileManager1Client = class DashToDock_FileManager1Client {
     getWindows(location) {
         let ret = new Set();
         for (let [k,v] of this._locationMap) {
-            if (k.startsWith(location)) {
+            if ((k + '/').startsWith(location + '/')) {
                 for (let l of v) {
                     ret.add(l);
                 }


### PR DESCRIPTION
On my system I have two drives mounted under `/mnt/Data` and `/mnt/Data 2`.

I noticed that browsing to the latter drive in Nautilus would also produce an open indicator in the dock for the former drive.

This simple tweak fixes the problem and should prevent issues of a similar nature from occurring.