### PR TITLE
locations: Do not manually dispose objects

### DIFF
--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -64,7 +64,7 @@ var FileManager1Client = class DashToDock_FileManager1Client {
     destroy() {
         this._cancellable.cancel();
         this._signalsHandler.destroy();
-        this._proxy.run_dispose();
+        this._proxy = null;
     }
 
     /**

--- a/locations.js
+++ b/locations.js
@@ -505,7 +505,7 @@ var Removables = class DashToDock_Removables {
 
     destroy() {
         this._signalsHandler.destroy();
-        this._monitor.run_dispose();
+        this._monitor = null;
     }
 
     _getWorkingIconName(icon) {


### PR DESCRIPTION
Leave the garbage collector do its job, especially on locations where
the object may be shared by multiple instances and its lifecycle can't
be controlled here.

See: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2020#note_1302901