### PR TITLE
Fix es translation

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -514,11 +514,6 @@ msgstr "Mostrar los dispositivos montados"
 msgid "Quit %d Windows"
 msgstr "Cerrar %d ventanas"
 
-#: appIcons.js:1146
-#, javascript-format
-msgid "Quit"
-msgstr "Cerrar"
-
 #. Translators: %s is "Settings", which is automatically translated. You
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1092


### PR DESCRIPTION
The Spanish translation .po file fails to compile because there is one sentence duplicated.
