### PR TITLE
workaround for function iconTexture.get_names does not exist

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -938,11 +938,14 @@ var DominantColorExtractor = class DashToDock_DominantColorExtractor {
         }
 
         // Get the pixel buffer from the icon theme
-        let icon_info = themeLoader.lookup_icon(iconTexture.get_names()[0], DOMINANT_COLOR_ICON_SIZE, 0);
-        if (icon_info !== null)
-            return icon_info.load_icon();
-        else
-            return null;
+        // sometime function  iconTexture.get_names does not exist:  JS ERROR: TypeError: iconTexture.get_names is not a function
+        if (iconTexture.get_names) {
+            let icon_info = themeLoader.lookup_icon(iconTexture.get_names()[0], DOMINANT_COLOR_ICON_SIZE, 0);
+            if (icon_info !== null)
+                return icon_info.load_icon();
+            else
+                return null;
+        }
     }
 
     /**


### PR DESCRIPTION
I am playing around with a lot of AppImage based tools and this fix is the only thing that keeps dash-to-dock running. No sideeffects so far.

`Feb 05 17:39:07 ticktack gnome-shell[3912]: JS ERROR: TypeError: iconTexture.get_names is not a function
                                            _getIconPixBuf@/home/tobias/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIconIndicators.js:941:61
                                            _getColorPalette@/home/tobias/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIconIndicators.js:960:27
                                            _enableBacklight@/home/tobias/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIconIndicators.js:216:57
                                            update@/home/tobias/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIconIndicators.js:340:22
                                            update@/home/tobias/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIconIndicators.js:102:23
                                            _updateIndicatorStyle@/home/tobias/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIcons.js:181:25
                                            _init@/home/tobias/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIcons.js:92:14
                                            _createAppItem@/home/tobias/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/dash.js:479:23
                                            _redisplay@/home/tobias/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/dash.js:809:36
                                            _runDeferredWork@resource:///org/gnome/shell/ui/main.js:693:31
                                            _runAllDeferredWork@resource:///org/gnome/shell/ui/main.js:702:25
                                            queueDeferredWork/_deferredTimeoutId<@resource:///org/gnome/shell/ui/main.js:783:13
