### PR TITLE
docking: Only animate on shell startup, not every extension startup

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -246,7 +246,7 @@ var DockedDash = GObject.registerClass({
         this._slider = new DashSlideContainer({
             monitor_index: this._monitor.index,
             side: this._position,
-            slide_x: 0,
+            slide_x: Main.layoutManager._startingUp ? 0 : 1,
             ...(this._isHorizontal ? {
                 x_align: Clutter.ActorAlign.CENTER,
             } : {


### PR DESCRIPTION
Since extensions get disabled on screen lock and then restarted on
screen unlock, we don't want that to get animated again. Particularly
if you have a maximized window and autohide=off, it looks ugly and
stuttery animating a full workarea relayout.

Related to: https://launchpad.net/bugs/1947149