### PR TITLE
Add new setting: preview size scale

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -574,6 +574,12 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="preview_size_adjustment">
+    <property name="lower">0.0</property>
+    <property name="upper">1.0</property>
+    <property name="step_increment">0.05</property>
+    <property name="page_increment">0.1</property>
+  </object>
   <object class="GtkNotebook" id="settings_notebook">
     <property name="visible">True</property>
     <property name="can_focus">True</property>
@@ -1050,6 +1056,53 @@
                             <property name="left_attach">0</property>
                             <property name="top_attach">1</property>
                             <property name="width">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow" id="preview_size_listboxrow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkGrid" id="preview_size_grid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="builtin_theme_label7">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Preview size scale</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScale" id="preview_size_scale">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="valign">baseline</property>
+                            <property name="hexpand">True</property>
+                            <property name="adjustment">preview_size_adjustment</property>
+                            <property name="round_digits">0</property>
+                            <property name="digits">2</property>
+                            <property name="value_pos">right</property>
+                            <signal name="format-value" handler="preview_size_scale_format_value_cb" swapped="no"/>
+                            <signal name="value-changed" handler="preview_size_scale_value_changed_cb" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
                           </packing>
                         </child>
                       </object>

--- a/prefs.js
+++ b/prefs.js
@@ -182,6 +182,14 @@ var Settings = class DashToDock_Settings {
                 });
             },
 
+            preview_size_scale_format_value_cb(scale, value) {
+                return value == 0 ? 'auto' : value;
+            },
+
+            preview_size_scale_value_changed_cb(scale) {
+                this._settings.set_double('preview-size-scale', scale.get_value());
+            },
+
             custom_opacity_scale_value_changed_cb(scale) {
                 // Avoid settings the opacity consinuosly as it's change is animated
                 if (this._opacity_timeout > 0)
@@ -441,6 +449,7 @@ var Settings = class DashToDock_Settings {
         DEFAULT_ICONS_SIZES.forEach(function(val) {
              icon_size_scale.add_mark(val, Gtk.PositionType.TOP, val.toString());
         });
+        this._builder.get_object('preview_size_scale').set_value(this._settings.get_double('preview-size-scale'));
 
         // Corrent for rtl languages
         if (this._rtl) {

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -156,6 +156,11 @@
       <summary>Maximum dash icon size</summary>
       <description>Set the allowed maximum dash icon size. Allowed range: 16..64.</description>
     </key>
+    <key type="d" name="preview-size-scale">
+      <default>0</default>
+      <summary>Preview size scale</summary>
+      <description>Set the allowed maximum dash preview size scale. Allowed range: 0,00..1,00.</description>
+    </key>
     <key type="b" name="icon-size-fixed">
       <default>false</default>
       <summary>Fixed icon size</summary>

--- a/utils.js
+++ b/utils.js
@@ -249,6 +249,10 @@ function getPosition() {
     return position;
 }
 
+function getPreviewScale() {
+    return Docking.DockManager.settings.get_double('preview-size-scale');
+}
+
 function drawRoundedLine(cr, x, y, width, height, isRoundLeft, isRoundRight, stroke, fill) {
     if (height > width) {
         y += Math.floor((height - width) / 2.0);

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -375,7 +375,20 @@ class DashToDock_WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
     _getWindowPreviewSize() {
         let mutterWindow = this._window.get_compositor_private();
         let [width, height] = mutterWindow.get_size();
-        let scale = Math.min(1.0, PREVIEW_MAX_WIDTH/width, PREVIEW_MAX_HEIGHT/height);
+
+        let scale;
+
+        if (Utils.getPreviewScale()) {
+            scale = Utils.getPreviewScale();
+        } else {
+            // a simple example with 1680x1050:
+            // * 250/1680 = 0,1488
+            // * 150/1050 = 0,1429
+            // => scale is 0,1429
+            scale = Math.min(1.0, PREVIEW_MAX_WIDTH/width, PREVIEW_MAX_HEIGHT/height)
+        }
+
+        // width and height that we wanna multiply by scale
         return [width, height, scale];
     }
 


### PR DESCRIPTION
This adds a new option to the configuration interface to manipulate the preview size scale:
* scale from 0,00 to 1,00 in steps of 0,05
* default is 0,00 a.k.a. "auto" which is the current scale calculation

I've implemented this since the current scale calculation results in a scale of 0,1429 for my monitor which is waaaaay too small IMHO. I prefer having a scale of 0,40.

![Bildschirmfoto vom 2021-06-04 11-38-49](https://user-images.githubusercontent.com/1405149/120781624-8758b200-c529-11eb-8809-e5f08dc4cb88.png)
