### PR TITLE
Cleanup nautilus listeners

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2226,6 +2226,7 @@ var DockManager = class DashToDock_DockManager {
         }
         this._trash?.destroy();
         this._trash = null;
+        Locations.unWrapWindowsManagerApp();
         this._removables?.destroy();
         this._removables = null;
         this._iconTheme.destroy();


### PR DESCRIPTION
This has been an issue with dash-to-panel for quite some time now:
https://github.com/home-sweet-gnome/dash-to-panel/issues/1265#issuecomment-882035294
https://github.com/home-sweet-gnome/dash-to-panel/issues/1500
Whenever you would start nautilus you would see:
```
TypeError: dockManager is null getRunningApps@/usr/share/gnome-shell/extensions/ubuntu-dock@ubuntu.com/locations.js:653:9
  wrapWindowsManagerApp/fileManagerApp._updateWindows@/usr/share/gnome-shell/extensions/ubuntu-dock@ubuntu.com/locations.js:258:9
  wrapWindowsManagerApp/windowsChangedId<@/usr/share/gnome-shell/extensions/ubuntu-dock@ubuntu.com/locations.js:250:24
```
However this file belongs to dash-to-dock and not dash-to-panel.

So I did some digging. Turns out that the changes introduced in https://github.com/micheleg/dash-to-dock/commit/53f85cf8ffa1cad63e985aeb7ea018e2819a797e did not cleanup [the listeners](https://github.com/micheleg/dash-to-dock/blob/afdc47b1a0b8ba14583e796b9cb8a2792dfbf0f5/locations.js#L249-L252). Now when dash-to-panel is started and dash-to-dock has destroyed itself, these now obsolete listeners will try to access `dockManager` when nautilus is opened and fail.
Thereby also preventing dash-to-panel from getting notified about the changed window.
