### PR TITLE
Disable starting in the overview

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -49,6 +49,7 @@ function conditionallyenabledock() {
 
     // enable or disable dock depending on dock status and to_enable state
     if (to_enable && !dockManager) {
+        Main.layoutManager.startInOverview = false;
         dockManager = new Docking.DockManager();
     } else if (!to_enable && dockManager) {
         dockManager.destroy();


### PR DESCRIPTION
We don't need it when the GNOME dash is being replaced.
([LP: #1940925](https://bugs.launchpad.net/bugs/1940925))

**Requires:** https://salsa.debian.org/gnome-team/gnome-shell/-/merge_requests/52 so this really is intended for ubuntu-dock only.

CC @3v1n0 