### PR TITLE
Desktop icons integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 UUID = dash-to-dock@micxgx.gmail.com
 BASE_MODULES = extension.js metadata.json COPYING README.md
-EXTRA_MODULES = dash.js docking.js appIcons.js appIconIndicators.js fileManager1API.js launcherAPI.js locations.js windowPreview.js intellihide.js prefs.js theming.js utils.js dbusmenuUtils.js Settings.ui
+EXTRA_MODULES = dash.js docking.js appIcons.js appIconIndicators.js fileManager1API.js launcherAPI.js locations.js windowPreview.js intellihide.js prefs.js theming.js utils.js dbusmenuUtils.js Settings.ui desktopIconsIntegration.js
 EXTRA_MEDIA = logo.svg glossy.svg highlight_stacked_bg.svg highlight_stacked_bg_h.svg
 TOLOCALIZE =  prefs.js appIcons.js locations.js
 MSGSRC = $(wildcard po/*.po)

--- a/desktopIconsIntegration.js
+++ b/desktopIconsIntegration.js
@@ -1,0 +1,159 @@
+/*
+ * The code in this file is distributed under a "1-clause BSD license",
+ * which makes it compatible with GPLv2 and GPLv3 too, and others.
+ *
+ * License text:
+ *
+ * Copyright (C) 2021 Sergio Costas (rastersoft@gmail.com)
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*******************************************************************************
+ * Integration class
+ *
+ * This class must be added to other extensions in order to integrate
+ * them with Desktop Icons NG. It allows an extension to notify how much margin
+ * it uses in each side of each monitor.
+ *
+ * DON'T SEND PATCHES TO THIS FILE TO THE EXTENSION MAINTAINER. SEND THEM TO
+ * DESKTOP ICONS NG MAINTAINER: https://gitlab.com/rastersoft/desktop-icons-ng
+ *
+ * In the *enable()* function, create a *DesktopIconsUsableAreaClass()*
+ * object with
+ *
+ *     new DesktopIconsIntegration.DesktopIconsUsableAreaClass(object);
+ *
+ * Now, in the *disable()* function just call to the *destroy()* method before
+ * nullifying the pointer. You must create a new object in enable() the next
+ * time the extension is enabled.
+ *
+ * In your code, every time you change the margins, you should call first to
+ * *resetMargins()* method to clear the current margins, and then call to
+ * *setMargins(...)* method as many times as you need to set the margins in each
+ * monitor. You don't need to call it for all the monitors, only for those where
+ * you are painting something. If you don't set values for a monitor, they will
+ * be considered zero.
+ *
+ * The margins values are relative to the monitor border.
+ *
+ *******************************************************************************/
+
+const GLib = imports.gi.GLib;
+const Main = imports.ui.main;
+
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+
+const IDENTIFIER_UUID = "130cbc66-235c-4bd6-8571-98d2d8bba5e2";
+
+var DesktopIconsUsableAreaClass = class {
+    constructor() {
+        this._extensionManager = Main.extensionManager;
+        this._timedMarginsID = 0;
+        this._margins = {};
+        this._emID = this._extensionManager.connect('extension-state-changed', (_obj, extension) => {
+            if (!extension)
+                return;
+
+            // If an extension is being enabled and lacks the DesktopIconsUsableArea object, we can avoid launching a refresh
+            if (extension.state === ExtensionUtils.ExtensionState.ENABLED) {
+                this._sendMarginsToExtension(extension);
+                return;
+            }
+            // if the extension is being disabled, we must do a full refresh, because if there were other extensions originally
+            // loaded after that extension, those extensions will be disabled and enabled again without notification
+            this._changedMargins();
+        });
+    }
+
+    /**
+     * Sets or updates the top, bottom, left and right margins for a
+     * monitor. Values are measured from the monitor border (and NOT from
+     * the workspace border).
+     *
+     * @param {int} monitor Monitor number to which set the margins.
+     *                      A negative value means "the primary monitor".
+     * @param {int} top Top margin in pixels
+     * @param {int} bottom Bottom margin in pixels
+     * @param {int} left Left margin in pixels
+     * @param {int} right Right margin in pixels
+     */
+    setMargins(monitor, top, bottom, left, right) {
+        this._margins[monitor] = {
+            'top': top,
+            'bottom': bottom,
+            'left': left,
+            'right': right
+        };
+        this._changedMargins();
+    }
+
+    /**
+     * Clears the current margins. Must be called before configuring the monitors
+     * margins with setMargins().
+     */
+    resetMargins() {
+        this._margins = {};
+        this._changedMargins();
+    }
+
+    /**
+     * Disconnects all the signals and removes the margins.
+     */
+    destroy() {
+        if (this._emID) {
+            this._extensionManager.disconnect(this._emID);
+            this._emID = 0;
+        }
+        if (this._timedMarginsID) {
+            GLib.source_remove(this._timedMarginsID);
+            this._timedMarginsID = 0;
+        }
+        this._margins = null;
+        this._changedMargins();
+    }
+
+    _changedMargins() {
+        if (this._timedMarginsID) {
+            GLib.source_remove(this._timedMarginsID);
+        }
+        this._timedMarginsID = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, ()=> {
+            this._sendMarginsToAll();
+            this._timedMarginsID = 0;
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
+    _sendMarginsToAll() {
+        this._extensionManager.getUuids().forEach(uuid =>
+            this._sendMarginsToExtension(this._extensionManager.lookup(uuid)));
+    }
+
+    _sendMarginsToExtension(extension) {
+        // check that the extension is an extension that has the logic to accept
+        // working margins
+        if (extension?.state !== ExtensionUtils.ExtensionState.ENABLED)
+            return;
+
+        const usableArea = extension?.stateObj?.DesktopIconsUsableArea;
+         if (usableArea?.uuid === IDENTIFIER_UUID)
+            usableArea.setMarginsForExtension(Me.uuid, this._margins);
+    }
+}

--- a/docking.js
+++ b/docking.js
@@ -1792,6 +1792,13 @@ var DockManager = class DashToDock_DockManager {
             this._settings,
             'changed::isolate-locations',
             () => this._ensureLocations()
+        ], [
+            this._settings,
+            'changed::intellihide',
+            () => {
+                if (!this._settings.intellihide)
+                    this._desktopIconsUsableArea.resetMargins();
+            }
         ]);
     }
 

--- a/docking.js
+++ b/docking.js
@@ -34,6 +34,7 @@ const DockDash = Me.imports.dash;
 const Locations = Me.imports.locations;
 const LauncherAPI = Me.imports.launcherAPI;
 const FileManager1API = Me.imports.fileManager1API;
+const DesktopIconsIntegration = Me.imports.desktopIconsIntegration;
 
 const DOCK_DWELL_CHECK_INTERVAL = 100;
 
@@ -548,7 +549,10 @@ var DockedDash = GObject.registerClass({
         ], [
             settings,
             'changed::intellihide',
-            this._updateVisibilityMode.bind(this)
+            () => {
+                this._updateVisibilityMode();
+                this._updateVisibleDesktop();
+            }
         ], [
             settings,
             'changed::intellihide-mode',
@@ -1102,6 +1106,21 @@ var DockedDash = GObject.registerClass({
         }
     }
 
+    _updateVisibleDesktop() {
+        if (!this._intellihideIsEnabled)
+            return;
+
+        const { desktopIconsUsableArea } = DockManager.getDefault();
+        if (this._position === St.Side.BOTTOM)
+            desktopIconsUsableArea.setMargins(this._monitorIndex, 0, this._box.height, 0, 0);
+        else if (this._position === St.Side.TOP)
+            desktopIconsUsableArea.setMargins(this._monitorIndex, this._box.height, 0, 0, 0);
+        else if (this._position === St.Side.RIGHT)
+            desktopIconsUsableArea.setMargins(this._monitorIndex, 0, 0, 0, this._box.width);
+        else if (this._position === St.Side.LEFT)
+            desktopIconsUsableArea.setMargins(this._monitorIndex, 0, 0, this._box.width, 0);
+    }
+
     _updateStaticBox() {
         this.staticBox.init_rect(
             this.x + this._slider.x - (this._position == St.Side.RIGHT ? this._box.width : 0),
@@ -1111,6 +1130,7 @@ var DockedDash = GObject.registerClass({
         );
 
         this._intellihide.updateTargetBox(this.staticBox);
+        this._updateVisibleDesktop();
     }
 
     _removeAnimations() {
@@ -1546,6 +1566,7 @@ var DockManager = class DashToDock_DockManager {
         this._vfuncInjections = new Utils.VFuncInjectionsHandler(this);
         this._propertyInjections = new Utils.PropertyInjectionsHandler(this);
         this._settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.dash-to-dock');
+        this._desktopIconsUsableArea = new DesktopIconsIntegration.DesktopIconsUsableAreaClass();
         this._oldDash = Main.overview.isDummy ? null : Main.overview.dash;
 
         // Connect relevant signals to the toggling function
@@ -1608,6 +1629,10 @@ var DockManager = class DashToDock_DockManager {
 
     get trash() {
         return this._trash;
+    }
+
+    get desktopIconsUsableArea() {
+        return this._desktopIconsUsableArea;
     }
 
     getDockByMonitor(monitorIndex) {
@@ -2130,6 +2155,7 @@ var DockManager = class DashToDock_DockManager {
         // Remove extra features
         this._workspaceIsolation.destroy();
         this._keyboardShortcuts.destroy();
+        this._desktopIconsUsableArea.resetMargins();
 
         // Delete all docks
         this._allDocks.forEach(d => d.destroy());
@@ -2241,6 +2267,8 @@ var DockManager = class DashToDock_DockManager {
         this._settings = null;
         this._oldDash = null;
 
+        this._desktopIconsUsableArea.destroy();
+        this._desktopIconsUsableArea = null;
         Me.imports.extension.dockManager = null;
     }
 


### PR DESCRIPTION
When Dash to Dock is in autohide mode, Desktop Icons NG (DING) can't know how much space the dock need, so icons can be put below the dock and become inaccessible.

This is a generic fix for this. It adds a class (DingIntegration) that allows other extensions to communicate with Ding and any other extension that would need to know variable margins to avoid to put elements there.

The other part is at https://gitlab.com/rastersoft/desktop-icons-ng/-/merge_requests/196 