### PR TITLE
Make dash-to-dock work with both horizontal and vertical workspaces

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1209,19 +1209,28 @@ var DockedDash = GObject.registerClass({
             let activeWs = global.workspace_manager.get_active_workspace();
             let direction = null;
 
+            let prev_direction, next_direction;
+            if (global.workspace_manager.layout_columns > global.workspace_manager.layout_rows) {
+                prev_direction = Meta.MotionDirection.UP;
+                next_direction = Meta.MotionDirection.DOWN;
+            } else {
+                prev_direction = Meta.MotionDirection.LEFT;
+                next_direction = Meta.MotionDirection.RIGHT;
+            }
+
             switch (event.get_scroll_direction()) {
             case Clutter.ScrollDirection.UP:
-                direction = Meta.MotionDirection.LEFT;
+                direction = prev_direction;
                 break;
             case Clutter.ScrollDirection.DOWN:
-                direction = Meta.MotionDirection.RIGHT;
+                direction = next_direction;
                 break;
             case Clutter.ScrollDirection.SMOOTH:
                 let [dx, dy] = event.get_scroll_delta();
                 if (dy < 0)
-                    direction = Meta.MotionDirection.LEFT;
+                    direction = prev_direction;
                 else if (dy > 0)
-                    direction = Meta.MotionDirection.RIGHT;
+                    direction = next_direction;
                 break;
             }
 


### PR DESCRIPTION
Make it compatible with the [Vertical Overview](https://extensions.gnome.org/extension/4144/vertical-overview/) extension, scrolling on the dock will move to the correct workspace in both horizontal and vertical layouts.

Update the code in https://github.com/micheleg/dash-to-dock/pull/1402#issuecomment-853986202 to make it work in both cases.