### PR TITLE
Fix urgent flag not being cleared

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -142,8 +142,10 @@ var DockAbstractAppIcon = GObject.registerClass({
         });
 
         this.connect('notify::focused', () => {
-            if (this.focused)
+            if (this.focused) {
                 this.add_style_class_name('focused');
+                this.urgent = false;
+            }
             else
                 this.remove_style_class_name('focused');
         })
@@ -311,7 +313,7 @@ var DockAbstractAppIcon = GObject.registerClass({
     }
 
     _addUrgentWindow(window) {
-        if (this._urgentWindows.has(window))
+        if (this._urgentWindows.has(window) || window.has_focus())
             return;
 
         if (window._manualUrgency && window.has_focus()) {


### PR DESCRIPTION
Fixes #1568 

1. Make sure that when a window is focused, the urgent flag is cleared.  See the above issue for Firefox repro steps.
2. Don't mark focused windows as urgent.  This breaks click to minimize and requires the user to click off and back on the app to clear the shaking animation once the first fix is applied.