### PR TITLE
change .shrink's border to 0px

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,7 +1,7 @@
 /* Shrink the dash by reducing padding */
 #dashtodockContainer.shrink #dash,
 #dashtodockContainer.dashtodock #dash {
-    border:1px;
+    border:0px;
     padding:0px;
 }
 


### PR DESCRIPTION
In panel mode + shrunken padding mode + custom theme mode, the panel does not cover the corner pixel on one side due to the border being 1px. An example of this bug is here: https://queer.af/@fenny/105063613088716362

I don't know if this is an issue outside of Pop_OS! 20.04