### PR TITLE
Update org.gnome.shell.extensions.dash-to-dock.gschema.xml

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -164,7 +164,7 @@
     <key type="b" name="icon-size-fixed">
       <default>false</default>
       <summary>Fixed icon size</summary>
-      <description>Keep the icon size fived by scrolling the dock.</description>
+      <description>Keep the icon size fixed by scrolling the dock.</description>
     </key>
     <key type="b" name="apply-custom-theme">
       <default>false</default>


### PR DESCRIPTION
Corrected spelling mistake in description for icon-size-fixed.