### PR TITLE
add preferred-monitor-by-connector as an alternative to storing the index

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -234,8 +234,9 @@ var Settings = GObject.registerClass({
         if (!this._monitors?.length)
             return;
 
-        const preferredMonitor = this._monitors[combo.get_active()].index;
-        this._settings.set_int('preferred-monitor', preferredMonitor);
+        const preferredMonitor = this._monitors[combo.get_active()].connector;
+        this._settings.set_string('preferred-monitor-by-connector', preferredMonitor);
+        this._settings.set_int('preferred-monitor', -2);
     }
 
     position_top_button_toggled_cb(button) {
@@ -344,6 +345,7 @@ var Settings = GObject.registerClass({
     _updateMonitorsSettings() {
         // Monitor options
         const preferredMonitor = this._settings.get_int('preferred-monitor');
+        const preferredMonitorByConnector = this._settings.get_string('preferred-monitor-by-connector');
         const dockMonitorCombo = this._builder.get_object('dock_monitor_combo');
 
         this._monitors = [];
@@ -368,7 +370,8 @@ var Settings = GObject.registerClass({
 
             this._monitors.push(monitor);
 
-            if (monitor.index === preferredMonitor)
+            if (monitor.index === preferredMonitor ||
+                (preferredMonitor == -2 && preferredMonitorByConnector == monitor.connector))
                 dockMonitorCombo.set_active(this._monitors.length - 1);
         }
     }

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -275,9 +275,14 @@
       <summary>Extend the dock container to all the available height</summary>
     </key>
     <key type="i" name="preferred-monitor">
-      <default>-1</default>
-      <summary>Monitor on which putting the dock</summary>
-      <description>Set on which monitor to put the dock, use -1 for the primary one</description>
+      <default>-2</default>
+      <summary>DEPRECATED: Monitor on which putting the dock (by index)</summary>
+      <description>Set on which monitor to put the dock, use -1 for the primary one. Use -2 refer to the 'preferred-monitor-by-connector' setting instead (this is the preferred value).</description>
+    </key>
+    <key type="s" name="preferred-monitor-by-connector">
+      <default>"primary"</default>
+      <summary>Monitor on which putting the dock (by connector)</summary>
+      <description>Set on which monitor to put the dock, for example 'DisplayPort-0'. Use 'primary' for primary one. This setting is only used if 'preferred-monitor' is -2.</description>
     </key>
     <key type="b" name="multi-monitor">
       <default>false</default>


### PR DESCRIPTION
As described in #1598 i experienced issues when displaying the dock on a secondary monitor and unplugging or replugging another secondary monitor. This behavior was caused because the monitor to display the dock on is stored as an index in `preferred-monitor` and the index of that monitor changed. However, when studying the source code, i realized that this behavior needs to be retained for backwards compatibility purposes.

This pull request fixes the issue while retaining backwards compatibility: 

- There is a new setting called `preferred-monitor-by-connector`. It stores the monitor to display the dock on using the port it is connected to instead of its index.
- The setting `preferred-monitor-by-connector` is only used when `preferred-monitor` is set to `-2`. (a previously unused value, `-1` refers to the primary monitor).
- This means that the setting `preferred-monitor` still exists and fully works, retaining backwards compatibility with old user configurations or external apps configuring this extension such as ubuntu's gnome-control-center. If such an external app sets the `preferred-monitor` setting to the index of a monitor, this setting and monitor will be used.
- The settings UI was updated to use the new setting. If the monitor to display the dock on is changed via the extension's settings UI, `preferred-monitor-by-connector` will be used and `preferred-monitor` will be set to `-2`.

I've fully tested this pull request and would kindly ask you to merge it.

Thank you for your work!
