### PR TITLE
po/es.po: Remove duplicated entry for Quit translation

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -99,7 +99,7 @@ msgstr "Focalizar o mostrar previsualizaciones"
 
 #: Settings.ui.h:11
 msgid "Quit"
-msgstr "Salir"
+msgstr "Cerrar"
 
 #: Settings.ui.h:12
 msgid "Behavior for Middle-Click."
@@ -513,11 +513,6 @@ msgstr "Mostrar los dispositivos montados"
 #, javascript-format
 msgid "Quit %d Windows"
 msgstr "Cerrar %d ventanas"
-
-#: appIcons.js:1146
-#, javascript-format
-msgid "Quit"
-msgstr "Cerrar"
 
 #. Translators: %s is "Settings", which is automatically translated. You
 #. can also translate the full message if this fits better your language.


### PR DESCRIPTION
And use "Cerrar" to be consistent with other cases.

Fixes: #1647