### PR TITLE
Locations refactory to use native Gio.AppIcon's (for GNOME 42 support)

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1208,11 +1208,24 @@
                                 <property name="can_focus">0</property>
                                 <property name="hexpand">1</property>
                                 <property name="halign">start</property>
-                                <property name="label" translatable="yes">Show mounted volumes and devices</property>
+                                <property name="label" translatable="yes">Show volumes and devices</property>
 
                                 <layout>
                                   <property name="column">0</property>
                                   <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="show_only_mounted_devices_check">
+                                <property name="label" translatable="yes">Only if mounted</property>
+                                <property name="halign">start</property>
+                                <property name="margin_top">12</property>
+
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">1</property>
+                                  <property name="column-span">1</property>
                                 </layout>
                               </object>
                             </child>

--- a/Settings.ui
+++ b/Settings.ui
@@ -921,7 +921,7 @@
                                 <property name="can_focus">0</property>
                                 <property name="hexpand">1</property>
                                 <property name="halign">start</property>
-                                <property name="label" translatable="yes">Show favorite applications</property>
+                                <property name="label" translatable="yes">Show pinned applications</property>
 
                                 <layout>
                                   <property name="column">0</property>

--- a/Settings.ui
+++ b/Settings.ui
@@ -1229,6 +1229,19 @@
                                 </layout>
                               </object>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="show_network_volumes_check">
+                                <property name="label" translatable="yes">Include network volumes</property>
+                                <property name="halign">start</property>
+                                <property name="margin_top">12</property>
+
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">2</property>
+                                  <property name="column-span">2</property>
+                                </layout>
+                              </object>
+                            </child>
                           </object>
                         </property>
                       </object>

--- a/appIcons.js
+++ b/appIcons.js
@@ -1026,6 +1026,7 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
             for (let i = 0; i < actions.length; i++) {
                 let action = actions[i];
                 let item = this._appendMenuItem(appInfo.get_action_name(action));
+                item.sensitive = !appInfo.busy;
                 item.connect('activate', (emitter, event) => {
                     this._source.app.launch_action(action, event.get_time(), -1);
                     this.emit('activate-window', null);

--- a/appIcons.js
+++ b/appIcons.js
@@ -16,6 +16,8 @@ const Gettext = imports.gettext.domain('dashtodock');
 const __ = Gettext.gettext;
 const N__ = function(e) { return e };
 
+const Config = imports.misc.config;
+
 const AppDisplay = imports.ui.appDisplay;
 const AppFavorites = imports.ui.appFavorites;
 const BoxPointer = imports.ui.boxpointer;
@@ -1041,15 +1043,20 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
                 this._appendSeparator();
 
                 let isFavorite = AppFavorites.getAppFavorites().isFavorite(this._source.app.get_id());
+                const [majorVersion] = Config.PACKAGE_VERSION.split('.');
 
                 if (isFavorite) {
-                    let item = this._appendMenuItem(_('Remove from Favorites'));
+                    const label = majorVersion >= 42 ? _('Unpin') :
+                        _('Remove from Favorites');
+                    let item = this._appendMenuItem(label);
                     item.connect('activate', () => {
                         let favs = AppFavorites.getAppFavorites();
                         favs.removeFavorite(this._source.app.get_id());
                     });
                 } else {
-                    let item = this._appendMenuItem(_('Add to Favorites'));
+                    const label = majorVersion >= 42 ? _('Pin to Dash') :
+                        _('Add to Favorites');
+                    let item = this._appendMenuItem(label);
                     item.connect('activate', () => {
                         let favs = AppFavorites.getAppFavorites();
                         favs.addFavorite(this._source.app.get_id());

--- a/appIcons.js
+++ b/appIcons.js
@@ -864,6 +864,8 @@ var DockLocationAppIcon = GObject.registerClass({
             this._signalsHandler.add(global.display, 'notify::focus-window',
                 () => this._updateFocusState());
         }
+
+        this._signalsHandler.add(this.app, 'notify::icon', () => this.icon.update());
     }
 
     get location() {

--- a/appIcons.js
+++ b/appIcons.js
@@ -31,6 +31,7 @@ const Workspace = imports.ui.workspace;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Docking = Me.imports.docking;
+const Locations = Me.imports.locations;
 const Utils = Me.imports.utils;
 const WindowPreview = Me.imports.windowPreview;
 const AppIconIndicators = Me.imports.appIconIndicators;
@@ -853,8 +854,8 @@ var DockAppIcon = GObject.registerClass({
 var DockLocationAppIcon = GObject.registerClass({
 }, class DockLocationAppIcon extends DockAbstractAppIcon {
     _init(app, monitorIndex, iconAnimator) {
-        if (!app.location)
-            throw new Error('Provided application %s has no location'.format(app));
+        if (!(app.appInfo instanceof Locations.LocationAppInfo))
+            throw new Error('Provided application %s is not a Location'.format(app));
 
         super._init(app, monitorIndex, iconAnimator);
 
@@ -881,9 +882,8 @@ var DockLocationAppIcon = GObject.registerClass({
 });
 
 function makeAppIcon(app, monitorIndex, iconAnimator) {
-    if (app.location)
+    if (app.appInfo instanceof Locations.LocationAppInfo)
         return new DockLocationAppIcon(app, monitorIndex, iconAnimator);
-
 
     return new DockAppIcon(app, monitorIndex, iconAnimator);
 }

--- a/dash.js
+++ b/dash.js
@@ -781,10 +781,7 @@ var DockDash = GObject.registerClass({
             oldApps = oldApps.filter(app => !app.location || app.isTrash)
         }
 
-        this._signalsHandler.removeWithLabel('show-trash');
         if (dockManager.trash) {
-            this._signalsHandler.addWithLabel('show-trash',
-                dockManager.trash, 'changed', this._queueRedisplay.bind(this));
             const trashApp = dockManager.trash.getApp();
             if (!newApps.includes(trashApp))
                 newApps.push(trashApp);

--- a/docking.js
+++ b/docking.js
@@ -1686,13 +1686,10 @@ var DockManager = class DashToDock_DockManager {
         }
 
         Locations.unWrapFileManagerApp();
-        [this._methodInjections, this._vfuncInjections, this._propertyInjections].forEach(
+        [this._methodInjections, this._propertyInjections].forEach(
             injections => injections.removeWithLabel('locations'));
 
         if (showMounts || showTrash) {
-            this._vfuncInjections.addWithLabel('locations', Gio.DesktopAppInfo.prototype,
-                'get_id', function () { return this.customId ?? this.vfunc_get_id() });
-
             if (this.settings.isolateLocations) {
                 const fileManagerApp = Locations.wrapFileManagerApp();
 

--- a/docking.js
+++ b/docking.js
@@ -1705,7 +1705,7 @@ var DockManager = class DashToDock_DockManager {
                         if (fileManagerIdx > -1 && fileManagerApp?.state !== Shell.AppState.RUNNING)
                             runningApps.splice(fileManagerIdx, 1);
 
-                        return [...runningApps, ...locationApps].sort(Locations.shellAppCompare);
+                        return [...runningApps, ...locationApps].sort(Utils.shellAppCompare);
                     }
                 ],
                 [

--- a/docking.js
+++ b/docking.js
@@ -1685,7 +1685,7 @@ var DockManager = class DashToDock_DockManager {
             this._trash = null;
         }
 
-        Locations.unWrapWindowsManagerApp();
+        Locations.unWrapFileManagerApp();
         [this._methodInjections, this._vfuncInjections, this._propertyInjections].forEach(
             injections => injections.removeWithLabel('locations'));
 
@@ -1694,7 +1694,7 @@ var DockManager = class DashToDock_DockManager {
                 'get_id', function () { return this.customId ?? this.vfunc_get_id() });
 
             if (this.settings.isolateLocations) {
-                const fileManagerApp = Locations.wrapWindowsManagerApp();
+                const fileManagerApp = Locations.wrapFileManagerApp();
 
                 this._methodInjections.addWithLabel('locations', [
                     Shell.AppSystem.prototype, 'get_running',
@@ -2366,7 +2366,7 @@ var DockManager = class DashToDock_DockManager {
         }
         this._trash?.destroy();
         this._trash = null;
-        Locations.unWrapWindowsManagerApp();
+        Locations.unWrapFileManagerApp();
         this._removables?.destroy();
         this._removables = null;
         this._iconTheme.destroy();

--- a/docking.js
+++ b/docking.js
@@ -205,6 +205,13 @@ var DockedDash = GObject.registerClass({
             reactive: false,
             style_class: positionStyleClass[this._position],
         });
+
+        if (this.monitorIndex === undefined) {
+            // Hello turkish locale, gjs has instead defined this.monitorİndex
+            // See: https://gitlab.gnome.org/GNOME/gjs/-/merge_requests/742
+            this.monitorIndex = this.monitor_index;
+        }
+
         this._rtl = (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL);
 
         // Load settings

--- a/docking.js
+++ b/docking.js
@@ -2379,9 +2379,12 @@ var DockManager = class DashToDock_DockManager {
     }
 
     /**
-     * Adjust Panel corners
+     * Adjust Panel corners, remove this when 41 won't be supported anymore
      */
     _adjustPanelCorners() {
+        if (!Main.panel._rightCorner || !Main.panel._leftCorner)
+            return;
+
         let position = Utils.getPosition();
         let isHorizontal = ((position == St.Side.TOP) || (position == St.Side.BOTTOM));
         let dockOnPrimary  = this._settings.multiMonitor ||
@@ -2396,8 +2399,8 @@ var DockManager = class DashToDock_DockManager {
     }
 
     _revertPanelCorners() {
-        Main.panel._leftCorner.show();
-        Main.panel._rightCorner.show();
+        Main.panel._leftCorner?.show();
+        Main.panel._rightCorner?.show();
     }
 };
 Signals.addSignalMethods(DockManager.prototype);

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -161,6 +161,8 @@ var FileManager1Client = class DashToDock_FileManager1Client {
         const locationsByWindowsPath = this._proxy.OpenWindowsWithLocations;
 
         const windowsByLocation = new Map();
+        this._signalsHandler.removeWithLabel('windows');
+
         Object.entries(locationsByWindowsPath).forEach(([windowPath, locations]) => {
             locations.forEach(location => {
                 const window = this._windowsByPath.get(windowPath);
@@ -174,6 +176,15 @@ var FileManager1Client = class DashToDock_FileManager1Client {
 
                     if (windows.size === 1)
                         windowsByLocation.set(location, windows);
+
+                    this._signalsHandler.addWithLabel('windows', window,
+                        'unmanaged', () => {
+                            const wins = this._windowsByLocation.get(location);
+                            wins.delete(window);
+                            if (!wins.size)
+                                this._windowsByLocation.delete(location);
+                            this.emit('windows-changed');
+                        });
                 }
             });
         });

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -26,7 +26,7 @@ var FileManager1Client = class DashToDock_FileManager1Client {
         this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._cancellable = new Gio.Cancellable();
 
-        this._locationMap = new Map();
+        this._windowsByLocation = new Map();
         this._proxy = new FileManager1Proxy(Gio.DBus.session,
                                             "org.freedesktop.FileManager1",
                                             "/org/freedesktop/FileManager1",
@@ -72,19 +72,16 @@ var FileManager1Client = class DashToDock_FileManager1Client {
      * sub-directories of that location.
      */
     getWindows(location) {
-        const ret = new Set();
-        let locationEsc = location;
-        if (!location.endsWith('/'))
-            locationEsc += '/';
+        if (!location)
+            return [];
 
-        for (let [k,v] of this._locationMap) {
-            if ((k + '/').startsWith(locationEsc)) {
-                for (let l of v) {
-                    ret.add(l);
-                }
-            }
-        }
-        return Array.from(ret);
+        location += location.endsWith('/') ? '' : '/';
+        const windows = [];
+        this._windowsByLocation.forEach((wins, l) => {
+            if (l.startsWith(location))
+                windows.push(...wins);
+        });
+        return [...new Set(windows)];
     }
 
     _onPropertyChanged(proxy, changed, invalidated) {
@@ -108,45 +105,27 @@ var FileManager1Client = class DashToDock_FileManager1Client {
     }
 
     _updateFromPaths() {
-        let pathToLocations = this._proxy.OpenWindowsWithLocations;
-        let pathToWindow = getPathToWindow();
+        const locationsByWindowsPath = this._proxy.OpenWindowsWithLocations;
+        const windowsByPath = Utils.getWindowsByObjectPath();
 
-        let locationToWindow = new Map();
-        for (let path in pathToLocations) {
-            let locations = pathToLocations[path];
-            for (let i = 0; i < locations.length; i++) {
-                let l = locations[i];
-                // Use a set to deduplicate when a window has a
-                // location open in multiple tabs.
-                if (!locationToWindow.has(l)) {
-                    locationToWindow.set(l, new Set());
+        this._windowsByLocation = new Map();
+        Object.entries(locationsByWindowsPath).forEach(([windowPath, locations]) => {
+            locations.forEach(location => {
+                const window = windowsByPath.get(windowPath);
+
+                if (window) {
+                    location += location.endsWith('/') ? '' : '/';
+                    // Use a set to deduplicate when a window has a
+                    // location open in multiple tabs.
+                    const windows = this._windowsByLocation.get(location) || new Set();
+                    windows.add(window);
+
+                    if (windows.size === 1)
+                        this._windowsByLocation.set(location, windows);
                 }
-                let window = pathToWindow.get(path);
-                if (window != null) {
-                    locationToWindow.get(l).add(window);
-                }
-            }
-        }
-        this._locationMap = locationToWindow;
+            });
+        });
         this.emit('windows-changed');
     }
 }
 Signals.addSignalMethods(FileManager1Client.prototype);
-
-/**
- * Construct a map of gtk application window object paths to MetaWindows.
- */
-function getPathToWindow() {
-    let pathToWindow = new Map();
-
-    for (let i = 0; i < global.workspace_manager.n_workspaces; i++) {
-        let ws = global.workspace_manager.get_workspace_by_index(i);
-        ws.list_windows().map(function(w) {
-            let path = w.get_gtk_window_object_path();
-        if (path != null) {
-                pathToWindow.set(path, w);
-            }
-        });
-    }
-    return pathToWindow;
-}

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -165,9 +165,12 @@ var FileManager1Client = class DashToDock_FileManager1Client {
 
         Object.entries(locationsByWindowsPath).forEach(([windowPath, locations]) => {
             locations.forEach(location => {
-                const window = this._windowsByPath.get(windowPath);
+                const win = this._windowsByPath.get(windowPath);
+                const windowGroup = win ? [win] : [];
 
-                if (window) {
+                win?.foreach_transient(w => (windowGroup.push(w) || true));
+
+                windowGroup.forEach(window => {
                     location += location.endsWith('/') ? '' : '/';
                     // Use a set to deduplicate when a window has a
                     // location open in multiple tabs.
@@ -185,7 +188,7 @@ var FileManager1Client = class DashToDock_FileManager1Client {
                                 this._windowsByLocation.delete(location);
                             this.emit('windows-changed');
                         });
-                }
+                });
             });
         });
 

--- a/locations.js
+++ b/locations.js
@@ -652,7 +652,8 @@ function makeLocationApp(params) {
     }, { getter: true, enumerable: true });
 
     shellApp._mi('toString', defaultToString =>
-        '[LocationApp - %s]'.format(defaultToString.call(shellApp)));
+        '[LocationApp "%s" - %s]'.format(shellApp.get_id(),
+            defaultToString.call(shellApp)));
 
     shellApp._mi('launch', (_om, timestamp, workspace, _gpuPref) =>
         shellApp.appInfo.launch([],

--- a/locations.js
+++ b/locations.js
@@ -1087,8 +1087,14 @@ var Removables = class DashToDock_Removables {
     _onMountAdded(mount) {
         Removables.initMountPromises(mount);
 
-        if (!this._volumeApps.find(({ appInfo }) => appInfo.mount === mount))
-            this._onVolumeAdded(mount.get_volume());
+        if (!this._volumeApps.find(({ appInfo }) => appInfo.mount === mount)) {
+            // In some Gio.Mount implementations the volume may be set after
+            // mount is emitted, so we could just ignore it as we'll get it
+            // later via volume-added
+            const volume = mount.get_volume();
+            if (volume)
+                this._onVolumeAdded(volume);
+        }
     }
 
     getApps() {

--- a/locations.js
+++ b/locations.js
@@ -516,19 +516,19 @@ function wrapWindowsBackedApp(shellApp) {
     shellApp._setDtdData({ mi: m, pi: p }, { public: false });
 
     m('get_state', () =>
-        shellApp.get_windows().length ? Shell.AppState.RUNNING : Shell.AppState.STOPPED);
+        shellApp.get_n_windows() ? Shell.AppState.RUNNING : Shell.AppState.STOPPED);
     p('state', { get: () => shellApp.get_state() });
 
     m('get_windows', () => shellApp._windows);
-    m('get_n_windows', () => shellApp.get_windows().length);
-    m('get_pids', () => shellApp.get_windows().reduce((pids, w) => {
+    m('get_n_windows', () => shellApp._windows.length);
+    m('get_pids', () => shellApp._windows.reduce((pids, w) => {
         if (w.get_pid() > 0 && !pids.includes(w.get_pid()))
             pids.push(w.get_pid());
         return pids;
     }, []));
-    m('is_on_workspace', (_om, workspace) => shellApp.get_windows().some(w =>
+    m('is_on_workspace', (_om, workspace) => shellApp._windows.some(w =>
         w.get_workspace() === workspace));
-    m('request_quit', () => shellApp.get_windows().filter(w =>
+    m('request_quit', () => shellApp._windows.filter(w =>
         w.can_close()).forEach(w => w.delete(global.get_current_time())));
 
     shellApp._setDtdData({
@@ -567,7 +567,7 @@ function wrapWindowsBackedApp(shellApp) {
 
     const windowTracker = Shell.WindowTracker.get_default();
     shellApp._checkFocused = function () {
-        if (this.get_windows().some(w => w.has_focus())) {
+        if (this._windows.some(w => w.has_focus())) {
             this.isFocused = true;
             windowTracker.notify('focus-app');
         } else if (this.isFocused) {
@@ -584,7 +584,7 @@ function wrapWindowsBackedApp(shellApp) {
     m('activate_window', function (_om, window, timestamp) {
         if (!window)
             [window] = this.get_windows();
-        else if (!this.get_windows().includes(window))
+        else if (!this._windows.includes(window))
             return;
 
         const currentWorkspace = global.workspace_manager.get_active_workspace();

--- a/locations.js
+++ b/locations.js
@@ -621,7 +621,7 @@ function wrapWindowsBackedApp(shellApp) {
 
     m('activate', () => shellApp.activate_full(-1, 0));
 
-    m('compare', (_om, other) => shellAppCompare(shellApp, other));
+    m('compare', (_om, other) => Utils.shellAppCompare(shellApp, other));
 
     const { destroy: defaultDestroy } = shellApp;
     shellApp.destroy = function() {
@@ -730,39 +730,6 @@ function unWrapFileManagerApp() {
         return;
 
     fileManagerApp.destroy();
-}
-
-// Re-implements shell_app_compare so that can be used to resort running apps
-function shellAppCompare(app, other) {
-    if (app.state !== other.state) {
-        if (app.state === Shell.AppState.RUNNING)
-            return -1;
-        return 1;
-    }
-
-    const windows = app.get_windows();
-    const otherWindows = other.get_windows();
-
-    const isMinimized = windows => !windows.some(w => w.showing_on_its_workspace());
-    const otherMinimized = isMinimized(otherWindows);
-    if (isMinimized(windows) != otherMinimized) {
-        if (otherMinimized)
-            return -1;
-        return 1;
-    }
-
-    if (app.state === Shell.AppState.RUNNING) {
-        if (windows.length && !otherWindows.length)
-            return -1;
-        else if (!windows.length && otherWindows.length)
-            return 1;
-
-        const lastUserTime = windows =>
-            Math.max(...windows.map(w => w.get_user_time()));
-        return lastUserTime(otherWindows) - lastUserTime(windows);
-    }
-
-    return 0;
 }
 
 /**

--- a/locations.js
+++ b/locations.js
@@ -302,6 +302,10 @@ const MountableVolumeAppInfo = GObject.registerClass({
             'mount', 'mount', 'mount',
             GObject.ParamFlags.READWRITE,
             Gio.Mount.$gtype),
+        'busy': GObject.ParamSpec.boolean(
+            'busy', 'busy', 'busy',
+            GObject.ParamFlags.READWRITE,
+            false),
     },
 },
 class MountableVolumeAppInfo extends LocationAppInfo {
@@ -329,6 +333,14 @@ class MountableVolumeAppInfo extends LocationAppInfo {
                 return GLib.SOURCE_REMOVE;
             });
         }
+    }
+
+    get busy() {
+        return !!this._currentAction;
+    }
+
+    get currentAction() {
+        return this._currentAction;
     }
 
     destroy() {
@@ -478,6 +490,7 @@ class MountableVolumeAppInfo extends LocationAppInfo {
         }
 
         this._currentAction = action;
+        this.notify('busy');
         const removable = this.mount ?? this.volume;
         const operation = new ShellMountOperation.ShellMountOperation(removable);
         try {
@@ -509,6 +522,7 @@ class MountableVolumeAppInfo extends LocationAppInfo {
             return false;
         } finally {
             delete this._currentAction;
+            this.notify('busy');
             this._update();
             operation.close();
         }
@@ -866,6 +880,17 @@ function makeLocationApp(params) {
 
     // FIXME: We need to add a new API to Nautilus to open new windows
     shellApp._mi('can_open_new_window', () => false);
+
+    if (shellApp.appInfo instanceof MountableVolumeAppInfo) {
+        shellApp._mi('get_busy', function (parentGetBusy) {
+            if (this.appInfo.busy)
+                return true;
+            return parentGetBusy.call(this);
+        });
+        shellApp._pi('busy', { get: () => shellApp.get_busy() });
+        shellApp._signalConnections.add(shellApp.appInfo, 'notify::busy', _ =>
+            shellApp.notify('busy'));
+    }
 
     shellApp._mi('get_windows', function () {
         if (this._needsResort)

--- a/locations.js
+++ b/locations.js
@@ -37,6 +37,10 @@ const NautilusFileOperations2Interface = '<node>\
 
 const NautilusFileOperations2ProxyInterface = Gio.DBusProxy.makeProxyWrapper(NautilusFileOperations2Interface);
 
+if (imports.system.version >= 17101) {
+    Gio._promisify(Gio.File.prototype, 'query_info_async', 'query_info_finish');
+}
+
 function makeNautilusFileOperationsProxy() {
     const proxy = new NautilusFileOperations2ProxyInterface(
         Gio.DBus.session,
@@ -213,35 +217,66 @@ var LocationAppInfo = GObject.registerClass({
         return [];
     }
 
-    async _queryLocationIcon(params) {
+    async _queryLocationIcons(params) {
+        const icons = { standard: null, custom: null };
         if (!this.location)
-            return null;
+            return icons;
 
         const cancellable = params.cancellable ?? this.cancellable;
+        const iconsQuery = [];
+        if (params?.standard)
+            iconsQuery.push(Gio.FILE_ATTRIBUTE_STANDARD_ICON);
 
+        if (params?.custom)
+            iconsQuery.push(ATTRIBUTE_METADATA_CUSTOM_ICON);
+
+        if (!iconsQuery.length)
+            throw new Error('Invalid Query Location Icons parameters');
+
+        let info;
         try {
-            const info = await this.location.query_info_async(
-                Gio.FILE_ATTRIBUTE_STANDARD_ICON,
+            // This is should not be needed in newer Gjs (> GNOME 41)
+            if (imports.system.version < 17101) {
+                Gio._promisify(this.location.constructor.prototype, 'query_info_async',
+                    'query_info_finish');
+            }
+            info = await this.location.query_info_async(
+                iconsQuery.join(','),
                 Gio.FileQueryInfoFlags.NONE,
                 GLib.PRIORITY_LOW, cancellable);
-
-            return info?.get_icon();
+            icons.standard = info.get_icon();
         } catch (e) {
             if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND) ||
                 e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_MOUNTED))
-                return null;
+                return icons;
             throw e;
         }
+
+        const customIcon = info.get_attribute_string(ATTRIBUTE_METADATA_CUSTOM_ICON);
+        if (customIcon) {
+            const customIconFile = GLib.uri_parse_scheme(customIcon) ?
+                Gio.File.new_for_uri(customIcon) : Gio.File.new_for_path(customIcon);
+            const iconFileInfo = await customIconFile.query_info_async(
+                Gio.FILE_ATTRIBUTE_STANDARD_TYPE,
+                Gio.FileQueryInfoFlags.NONE,
+                GLib.PRIORITY_LOW, cancellable);
+
+            if (iconFileInfo.get_file_type() === Gio.FileType.REGULAR)
+                icons.custom = Gio.FileIcon.new(customIconFile);
+        }
+
+        return icons;
     }
 
-    async _updateLocationIcon(params={}) {
+    async _updateLocationIcon(params = { standard: true, custom: true }) {
         const cancellable = new Utils.CancellableChild(this.cancellable);
 
         try {
             this._updateIconCancellable?.cancel();
             this._updateIconCancellable = cancellable;
 
-            const icon = await this._queryLocationIcon({ cancellable, ...params });
+            const icons = await this._queryLocationIcons({ cancellable, ...params });
+            const icon = icons.custom ?? icons.standard;
 
             if (icon && !icon.equal(this.icon))
                 this.icon = icon;
@@ -274,6 +309,7 @@ class VolumeAppInfo extends LocationAppInfo {
             icon: volume.get_icon(),
             cancellable,
         });
+        this._updateLocationIcon({ custom: true });
     }
 
     vfunc_dup() {
@@ -369,6 +405,7 @@ class MountAppInfo extends LocationAppInfo {
             icon: mount.get_icon(),
             cancellable,
         });
+        this._updateLocationIcon({ custom: true });
     }
 
     vfunc_dup() {

--- a/locations.js
+++ b/locations.js
@@ -583,18 +583,18 @@ var Removables = class DashToDock_Removables {
             appInfo: volumeAppInfo,
             gicon: volume.get_icon() || Gio.ThemedIcon.new(FALLBACK_REMOVABLE_MEDIA_ICON),
         });
+        volumeApp.appInfo.volume = volume;
         this._volumeApps.push(volumeApp);
         this.emit('changed');
     }
 
     _onVolumeRemoved(monitor, volume) {
-        for (let i = 0; i < this._volumeApps.length; i++) {
-            let app = this._volumeApps[i];
-            if (app.get_name() == volume.get_name()) {
-                const [volumeApp] = this._volumeApps.splice(i, 1);
-                volumeApp.destroy();
-                this.emit('changed');
-            }
+        const volumeIndex = this._volumeApps.findIndex(({ appInfo }) =>
+            appInfo.volume === volume);
+        if (volumeIndex !== -1) {
+            const [volumeApp] = this._volumeApps.splice(volumeIndex, 1);
+            volumeApp.destroy();
+            this.emit('changed');
         }
     }
 
@@ -635,18 +635,18 @@ var Removables = class DashToDock_Removables {
             location: escapedUri,
             gicon: mount.get_icon() || new Gio.ThemedIcon(FALLBACK_REMOVABLE_MEDIA_ICON),
         });
+        mountApp.appInfo.mount = mount;
         this._mountApps.push(mountApp);
         this.emit('changed');
     }
 
     _onMountRemoved(monitor, mount) {
-        for (let i = 0; i < this._mountApps.length; i++) {
-            let app = this._mountApps[i];
-            if (app.get_name() == mount.get_name()) {
-                const [mountApp] = this._mountApps.splice(i, 1);
-                mountApp.destroy();
-                this.emit('changed');
-            }
+        const mountIndex = this._mountApps.findIndex(({ appInfo }) =>
+            appInfo.mount === mount);
+        if (mountIndex !== -1) {
+            const [mountApp] = this._mountApps.splice(mountIndex, 1);
+            mountApp.destroy();
+            this.emit('changed');
         }
     }
 

--- a/locations.js
+++ b/locations.js
@@ -529,6 +529,9 @@ var Removables = class DashToDock_Removables {
     }
 
     destroy() {
+        [...this._volumeApps, ...this._mountApps].forEach(a => a.destroy());
+        this._volumeApps = [];
+        this._mountApps = [];
         this._signalsHandler.destroy();
         this._monitor = null;
     }

--- a/locations.js
+++ b/locations.js
@@ -581,9 +581,9 @@ var Removables = class DashToDock_Removables {
             if (app.get_name() == volume.get_name()) {
                 const [volumeApp] = this._volumeApps.splice(i, 1);
                 volumeApp.destroy();
+                this.emit('changed');
             }
         }
-        this.emit('changed');
     }
 
     _onMountAdded(monitor, mount) {
@@ -633,9 +633,9 @@ var Removables = class DashToDock_Removables {
             if (app.get_name() == mount.get_name()) {
                 const [mountApp] = this._mountApps.splice(i, 1);
                 mountApp.destroy();
+                this.emit('changed');
             }
         }
-        this.emit('changed');
     }
 
     getApps() {

--- a/locations.js
+++ b/locations.js
@@ -256,7 +256,7 @@ function getFileManagerApp() {
     return Shell.AppSystem.get_default().lookup_app(FILE_MANAGER_DESKTOP_APP_ID);
 }
 
-function wrapWindowsManagerApp() {
+function wrapFileManagerApp() {
     const fileManagerApp = getFileManagerApp();
     if (!fileManagerApp)
         return null;
@@ -308,7 +308,7 @@ function wrapWindowsManagerApp() {
     return fileManagerApp;
 }
 
-function unWrapWindowsManagerApp() {
+function unWrapFileManagerApp() {
     const fileManagerApp = getFileManagerApp();
     if (!fileManagerApp || !fileManagerApp._dtdData)
         return;

--- a/locations.js
+++ b/locations.js
@@ -670,10 +670,24 @@ function makeLocationApp(params) {
     // FIXME: We need to add a new API to Nautilus to open new windows
     shellApp._mi('can_open_new_window', () => false);
 
+    shellApp._mi('get_windows', function () {
+        if (this._needsResort)
+            this._sortWindows();
+        return this._windows;
+    });
+
     const { fm1Client } = Docking.DockManager.getDefault();
     shellApp._setDtdData({
+        _needsResort: true,
+
+        _windowsOrderChanged: function() {
+            this._needsResort = true;
+            this.emit('windows-changed');
+        },
+
         _sortWindows: function () {
             this._windows.sort(Utils.shellWindowsCompare);
+            this._needsResort = false;
         },
 
         _updateWindows: function () {
@@ -688,23 +702,18 @@ function makeLocationApp(params) {
             windows.forEach(w =>
                 this._signalConnections.addWithLabel('location-windows', w,
                     'notify::user-time', () => {
-                        if (w != this._windows[0]) {
-                            this._sortWindows();
-                            this.emit('windows-changed');
-                        }
+                        if (w != this._windows[0])
+                            this._windowsOrderChanged();
                     }));
         },
-    });
+    }, { readOnly: false });
 
     shellApp._signalConnections.add(fm1Client, 'windows-changed', () =>
         shellApp._updateWindows());
     shellApp._signalConnections.add(shellApp.appInfo, 'notify::icon', () =>
         shellApp.notify('icon'));
     shellApp._signalConnections.add(global.workspaceManager,
-        'workspace-switched', () => {
-            shellApp._sortWindows();
-            shellApp.emit('windows-changed');
-        });
+        'workspace-switched', () => shellApp._windowsOrderChanged());
 
     return shellApp;
 }

--- a/locations.js
+++ b/locations.js
@@ -959,7 +959,13 @@ function wrapFileManagerApp() {
     fileManagerApp._signalConnections.addWithLabel('windowsChanged',
         fileManagerApp, 'windows-changed', () => {
             fileManagerApp.stop_emission_by_name('windows-changed');
-            fileManagerApp._updateWindows();
+            // Let's wait for the location app to take control before of us
+            const id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+                fileManagerApp._sources.delete(id);
+                fileManagerApp._updateWindows();
+                return GLib.SOURCE_REMOVE;
+            });
+            fileManagerApp._sources.add(id);
         });
 
     if (removables) {

--- a/locations.js
+++ b/locations.js
@@ -815,7 +815,10 @@ function wrapFileManagerApp() {
 
     const { removables, trash } = Docking.DockManager.getDefault();
     fileManagerApp._signalConnections.addWithLabel('windowsChanged',
-        fileManagerApp, 'windows-changed', () => fileManagerApp._updateWindows());
+        fileManagerApp, 'windows-changed', () => {
+            fileManagerApp.stop_emission_by_name('windows-changed');
+            fileManagerApp._updateWindows();
+        });
 
     if (removables) {
         fileManagerApp._signalConnections.add(removables, 'changed', () =>

--- a/locations.js
+++ b/locations.js
@@ -212,6 +212,48 @@ var LocationAppInfo = GObject.registerClass({
     vfunc_get_supported_types() {
         return [];
     }
+
+    async _queryLocationIcon(params) {
+        if (!this.location)
+            return null;
+
+        const cancellable = params.cancellable ?? this.cancellable;
+
+        try {
+            const info = await this.location.query_info_async(
+                Gio.FILE_ATTRIBUTE_STANDARD_ICON,
+                Gio.FileQueryInfoFlags.NONE,
+                GLib.PRIORITY_LOW, cancellable);
+
+            return info?.get_icon();
+        } catch (e) {
+            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND) ||
+                e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_MOUNTED))
+                return null;
+            throw e;
+        }
+    }
+
+    async _updateLocationIcon(params={}) {
+        const cancellable = new Utils.CancellableChild(this.cancellable);
+
+        try {
+            this._updateIconCancellable?.cancel();
+            this._updateIconCancellable = cancellable;
+
+            const icon = await this._queryLocationIcon({ cancellable, ...params });
+
+            if (icon && !icon.equal(this.icon))
+                this.icon = icon;
+        } catch (e) {
+            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                logError(e, 'Impossible to update icon for %s'.format(this.get_id()));
+        } finally {
+            cancellable.cancel();
+            if (this._updateIconCancellable === cancellable)
+                delete this._updateIconCancellable;
+        }
+    }
 });
 
 const VolumeAppInfo = GObject.registerClass({
@@ -417,10 +459,10 @@ class TrashAppInfo extends LocationAppInfo {
         super._init({
             location: Gio.file_new_for_uri(TRASH_URI),
             name: __('Trash'),
+            icon: Gio.ThemedIcon.new(FALLBACK_TRASH_ICON),
             cancellable,
         });
-        this.connect('notify::empty', () =>
-            (this.icon = Gio.ThemedIcon.new(this.empty ? 'user-trash' : 'user-trash-full')));
+        this.connect('notify::empty', () => this._updateLocationIcon());
         this.notify('empty');
     }
 
@@ -774,10 +816,11 @@ var Trash = class DashToDock_Trash {
         if (Trash._promisified)
             return;
 
+        const trashProto = Gio.file_new_for_uri(TRASH_URI).constructor.prototype;
         Gio._promisify(Gio.FileEnumerator.prototype, 'close_async', 'close_finish');
         Gio._promisify(Gio.FileEnumerator.prototype, 'next_files_async', 'next_files_finish');
-        Gio._promisify(Gio.file_new_for_uri(TRASH_URI).constructor.prototype,
-            'enumerate_children_async', 'enumerate_children_finish');
+        Gio._promisify(trashProto, 'enumerate_children_async', 'enumerate_children_finish');
+        Gio._promisify(trashProto, 'query_info_async', 'query_info_finish');
         Trash._promisified = true;
     }
 

--- a/locations.js
+++ b/locations.js
@@ -242,10 +242,13 @@ function makeLocationApp(params) {
 
     const windowsChangedId = fm1Client.connect('windows-changed', () =>
         shellApp._updateWindows());
+    const workspaceChangedId = global.workspaceManager.connect('workspace-switched',
+        () => shellApp.emit('windows-changed'));
 
     const parentDestroy = shellApp.destroy;
     shellApp.destroy = function () {
         fm1Client.disconnect(windowsChangedId);
+        global.workspaceManager.disconnect(workspaceChangedId);
         parentDestroy.call(this);
     }
 

--- a/locations.js
+++ b/locations.js
@@ -679,7 +679,20 @@ function makeLocationApp(params) {
         _updateWindows: function () {
             const windows = fm1Client.getWindows(this.location?.get_uri()).sort(
                 Utils.shellWindowsCompare);
-            this._setWindows(windows);
+            const { windowsChanged } = this._setWindows(windows);
+
+            if (!windowsChanged)
+                return;
+
+            this._signalConnections.removeWithLabel('location-windows');
+            windows.forEach(w =>
+                this._signalConnections.addWithLabel('location-windows', w,
+                    'notify::user-time', () => {
+                        if (w != this._windows[0]) {
+                            this._sortWindows();
+                            this.emit('windows-changed');
+                        }
+                    }));
         },
     });
 

--- a/locations.js
+++ b/locations.js
@@ -492,6 +492,18 @@ const TrashAppInfo = GObject.registerClass({
     },
 },
 class TrashAppInfo extends LocationAppInfo {
+    static initPromises(file) {
+        if (TrashAppInfo._promisified)
+            return;
+
+        const trashProto = file.constructor.prototype;
+        Gio._promisify(Gio.FileEnumerator.prototype, 'close_async', 'close_finish');
+        Gio._promisify(Gio.FileEnumerator.prototype, 'next_files_async', 'next_files_finish');
+        Gio._promisify(trashProto, 'enumerate_children_async', 'enumerate_children_finish');
+        Gio._promisify(trashProto, 'query_info_async', 'query_info_finish');
+        TrashAppInfo._promisified = true;
+    }
+
     _init(cancellable = null) {
         super._init({
             location: Gio.file_new_for_uri(TRASH_URI),
@@ -499,8 +511,31 @@ class TrashAppInfo extends LocationAppInfo {
             icon: Gio.ThemedIcon.new(FALLBACK_TRASH_ICON),
             cancellable,
         });
+        TrashAppInfo.initPromises(this.location);
+
+        try {
+            this._monitor = this.location.monitor_directory(0, this.cancellable);
+            this._monitor.set_rate_limit(UPDATE_TRASH_DELAY);
+            this._monitorChangedId = this._monitor.connect('changed', () =>
+                this._onTrashChange());
+        } catch (e) {
+            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                return;
+            logError(e, 'Impossible to monitor trash');
+        }
+        this._updateTrash();
+
         this.connect('notify::empty', () => this._updateLocationIcon());
         this.notify('empty');
+    }
+
+    destroy() {
+        if (this._trashChangedIdle)
+            GLib.source_remove(this._trashChangedIdle);
+
+        this._monitor?.disconnect(this._monitorChangedId);
+        this._monitor = null;
+        this.location = null;
     }
 
     list_actions() {
@@ -513,6 +548,53 @@ class TrashAppInfo extends LocationAppInfo {
                 return __('Empty Trash');
             default:
                 return null;
+        }
+    }
+
+    _onTrashChange() {
+        if (this._trashChangedIdle)
+            return;
+
+        if (this._monitor.is_cancelled())
+            return;
+
+        this._trashChangedIdle = GLib.timeout_add(
+            GLib.PRIORITY_LOW, UPDATE_TRASH_DELAY, () => {
+                this._trashChangedIdle = 0;
+                this._updateTrash();
+                return GLib.SOURCE_REMOVE;
+            });
+    }
+
+    async _updateTrash() {
+        const priority = GLib.PRIORITY_LOW;
+        const { cancellable } = this;
+
+        try {
+            const trashInfo = await this.location.query_info_async(
+                Gio.FILE_ATTRIBUTE_TRASH_ITEM_COUNT,
+                Gio.FileQueryInfoFlags.NONE,
+                priority, cancellable);
+            this.empty = !trashInfo.get_attribute_uint32(
+                Gio.FILE_ATTRIBUTE_TRASH_ITEM_COUNT);
+            return;
+        } catch (e) {
+            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                logError(e, 'Impossible to get trash children from infos');
+        }
+
+        try {
+            const childrenEnumerator = await this.location.enumerate_children_async(
+                Gio.FILE_ATTRIBUTE_STANDARD_TYPE, Gio.FileQueryInfoFlags.NONE,
+                priority, cancellable);
+            const children = await childrenEnumerator.next_files_async(1,
+                priority, cancellable);
+            this.empty = !children.length;
+
+            await childrenEnumerator.close_async(priority, null);
+        } catch (e) {
+            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                logError(e, 'Impossible to enumerate trash children');
         }
     }
 
@@ -707,6 +789,7 @@ function wrapWindowsBackedApp(shellApp) {
         this._dtdData.proxyProperties.forEach(p => (delete this[p]));
         this._dtdData.destroy();
         this._dtdData = undefined;
+        this.appInfo.destroy && this.appInfo.destroy();
         this.destroy = defaultDestroy;
         defaultDestroy && defaultDestroy.call(this);
     }
@@ -862,96 +945,14 @@ function unWrapFileManagerApp() {
  * up-to-date as the trash fills and is emptied over time.
  */
 var Trash = class DashToDock_Trash {
-    static initPromises() {
-        if (Trash._promisified)
-            return;
-
-        const trashProto = Gio.file_new_for_uri(TRASH_URI).constructor.prototype;
-        Gio._promisify(Gio.FileEnumerator.prototype, 'close_async', 'close_finish');
-        Gio._promisify(Gio.FileEnumerator.prototype, 'next_files_async', 'next_files_finish');
-        Gio._promisify(trashProto, 'enumerate_children_async', 'enumerate_children_finish');
-        Gio._promisify(trashProto, 'query_info_async', 'query_info_finish');
-        Trash._promisified = true;
-    }
-
     constructor() {
-        Trash.initPromises();
         this._cancellable = new Gio.Cancellable();
-        this._file = Gio.file_new_for_uri(TRASH_URI);
-        try {
-            this._monitor = this._file.monitor_directory(0, this._cancellable);
-            this._monitor.set_rate_limit(UPDATE_TRASH_DELAY);
-            this._signalId = this._monitor.connect('changed', () => this._onTrashChange());
-        } catch (e) {
-            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
-                return;
-            logError(e, 'Impossible to monitor trash');
-        }
-        this._schedUpdateId = 0;
-        this._updateTrash();
     }
 
     destroy() {
         this._cancellable.cancel();
         this._cancellable = null;
-        this._monitor?.disconnect(this._signalId);
-        this._monitor = null;
-        this._file = null;
         this._trashApp?.destroy();
-    }
-
-    _onTrashChange() {
-        if (this._schedUpdateId)
-            return;
-
-        if (this._monitor.is_cancelled())
-            return;
-
-        this._schedUpdateId = GLib.timeout_add(
-            GLib.PRIORITY_LOW, UPDATE_TRASH_DELAY, () => {
-                this._schedUpdateId = 0;
-                this._updateTrash();
-                return GLib.SOURCE_REMOVE;
-            });
-    }
-
-    async _updateTrash() {
-        const priority = GLib.PRIORITY_LOW;
-        const cancellable = this._cancellable;
-
-        try {
-            const trashInfo = await this._file.query_info_async(
-                Gio.FILE_ATTRIBUTE_TRASH_ITEM_COUNT,
-                Gio.FileQueryInfoFlags.NONE,
-                priority, cancellable);
-            this._updateApp(!trashInfo.get_attribute_uint32(
-                Gio.FILE_ATTRIBUTE_TRASH_ITEM_COUNT));
-            return;
-        } catch (e) {
-            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
-                logError(e, 'Impossible to get trash children from infos');
-        }
-
-        try {
-            const childrenEnumerator = await this._file.enumerate_children_async(
-                Gio.FILE_ATTRIBUTE_STANDARD_TYPE, Gio.FileQueryInfoFlags.NONE,
-                priority, cancellable);
-            const children = await childrenEnumerator.next_files_async(1,
-                priority, cancellable);
-            this._updateApp(!children.length);
-
-            await childrenEnumerator.close_async(priority, null);
-        } catch (e) {
-            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
-                logError(e, 'Impossible to enumerate trash children');
-        }
-    }
-
-    _updateApp(isEmpty) {
-        if (!this._trashApp)
-            return
-
-        this._trashApp.appInfo.empty = isEmpty;
     }
 
     _ensureApp() {

--- a/locations.js
+++ b/locations.js
@@ -916,9 +916,23 @@ var Trash = class DashToDock_Trash {
     }
 
     async _updateTrash() {
+        const priority = GLib.PRIORITY_LOW;
+        const cancellable = this._cancellable;
+
         try {
-            const priority = GLib.PRIORITY_LOW;
-            const cancellable = this._cancellable;
+            const trashInfo = await this._file.query_info_async(
+                Gio.FILE_ATTRIBUTE_TRASH_ITEM_COUNT,
+                Gio.FileQueryInfoFlags.NONE,
+                priority, cancellable);
+            this._updateApp(!trashInfo.get_attribute_uint32(
+                Gio.FILE_ATTRIBUTE_TRASH_ITEM_COUNT));
+            return;
+        } catch (e) {
+            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                logError(e, 'Impossible to get trash children from infos');
+        }
+
+        try {
             const childrenEnumerator = await this._file.enumerate_children_async(
                 Gio.FILE_ATTRIBUTE_STANDARD_TYPE, Gio.FileQueryInfoFlags.NONE,
                 priority, cancellable);

--- a/locations.js
+++ b/locations.js
@@ -457,10 +457,12 @@ function wrapWindowsBackedApp(shellApp) {
 
     shellApp._dtdData = {
         windows: [],
+        signalConnections: new Utils.GlobalSignalsHandler(),
         methodInjections: new Utils.InjectionsHandler(),
         propertyInjections: new Utils.PropertyInjectionsHandler(),
         destroy: function () {
             this.windows = [];
+            this.signalConnections.destroy();
             this.methodInjections.destroy();
             this.propertyInjections.destroy();
         }
@@ -470,6 +472,7 @@ function wrapWindowsBackedApp(shellApp) {
     const p = (...args) => shellApp._dtdData.propertyInjections.add(shellApp, ...args);
     shellApp._mi = m; // Method injector
     shellApp._pi = p; // Property injector
+    shellApp._signalConnections = shellApp._dtdData.signalConnections;
 
     m('get_state', () =>
         shellApp.get_windows().length ? Shell.AppState.RUNNING : Shell.AppState.STOPPED);
@@ -509,7 +512,7 @@ function wrapWindowsBackedApp(shellApp) {
     }
 
     shellApp._checkFocused();
-    const focusWindowNotifyId = global.display.connect('notify::focus-window', () =>
+    shellApp._signalConnections.add(global.display, 'notify::focus-window', () =>
         shellApp._checkFocused());
 
     // Re-implements shell_app_activate_window for generic activation and alt-tab support
@@ -556,7 +559,6 @@ function wrapWindowsBackedApp(shellApp) {
     m('compare', (_om, other) => shellAppCompare(shellApp, other));
 
     shellApp.destroy = function() {
-        global.display.disconnect(focusWindowNotifyId);
         updateWindowsIdle && GLib.source_remove(updateWindowsIdle);
         this._dtdData.destroy();
         this._dtdData = undefined;
@@ -618,20 +620,12 @@ function makeLocationApp(params) {
         }
     };
 
-    const windowsChangedId = fm1Client.connect('windows-changed', () =>
+    shellApp._signalConnections.add(fm1Client, 'windows-changed', () =>
         shellApp._updateWindows());
-    const workspaceChangedId = global.workspaceManager.connect('workspace-switched',
-        () => shellApp.emit('windows-changed'));
-    const iconChangedId = shellApp.appInfo.connect('notify::icon', () =>
+    shellApp._signalConnections.add(global.workspaceManager,
+        'workspace-switched', () => shellApp.emit('windows-changed'));
+    shellApp._signalConnections.add(shellApp.appInfo, 'notify::icon', () =>
         shellApp.notify('icon'));
-
-    const parentDestroy = shellApp.destroy;
-    shellApp.destroy = function () {
-        fm1Client.disconnect(windowsChangedId);
-        global.workspaceManager.disconnect(workspaceChangedId);
-        shellApp.appInfo.disconnect(iconChangedId);
-        parentDestroy.call(this);
-    }
 
     return shellApp;
 }
@@ -652,9 +646,9 @@ function wrapFileManagerApp() {
     wrapWindowsBackedApp(fileManagerApp);
 
     const { fm1Client } = Docking.DockManager.getDefault();
-    const windowsChangedId = fileManagerApp.connect('windows-changed', () =>
-        fileManagerApp._updateWindows());
-    const fm1WindowsChangedId = fm1Client.connect('windows-changed', () =>
+    fileManagerApp._signalConnections.addWithLabel('windowsChanged',
+        fileManagerApp, 'windows-changed', () => fileManagerApp._updateWindows());
+    fileManagerApp._signalConnections.add(fm1Client, 'windows-changed', () =>
         fileManagerApp._updateWindows());
 
     fileManagerApp._updateWindows = function () {
@@ -667,9 +661,9 @@ function wrapFileManagerApp() {
 
         if (this.get_windows().length !== oldWindows.length ||
             this.get_windows().some((win, index) => win !== oldWindows[index])) {
-            this.block_signal_handler(windowsChangedId);
+            this._signalConnections.blockWithLabel('windowsChanged');
             this.emit('windows-changed');
-            this.unblock_signal_handler(windowsChangedId);
+            this._signalConnections.unblockWithLabel('windowsChanged');
         }
 
         if (oldState !== this.state) {
@@ -681,13 +675,6 @@ function wrapFileManagerApp() {
 
     fileManagerApp._mi('toString', defaultToString =>
         '[FileManagerApp - %s]'.format(defaultToString.call(fileManagerApp)));
-
-    const parentDestroy = fileManagerApp.destroy;
-    fileManagerApp.destroy = function () {
-        fileManagerApp.disconnect(windowsChangedId);
-        fm1Client.disconnect(fm1WindowsChangedId);
-        parentDestroy.call(this);
-    }
 
     return fileManagerApp;
 }

--- a/locations.js
+++ b/locations.js
@@ -148,6 +148,10 @@ var LocationAppInfo = GObject.registerClass({
                 Gio.IOErrorEnum.NOT_SUPPORTED, 'Launching with files not supported');
         }
 
+        const handler = this._getHandlerApp();
+        if (handler)
+            return handler.launch_uris([this.location.get_uri()], context);
+
         const [ret] = GLib.spawn_async(null, this.get_commandline().split(' '),
             context?.get_environment() || null, GLib.SpawnFlags.SEARCH_PATH, null);
         return ret;
@@ -201,7 +205,8 @@ var LocationAppInfo = GObject.registerClass({
     }
 
     vfunc_get_commandline() {
-        return 'gio open %s'.format(this.location?.get_uri());
+        return this._getHandlerApp()?.get_commandline() ??
+            'gio open %s'.format(this.location?.get_uri());
     }
 
     vfunc_get_display_name() {
@@ -287,6 +292,24 @@ var LocationAppInfo = GObject.registerClass({
             cancellable.cancel();
             if (this._updateIconCancellable === cancellable)
                 delete this._updateIconCancellable;
+        }
+    }
+
+    _getHandlerApp() {
+        if (!this.location)
+            return null;
+
+        try {
+            return this.location.query_default_handler(this.cancellable);
+        } catch (e) {
+            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_MOUNTED))
+                return getFileManagerApp()?.appInfo;
+
+            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) {
+                logError(e, 'Impossible to find an URI handler for %s'.format(
+                    this.get_id()));
+            }
+            return null;
         }
     }
 });
@@ -903,7 +926,17 @@ function makeLocationApp(params) {
     }));
 
     // FIXME: We need to add a new API to Nautilus to open new windows
-    shellApp._mi('can_open_new_window', () => false);
+    shellApp._mi('can_open_new_window', () =>
+        shellApp.appInfo.get_commandline()?.split(' ').includes('--new-window'));
+
+    shellApp._mi('open_new_window', function (_om, workspace) {
+        const context = global.create_app_launch_context(0, workspace);
+        const [ret] = GLib.spawn_async(null,
+            [...this.appInfo.get_commandline().split(' ').filter(
+                t => !t.startsWith('%')), this.appInfo.location.get_uri() ],
+            context.get_environment(), GLib.SpawnFlags.SEARCH_PATH, null);
+        return ret;
+    });
 
     if (shellApp.appInfo instanceof MountableVolumeAppInfo) {
         shellApp._mi('get_busy', function (parentGetBusy) {

--- a/locations.js
+++ b/locations.js
@@ -811,7 +811,7 @@ function wrapWindowsBackedApp(shellApp) {
 
             if (windows.length !== oldWindows.length ||
                 windows.some((win, index) => win !== oldWindows[index])) {
-                this._windows = windows;
+                this._windows = windows.filter(w => !w.is_override_redirect());
                 this.emit('windows-changed');
                 result.windowsChanged = true;
             }

--- a/locations.js
+++ b/locations.js
@@ -585,7 +585,7 @@ class TrashAppInfo extends LocationAppInfo {
 
         try {
             this._monitor = this.location.monitor_directory(0, this.cancellable);
-            this._monitor.set_rate_limit(UPDATE_TRASH_DELAY);
+            this._schedUpdateId = 0;
             this._monitorChangedId = this._monitor.connect('changed', () =>
                 this._onTrashChange());
         } catch (e) {
@@ -600,6 +600,10 @@ class TrashAppInfo extends LocationAppInfo {
     }
 
     destroy() {
+        if (this._schedUpdateId) {
+            GLib.source_remove(this._schedUpdateId);
+            this._schedUpdateId = 0;
+        }
         this._updateTrashCancellable?.cancel();
         this._monitor?.disconnect(this._monitorChangedId);
         this._monitor = null;
@@ -620,10 +624,20 @@ class TrashAppInfo extends LocationAppInfo {
     }
 
     _onTrashChange() {
+        if (this._schedUpdateId) {
+            GLib.source_remove(this._schedUpdateId);
+            this._schedUpdateId = 0;
+        }
+
         if (this._monitor.is_cancelled())
             return;
 
-        this._updateTrash();
+        this._schedUpdateId = GLib.timeout_add(GLib.PRIORITY_LOW,
+            UPDATE_TRASH_DELAY, () => {
+            this._schedUpdateId = 0;
+            this._updateTrash();
+            return GLib.SOURCE_REMOVE;
+        });
     }
 
     async _updateTrash() {

--- a/locations.js
+++ b/locations.js
@@ -542,9 +542,7 @@ class TrashAppInfo extends LocationAppInfo {
     }
 
     destroy() {
-        if (this._trashChangedIdle)
-            GLib.source_remove(this._trashChangedIdle);
-
+        this._updateTrashCancellable?.cancel();
         this._monitor?.disconnect(this._monitorChangedId);
         this._monitor = null;
         this.location = null;
@@ -564,23 +562,17 @@ class TrashAppInfo extends LocationAppInfo {
     }
 
     _onTrashChange() {
-        if (this._trashChangedIdle)
-            return;
-
         if (this._monitor.is_cancelled())
             return;
 
-        this._trashChangedIdle = GLib.timeout_add(
-            GLib.PRIORITY_LOW, UPDATE_TRASH_DELAY, () => {
-                this._trashChangedIdle = 0;
-                this._updateTrash();
-                return GLib.SOURCE_REMOVE;
-            });
+        this._updateTrash();
     }
 
     async _updateTrash() {
         const priority = GLib.PRIORITY_LOW;
-        const { cancellable } = this;
+        this._updateTrashCancellable?.cancel();
+        const cancellable = new Utils.CancellableChild(this.cancellable);
+        this._updateTrashCancellable = cancellable;
 
         try {
             const trashInfo = await this.location.query_info_async(
@@ -593,6 +585,10 @@ class TrashAppInfo extends LocationAppInfo {
         } catch (e) {
             if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
                 logError(e, 'Impossible to get trash children from infos');
+        } finally {
+            cancellable.cancel();
+            if (this._updateIconCancellable === cancellable)
+                delete this._updateTrashCancellable;
         }
 
         try {
@@ -607,6 +603,10 @@ class TrashAppInfo extends LocationAppInfo {
         } catch (e) {
             if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
                 logError(e, 'Impossible to enumerate trash children');
+        } finally {
+            cancellable.cancel();
+            if (this._updateIconCancellable === cancellable)
+                delete this._updateTrashCancellable;
         }
     }
 

--- a/locations.js
+++ b/locations.js
@@ -88,6 +88,7 @@ function wrapWindowsBackedApp(shellApp, params = {}) {
     }
     shellApp._mi = m; // Method injector
     shellApp._pi = p; // Property injector
+    shellApp._aMi = aM; // appInfo method Injector
 
     m('get_state', () =>
         shellApp.get_windows().length ? Shell.AppState.RUNNING : Shell.AppState.STOPPED);

--- a/locations.js
+++ b/locations.js
@@ -459,6 +459,7 @@ function wrapWindowsBackedApp(shellApp) {
         windows: [],
         isFocused: false,
         proxyProperties: [],
+        sources: new Set(),
         signalConnections: new Utils.GlobalSignalsHandler(),
         methodInjections: new Utils.InjectionsHandler(),
         propertyInjections: new Utils.PropertyInjectionsHandler(),
@@ -480,6 +481,8 @@ function wrapWindowsBackedApp(shellApp) {
         destroy: function () {
             this.windows = [];
             this.proxyProperties = [];
+            this.sources.forEach(s => GLib.source_remove(s));
+            this.sources.clear();
             this.signalConnections.destroy();
             this.methodInjections.destroy();
             this.propertyInjections.destroy();
@@ -490,7 +493,7 @@ function wrapWindowsBackedApp(shellApp) {
         windows: {},
         isFocused: { public: true },
         signalConnections: { readOnly: true },
-        updateWindows: {},
+        sources: { readOnly: true },
         checkFocused: {},
         setDtdData: {},
     });
@@ -532,11 +535,11 @@ function wrapWindowsBackedApp(shellApp) {
         throw new GObject.NotImplementedError(`_updateWindows in ${this.constructor.name}`);
     };
 
-    let updateWindowsIdle = GLib.idle_add(GLib.DEFAULT_PRIORITY, () => {
+    shellApp._sources.add(GLib.idle_add(GLib.DEFAULT_PRIORITY, () => {
         shellApp._updateWindows();
-        updateWindowsIdle = undefined;
+        shellApp._sources.delete(GLib.main_current_source().source_id);
         return GLib.SOURCE_REMOVE;
-    });
+    }));
 
     const windowTracker = Shell.WindowTracker.get_default();
     shellApp._checkFocused = function () {
@@ -598,7 +601,6 @@ function wrapWindowsBackedApp(shellApp) {
 
     const { destroy: defaultDestroy } = shellApp;
     shellApp.destroy = function() {
-        updateWindowsIdle && GLib.source_remove(updateWindowsIdle);
         this._dtdData.proxyProperties.forEach(p => (delete this[p]));
         this._dtdData.destroy();
         this._dtdData = undefined;

--- a/locations.js
+++ b/locations.js
@@ -5,6 +5,7 @@ const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Shell = imports.gi.Shell;
+const ShellMountOperation = imports.ui.shellMountOperation;
 const Signals = imports.signals;
 const St = imports.gi.St;
 
@@ -19,7 +20,9 @@ const Docking = Me.imports.docking;
 const Utils = Me.imports.utils;
 
 const FALLBACK_REMOVABLE_MEDIA_ICON = 'drive-removable-media';
+const FALLBACK_TRASH_ICON = 'user-trash';
 const FILE_MANAGER_DESKTOP_APP_ID = 'org.gnome.Nautilus.desktop';
+const ATTRIBUTE_METADATA_CUSTOM_ICON = 'metadata::custom-icon';
 const TRASH_URI = 'trash://';
 const UPDATE_TRASH_DELAY = 1000;
 
@@ -65,7 +68,390 @@ function makeNautilusFileOperationsProxy() {
     return proxy;
 }
 
-function wrapWindowsBackedApp(shellApp, params = {}) {
+var LocationAppInfo = GObject.registerClass({
+    Implements: [Gio.AppInfo],
+    Properties: {
+        'location': GObject.ParamSpec.object(
+            'location', 'location', 'location',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            Gio.File.$gtype),
+        'name': GObject.ParamSpec.string(
+            'name', 'name', 'name',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            null),
+        'icon': GObject.ParamSpec.object(
+            'icon', 'icon', 'icon',
+            GObject.ParamFlags.READWRITE,
+            Gio.Icon.$gtype),
+        'cancellable': GObject.ParamSpec.object(
+            'cancellable', 'cancellable', 'cancellable',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            Gio.Cancellable.$gtype),
+    },
+}, class LocationAppInfo extends Gio.DesktopAppInfo {
+    list_actions() {
+        return [];
+    }
+
+    get_action_name() {
+        return null
+    }
+
+    get_boolean() {
+        return false;
+    }
+
+    vfunc_dup() {
+        return new LocationAppInfo({
+            location: this.location,
+            name: this.name,
+            icon: this.icon,
+            cancellable: this.cancellable,
+        });
+    }
+
+    vfunc_equal(other) {
+        if (this.location)
+            return this.location.equal(other?.location);
+
+        return this.name === other.name &&
+            (this.icon ? this.icon.equal(other?.icon) : !other?.icon);
+    }
+
+    vfunc_get_id() {
+        return 'location:%s'.format(this.location?.get_uri());
+    }
+
+    vfunc_get_name() {
+        return this.name;
+    }
+
+    vfunc_get_description() {
+        return null;
+    }
+
+    vfunc_get_executable() {
+        return null;
+    }
+
+    vfunc_get_icon() {
+        return this.icon;
+    }
+
+    vfunc_launch(files, context) {
+        if (files?.length) {
+            throw new GLib.Error(Gio.IOErrorEnum,
+                Gio.IOErrorEnum.NOT_SUPPORTED, 'Launching with files not supported');
+        }
+
+        const [ret] = GLib.spawn_async(null, this.get_commandline().split(' '),
+            context?.get_environment() || null, GLib.SpawnFlags.SEARCH_PATH, null);
+        return ret;
+    }
+
+    vfunc_supports_uris() {
+        return false;
+    }
+
+    vfunc_supports_files() {
+        return false;
+    }
+
+    vfunc_launch_uris(uris, context) {
+        return this.launch(uris, context);
+    }
+
+    vfunc_should_show() {
+        return true;
+    }
+
+    vfunc_set_as_default_for_type() {
+        throw new GLib.Error(Gio.IOErrorEnum,
+            Gio.IOErrorEnum.NOT_SUPPORTED, 'Not supported');
+    }
+
+    vfunc_set_as_default_for_extension() {
+        throw new GLib.Error(Gio.IOErrorEnum,
+            Gio.IOErrorEnum.NOT_SUPPORTED, 'Not supported');
+    }
+
+    vfunc_add_supports_type() {
+        throw new GLib.Error(Gio.IOErrorEnum,
+            Gio.IOErrorEnum.NOT_SUPPORTED, 'Not supported');
+    }
+
+    vfunc_can_remove_supports_type() {
+        return false;
+    }
+
+    vfunc_remove_supports_type() {
+        return false;
+    }
+
+    vfunc_can_delete() {
+        return false;
+    }
+
+    vfunc_do_delete() {
+        return false;
+    }
+
+    vfunc_get_commandline() {
+        return 'gio open %s'.format(this.location?.get_uri());
+    }
+
+    vfunc_get_display_name() {
+        return this.name;
+    }
+
+    vfunc_set_as_last_used_for_type() {
+        throw new GLib.Error(Gio.IOErrorEnum,
+            Gio.IOErrorEnum.NOT_SUPPORTED, 'Not supported');
+    }
+
+    vfunc_get_supported_types() {
+        return [];
+    }
+});
+
+const VolumeAppInfo = GObject.registerClass({
+    Implements: [Gio.AppInfo],
+    Properties: {
+        'volume': GObject.ParamSpec.object(
+            'volume', 'volume', 'volume',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            Gio.Volume.$gtype),
+    },
+},
+class VolumeAppInfo extends LocationAppInfo {
+    _init(volume, cancellable = null) {
+        super._init({
+            volume,
+            location: volume.get_activation_root(),
+            name: volume.get_name(),
+            icon: volume.get_icon(),
+            cancellable,
+        });
+    }
+
+    vfunc_dup() {
+        return new VolumeAppInfo({
+            volume: this.volume,
+            cancellable: this.cancellable,
+        });
+    }
+
+    vfunc_get_id() {
+        const uuid = this.volume.get_uuid();
+        return uuid ? 'volume:%s'.format(uuid) : super.vfunc_get_id();
+    }
+
+    vfunc_equal(other) {
+        if (this.volume === other?.volume)
+            return true;
+
+        return this.get_id() === other?.get_id();
+    }
+
+    list_actions() {
+        const actions = [];
+
+        if (this.volume.can_mount())
+            actions.push('mount');
+        if (this.volume.can_eject())
+            actions.push('eject');
+
+        return actions;
+    }
+
+    get_action_name(action) {
+        switch (action) {
+            case 'mount':
+                return __('Mount');
+            case 'eject':
+                return __('Eject');
+            default:
+                return null;
+        }
+    }
+
+    async launchAction(action) {
+        if (!this.list_actions().includes(action))
+            throw new Error('Action %s is not supported by %s', action, this);
+
+        const operation = new ShellMountOperation.ShellMountOperation(this.volume);
+        try {
+            if (action === 'mount') {
+                await this.volume.mount(Gio.MountMountFlags.NONE, operation.mountOp,
+                    this.cancellable);
+            } else if (action === 'eject') {
+                await this.volume.eject_with_operation(Gio.MountUnmountFlags.FORCE,
+                    operation.mountOp, this.cancellable);
+            }
+        } catch (e) {
+            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.FAILED)) {
+                if (action === 'mount') {
+                    global.notify_error(__("Failed to mount “%s”".format(
+                        this.get_name())), e.message);
+                } else if (action === 'eject') {
+                    global.notify_error(__("Failed to eject “%s”".format(
+                        this.get_name())), e.message);
+                }
+            }
+
+            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) {
+                logError(e, 'Impossible to %s volume %s'.format(action,
+                    this.volume.get_name()));
+            }
+        } finally {
+            operation.close();
+        }
+    }
+});
+
+const MountAppInfo = GObject.registerClass({
+    Implements: [Gio.AppInfo],
+    Properties: {
+        'mount': GObject.ParamSpec.object(
+            'mount', 'mount', 'mount',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            Gio.Mount.$gtype),
+    },
+},
+class MountAppInfo extends LocationAppInfo {
+    _init(mount, cancellable = null) {
+        super._init({
+            mount,
+            location: mount.get_default_location(),
+            name: mount.get_name(),
+            icon: mount.get_icon(),
+            cancellable,
+        });
+    }
+
+    vfunc_dup() {
+        return new MountAppInfo({
+            mount: this.mount,
+            cancellable: this.cancellable,
+        });
+    }
+
+    vfunc_get_id() {
+        const uuid = this.mount.get_uuid() ?? this.mount.get_volume()?.get_uuid();
+        return uuid ? 'mount:%s'.format(uuid) : super.vfunc_get_id();
+    }
+
+    vfunc_equal(other) {
+        if (this.mount === other?.mount)
+            return true;
+
+        return this.get_id() === other?.get_id();
+    }
+
+    list_actions() {
+        const actions = [];
+
+        if (this.mount.can_unmount())
+            actions.push('unmount');
+        if (this.mount.can_eject())
+            actions.push('eject');
+
+        return actions;
+    }
+
+    get_action_name(action) {
+        switch (action) {
+            case 'unmount':
+                return __('Unmount');
+            case 'eject':
+                return __('Eject');
+            default:
+                return null;
+        }
+    }
+
+    async launchAction(action) {
+        if (!this.list_actions().includes(action))
+            throw new Error('Action %s is not supported by %s', action, this);
+
+        const operation = new ShellMountOperation.ShellMountOperation(this.mount);
+        try {
+            if (action === 'unmount') {
+                await this.mount.unmount_with_operation(Gio.MountUnmountFlags.FORCE,
+                    operation.mountOp, this.cancellable);
+            } else if (action === 'eject') {
+                await this.mount.eject_with_operation(Gio.MountUnmountFlags.FORCE,
+                    operation.mountOp, this.cancellable);
+            }
+        } catch (e) {
+            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.FAILED)) {
+                if (action === 'unmount') {
+                    global.notify_error(__("Failed to umount “%s”".format(
+                        this.get_name())), e.message);
+                } else if (action === 'eject') {
+                    global.notify_error(__("Failed to eject “%s”".format(
+                        this.get_name())), e.message);
+                }
+            }
+            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) {
+                logError(e, 'Impossible to %s mount %s'.format(action,
+                    this.mount.get_name()));
+            }
+        } finally {
+            operation.close();
+        }
+    }
+});
+
+const TrashAppInfo = GObject.registerClass({
+    Implements: [Gio.AppInfo],
+    Properties: {
+        'empty': GObject.ParamSpec.boolean(
+            'empty', 'empty', 'empty',
+            GObject.ParamFlags.READWRITE,
+            true),
+    },
+},
+class TrashAppInfo extends LocationAppInfo {
+    _init(cancellable = null) {
+        super._init({
+            location: Gio.file_new_for_uri(TRASH_URI),
+            name: __('Trash'),
+            cancellable,
+        });
+        this.connect('notify::empty', () =>
+            (this.icon = Gio.ThemedIcon.new(this.empty ? 'user-trash' : 'user-trash-full')));
+        this.notify('empty');
+    }
+
+    list_actions() {
+        return this.empty ? [] : ['empty-trash'];
+    }
+
+    get_action_name(action) {
+        switch (action) {
+            case 'empty-trash':
+                return __('Empty Trash');
+            default:
+                return null;
+        }
+    }
+
+    launchAction(action, timestamp) {
+        if (!this.list_actions().includes(action))
+            throw new Error('Action %s is not supported by %s', action, this);
+
+        const nautilus = makeNautilusFileOperationsProxy();
+        const askConfirmation = true;
+        nautilus.EmptyTrashRemote(askConfirmation,
+            nautilus.platformData({ timestamp }), (_p, error) => {
+                if (error)
+                    logError(error, 'Empty trash failed');
+        }, this.cancellable);
+    }
+});
+
+function wrapWindowsBackedApp(shellApp) {
     if (shellApp._dtdData)
         throw new Error('%s has been already wrapped'.format(shellApp));
 
@@ -82,42 +468,12 @@ function wrapWindowsBackedApp(shellApp, params = {}) {
 
     const m = (...args) => shellApp._dtdData.methodInjections.add(shellApp, ...args);
     const p = (...args) => shellApp._dtdData.propertyInjections.add(shellApp, ...args);
-    const aM = (...args) => {
-        if (shellApp.appInfo)
-            shellApp._dtdData.methodInjections.add(shellApp.appInfo, ...args);
-    }
     shellApp._mi = m; // Method injector
     shellApp._pi = p; // Property injector
-    shellApp._aMi = aM; // appInfo method Injector
-
-    shellApp._setActions = function(actionsGetter) {
-        aM('list_actions', () => Object.keys(actionsGetter()));
-        aM('get_action_name', (_om, name) => actionsGetter()[name]?.name);
-        m('launch_action', (launchAction, actionName, ...args) => {
-            const actions = actionsGetter();
-            if (actionName in actions)
-                actions[actionName].exec(...args);
-            else
-                return launchAction.call(shellApp, actionName, ...args);
-        });
-    };
 
     m('get_state', () =>
         shellApp.get_windows().length ? Shell.AppState.RUNNING : Shell.AppState.STOPPED);
     p('state', { get: () => shellApp.get_state() });
-
-    if (params.gicon) {
-        const { gicon } = params;
-        m('get_icon', () => gicon);
-        p('icon', { get: () => shellApp.get_icon() });
-        aM('get_icon', () => shellApp.get_icon());
-
-        m('create_icon_texture', (_om, icon_size) => new St.Icon({
-            icon_size,
-            gicon: shellApp.icon,
-            fallback_icon_name: FALLBACK_REMOVABLE_MEDIA_ICON,
-        }));
-    }
 
     m('get_windows', () => shellApp._dtdData.windows);
     m('get_n_windows', () => shellApp.get_windows().length);
@@ -212,25 +568,35 @@ function wrapWindowsBackedApp(shellApp, params = {}) {
 
 // We can't inherit from Shell.App as it's a final type, so let's patch it
 function makeLocationApp(params) {
-    if (!params.location)
+    if (!(params?.appInfo instanceof LocationAppInfo))
         throw new TypeError('Invalid location');
 
-    const location = params.location;
-    const gicon = params.gicon;
-    delete params.location;
-    delete params.gicon;
+    const { fallbackIconName } = params;
+    delete params.fallbackIconName;
 
     const shellApp = new Shell.App(params);
-    wrapWindowsBackedApp(shellApp, { gicon });
-    shellApp.appInfo.customId = 'location:%s'.format(location);
+    wrapWindowsBackedApp(shellApp);
 
     Object.defineProperties(shellApp, {
-        location: { value: location },
-        isTrash: { value: location.startsWith(TRASH_URI) },
+        location: { get: () => shellApp.appInfo.location },
+        isTrash: { get: () => shellApp.appInfo instanceof TrashAppInfo },
     });
 
     shellApp._mi('toString', defaultToString =>
         '[LocationApp - %s]'.format(defaultToString.call(shellApp)));
+
+    shellApp._mi('launch', (_om, timestamp, workspace, _gpuPref) =>
+        shellApp.appInfo.launch([],
+            global.create_app_launch_context(timestamp, workspace)));
+
+    shellApp._mi('launch_action', (_om, actionName, ...args) =>
+        shellApp.appInfo.launchAction(actionName, ...args));
+
+    shellApp._mi('create_icon_texture', (_om, iconSize) => new St.Icon({
+        iconSize,
+        gicon: shellApp.icon,
+        fallbackIconName,
+    }));
 
     // FIXME: We need to add a new API to Nautilus to open new windows
     shellApp._mi('can_open_new_window', () => false);
@@ -239,7 +605,7 @@ function makeLocationApp(params) {
     shellApp._updateWindows = function () {
         const oldState = this.state;
         const oldWindows = this.get_windows();
-        this._dtdData.windows = fm1Client.getWindows(this.location);
+        this._dtdData.windows = fm1Client.getWindows(this.location?.get_uri());
 
         if (this.get_windows().length !== oldWindows.length ||
             this.get_windows().some((win, index) => win !== oldWindows[index]))
@@ -256,11 +622,14 @@ function makeLocationApp(params) {
         shellApp._updateWindows());
     const workspaceChangedId = global.workspaceManager.connect('workspace-switched',
         () => shellApp.emit('windows-changed'));
+    const iconChangedId = shellApp.appInfo.connect('notify::icon', () =>
+        shellApp.notify('icon'));
 
     const parentDestroy = shellApp.destroy;
     shellApp.destroy = function () {
         fm1Client.disconnect(windowsChangedId);
         global.workspaceManager.disconnect(workspaceChangedId);
+        shellApp.appInfo.disconnect(iconChangedId);
         parentDestroy.call(this);
     }
 
@@ -369,8 +738,6 @@ function shellAppCompare(app, other) {
  * up-to-date as the trash fills and is emptied over time.
  */
 var Trash = class DashToDock_Trash {
-    _promisified = false;
-
     static initPromises() {
         if (Trash._promisified)
             return;
@@ -395,7 +762,6 @@ var Trash = class DashToDock_Trash {
                 return;
             logError(e, 'Impossible to monitor trash');
         }
-        this._empty = true;
         this._schedUpdateId = 0;
         this._updateTrash();
     }
@@ -433,8 +799,7 @@ var Trash = class DashToDock_Trash {
                 priority, cancellable);
             const children = await childrenEnumerator.next_files_async(1,
                 priority, cancellable);
-            this._empty = !children.length;
-            this._updateApp();
+            this._updateApp(!children.length);
 
             await childrenEnumerator.close_async(priority, null);
         } catch (e) {
@@ -443,50 +808,21 @@ var Trash = class DashToDock_Trash {
         }
     }
 
-    _updateApp() {
-        if (this._lastEmpty === this._empty)
+    _updateApp(isEmpty) {
+        if (!this._trashApp)
             return
 
-        this._lastEmpty = this._empty;
-        this._trashApp?.notify('icon');
+        this._trashApp.appInfo.empty = isEmpty;
     }
 
     _ensureApp() {
         if (this._trashApp)
             return;
 
-        const trashKeys = new GLib.KeyFile();
-        trashKeys.set_string('Desktop Entry', 'Name', __('Trash'));
-        trashKeys.set_string('Desktop Entry', 'Type', 'Application');
-        trashKeys.set_string('Desktop Entry', 'Exec', 'gio open %s'.format(TRASH_URI));
-        trashKeys.set_string('Desktop Entry', 'StartupNotify', 'false');
-
-        const trashAppInfo = Gio.DesktopAppInfo.new_from_keyfile(trashKeys);
-        const trashIcon = () => Gio.ThemedIcon.new(this._empty ?
-            'user-trash' : 'user-trash-full');
-
         this._trashApp = makeLocationApp({
-            location: TRASH_URI + '/',
-            appInfo: trashAppInfo,
-            gicon: trashIcon(),
+            appInfo: new TrashAppInfo(this._cancellable),
+            fallbackIconName: FALLBACK_TRASH_ICON,
         });
-
-        this._trashApp._mi('get_icon', () => trashIcon());
-
-        this._trashApp._setActions(() => (this._empty ? {} : {
-            'empty-trash': {
-                name: __('Empty Trash'),
-                exec: timestamp => {
-                    const nautilus = makeNautilusFileOperationsProxy();
-                    const askConfirmation = true;
-                    nautilus.EmptyTrashRemote(askConfirmation,
-                        nautilus.platformData({ timestamp }), (_p, error) => {
-                            if (error)
-                                logError(error, 'Empty trash failed');
-                        });
-                    }
-                }
-            }));
     }
 
     getApp() {
@@ -502,10 +838,36 @@ var Trash = class DashToDock_Trash {
  */
 var Removables = class DashToDock_Removables {
 
+    static initVolumePromises(object) {
+        // TODO: This can be simplified using actual interface type when we
+        // can depend on gjs 1.72
+        if (!(object instanceof Gio.Volume) || object.constructor.prototype._d2dPromisified)
+            return;
+
+        Gio._promisify(object.constructor.prototype, 'mount', 'mount_finish');
+        Gio._promisify(object.constructor.prototype, 'eject_with_operation',
+            'eject_with_operation_finish');
+        object.constructor.prototype._d2dPromisified = true;
+    }
+
+    static initMountPromises(object) {
+        // TODO: This can be simplified using actual interface type when we
+        // can depend on gjs 1.72
+        if (!(object instanceof Gio.Mount) || object.constructor.prototype._d2dPromisified)
+            return;
+
+        Gio._promisify(object.constructor.prototype, 'eject_with_operation',
+            'eject_with_operation_finish');
+        Gio._promisify(object.constructor.prototype, 'unmount_with_operation',
+            'unmount_with_operation_finish');
+        object.constructor.prototype._d2dPromisified = true;
+    }
+
     constructor() {
         this._signalsHandler = new Utils.GlobalSignalsHandler();
 
         this._monitor = Gio.VolumeMonitor.get();
+        this._cancellable = new Gio.Cancellable();
         this._volumeApps = []
         this._mountApps = []
 
@@ -544,12 +906,19 @@ var Removables = class DashToDock_Removables {
         [...this._volumeApps, ...this._mountApps].forEach(a => a.destroy());
         this._volumeApps = [];
         this._mountApps = [];
+        this._cancellable.cancel();
+        this._cancellable = null;
         this._signalsHandler.destroy();
         this._monitor = null;
     }
 
     _onVolumeAdded(monitor, volume) {
-        if (!volume.can_mount()) {
+        Removables.initVolumePromises(volume);
+
+        if (volume.get_mount())
+            return;
+
+        if (!volume.can_mount() && !volume.can_eject()) {
             return;
         }
 
@@ -557,8 +926,7 @@ var Removables = class DashToDock_Removables {
             return;
         }
 
-        let activationRoot = volume.get_activation_root();
-        if (!activationRoot) {
+        if (!volume.get_activation_root()) {
             // Can't offer to mount a device if we don't know
             // where to mount it.
             // These devices are usually ejectable so you
@@ -566,24 +934,11 @@ var Removables = class DashToDock_Removables {
             return;
         }
 
-        let escapedUri = activationRoot.get_uri()
-        let uri = GLib.uri_unescape_string(escapedUri, null);
-
-        let volumeKeys = new GLib.KeyFile();
-        volumeKeys.set_string('Desktop Entry', 'Name', volume.get_name());
-        volumeKeys.set_string('Desktop Entry', 'Type', 'Application');
-        volumeKeys.set_string('Desktop Entry', 'Exec', 'gio open "' + uri + '"');
-        volumeKeys.set_string('Desktop Entry', 'StartupNotify', 'false');
-        volumeKeys.set_string('Desktop Entry', 'Actions', 'mount;');
-        volumeKeys.set_string('Desktop Action mount', 'Name', __('Mount'));
-        volumeKeys.set_string('Desktop Action mount', 'Exec', 'gio mount "' + uri + '"');
-        let volumeAppInfo = Gio.DesktopAppInfo.new_from_keyfile(volumeKeys);
+        const appInfo = new VolumeAppInfo(volume, this._cancellable);
         const volumeApp = makeLocationApp({
-            location: escapedUri,
-            appInfo: volumeAppInfo,
-            gicon: volume.get_icon() || Gio.ThemedIcon.new(FALLBACK_REMOVABLE_MEDIA_ICON),
+            appInfo,
+            fallbackIconName: FALLBACK_REMOVABLE_MEDIA_ICON,
         });
-        volumeApp.appInfo.volume = volume;
         this._volumeApps.push(volumeApp);
         this.emit('changed');
     }
@@ -599,6 +954,8 @@ var Removables = class DashToDock_Removables {
     }
 
     _onMountAdded(monitor, mount) {
+        Removables.initMountPromises(mount);
+
         // Filter out uninteresting mounts
         if (!mount.can_eject() && !mount.can_unmount())
             return;
@@ -610,32 +967,11 @@ var Removables = class DashToDock_Removables {
             return;
         }
 
-        const escapedUri = mount.get_default_location().get_uri()
-        let uri = GLib.uri_unescape_string(escapedUri, null);
-
-        let mountKeys = new GLib.KeyFile();
-        mountKeys.set_string('Desktop Entry', 'Name', mount.get_name());
-        mountKeys.set_string('Desktop Entry', 'Type', 'Application');
-        mountKeys.set_string('Desktop Entry', 'Exec', 'gio open "' + uri + '"');
-        mountKeys.set_string('Desktop Entry', 'StartupNotify', 'false');
-        mountKeys.set_string('Desktop Entry', 'Actions', 'unmount;');
-        if (mount.can_eject()) {
-            mountKeys.set_string('Desktop Action unmount', 'Name', __('Eject'));
-            mountKeys.set_string('Desktop Action unmount', 'Exec',
-                                 'gio mount -e "' + uri + '"');
-        } else {
-            mountKeys.set_string('Desktop Entry', 'Actions', 'unmount;');
-            mountKeys.set_string('Desktop Action unmount', 'Name', __('Unmount'));
-            mountKeys.set_string('Desktop Action unmount', 'Exec',
-                                 'gio mount -u "' + uri + '"');
-        }
-        let mountAppInfo = Gio.DesktopAppInfo.new_from_keyfile(mountKeys);
+        const appInfo = new MountAppInfo(mount, this._cancellable);
         const mountApp = makeLocationApp({
-            appInfo: mountAppInfo,
-            location: escapedUri,
-            gicon: mount.get_icon() || new Gio.ThemedIcon(FALLBACK_REMOVABLE_MEDIA_ICON),
+            appInfo,
+            fallbackIconName: FALLBACK_REMOVABLE_MEDIA_ICON,
         });
-        mountApp.appInfo.mount = mount;
         this._mountApps.push(mountApp);
         this.emit('changed');
     }

--- a/locations.js
+++ b/locations.js
@@ -444,10 +444,40 @@ class MountableVolumeAppInfo extends LocationAppInfo {
         }
     }
 
+    _notifyActionError(action, message) {
+        if (action === 'mount') {
+            global.notify_error(__("Failed to mount “%s”".format(
+                this.get_name())), message);
+        } else if (action === 'unmount') {
+            global.notify_error(__("Failed to umount “%s”".format(
+                this.get_name())), message);
+        } else if (action === 'eject') {
+            global.notify_error(__("Failed to eject “%s”".format(
+                this.get_name())), message);
+        }
+    }
+
     async launchAction(action) {
         if (!this.list_actions().includes(action))
             throw new Error('Action %s is not supported by %s', action, this);
 
+        if (this._currentAction) {
+            if (this._currentAction === 'mount') {
+                this._notifyActionError(action,
+                    __("Mount operation already in progress"));
+            } else if (this._currentAction === 'unmount') {
+                this._notifyActionError(action,
+                    __("Umount operation already in progress"));
+            } else if (this._currentAction === 'eject') {
+                this._notifyActionError(action,
+                    __("Eject operation already in progress"));
+            }
+
+            throw new Error('Another action %s is being performed in %s'.format(
+                this._currentAction, this));
+        }
+
+        this._currentAction = action;
         const removable = this.mount ?? this.volume;
         const operation = new ShellMountOperation.ShellMountOperation(removable);
         try {
@@ -468,18 +498,8 @@ class MountableVolumeAppInfo extends LocationAppInfo {
 
             return true;
         } catch (e) {
-            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.FAILED)) {
-                if (action === 'mount') {
-                    global.notify_error(__("Failed to mount “%s”".format(
-                        this.get_name())), e.message);
-                } else if (action === 'unmount') {
-                    global.notify_error(__("Failed to umount “%s”".format(
-                        this.get_name())), e.message);
-                } else if (action === 'eject') {
-                    global.notify_error(__("Failed to eject “%s”".format(
-                        this.get_name())), e.message);
-                }
-            }
+            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.FAILED))
+                this._notifyActionError(action, e);
 
             if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) {
                 logError(e, 'Impossible to %s removable %s'.format(action,
@@ -488,6 +508,7 @@ class MountableVolumeAppInfo extends LocationAppInfo {
 
             return false;
         } finally {
+            delete this._currentAction;
             this._update();
             operation.close();
         }

--- a/locations.js
+++ b/locations.js
@@ -77,11 +77,11 @@ var LocationAppInfo = GObject.registerClass({
     Properties: {
         'location': GObject.ParamSpec.object(
             'location', 'location', 'location',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             Gio.File.$gtype),
         'name': GObject.ParamSpec.string(
             'name', 'name', 'name',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             null),
         'icon': GObject.ParamSpec.object(
             'icon', 'icon', 'icon',
@@ -291,41 +291,56 @@ var LocationAppInfo = GObject.registerClass({
     }
 });
 
-const VolumeAppInfo = GObject.registerClass({
+const MountableVolumeAppInfo = GObject.registerClass({
     Implements: [Gio.AppInfo],
     Properties: {
         'volume': GObject.ParamSpec.object(
             'volume', 'volume', 'volume',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
             Gio.Volume.$gtype),
+        'mount': GObject.ParamSpec.object(
+            'mount', 'mount', 'mount',
+            GObject.ParamFlags.READWRITE,
+            Gio.Mount.$gtype),
     },
 },
-class VolumeAppInfo extends LocationAppInfo {
+class MountableVolumeAppInfo extends LocationAppInfo {
     _init(volume, cancellable = null) {
         super._init({
             volume,
-            location: volume.get_activation_root(),
-            name: volume.get_name(),
-            icon: volume.get_icon(),
             cancellable,
         });
-        this._updateLocationIcon({ custom: true });
+
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
+
+        const updateAndMonitor = () => {
+            this._update();
+            this._monitorChanges();
+        };
+        updateAndMonitor();
+        this._mountChanged = this.connect('notify::mount', updateAndMonitor);
+    }
+
+    destroy() {
+        this.disconnect(this._mountChanged);
+        this.mount = null;
+        this._signalsHandler.destroy();
     }
 
     vfunc_dup() {
-        return new VolumeAppInfo({
+        return new MountableVolumeAppInfo({
             volume: this.volume,
             cancellable: this.cancellable,
         });
     }
 
     vfunc_get_id() {
-        const uuid = this.volume.get_uuid();
-        return uuid ? 'volume:%s'.format(uuid) : super.vfunc_get_id();
+        const uuid = this.mount?.get_uuid() ?? this.volume.get_uuid();
+        return uuid ? 'mountable-volume:%s'.format(uuid) : super.vfunc_get_id();
     }
 
     vfunc_equal(other) {
-        if (this.volume === other?.volume)
+        if (this.volume === other?.volume && this.mount === other?.mount)
             return true;
 
         return this.get_id() === other?.get_id();
@@ -333,6 +348,16 @@ class VolumeAppInfo extends LocationAppInfo {
 
     list_actions() {
         const actions = [];
+        const { mount } = this;
+
+        if (mount) {
+            if (this.mount.can_unmount())
+                actions.push('unmount');
+            if (this.mount.can_eject())
+                actions.push('eject');
+
+            return actions;
+        }
 
         if (this.volume.can_mount())
             actions.push('mount');
@@ -346,100 +371,6 @@ class VolumeAppInfo extends LocationAppInfo {
         switch (action) {
             case 'mount':
                 return __('Mount');
-            case 'eject':
-                return __('Eject');
-            default:
-                return null;
-        }
-    }
-
-    async launchAction(action) {
-        if (!this.list_actions().includes(action))
-            throw new Error('Action %s is not supported by %s', action, this);
-
-        const operation = new ShellMountOperation.ShellMountOperation(this.volume);
-        try {
-            if (action === 'mount') {
-                await this.volume.mount(Gio.MountMountFlags.NONE, operation.mountOp,
-                    this.cancellable);
-            } else if (action === 'eject') {
-                await this.volume.eject_with_operation(Gio.MountUnmountFlags.FORCE,
-                    operation.mountOp, this.cancellable);
-            }
-        } catch (e) {
-            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.FAILED)) {
-                if (action === 'mount') {
-                    global.notify_error(__("Failed to mount “%s”".format(
-                        this.get_name())), e.message);
-                } else if (action === 'eject') {
-                    global.notify_error(__("Failed to eject “%s”".format(
-                        this.get_name())), e.message);
-                }
-            }
-
-            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) {
-                logError(e, 'Impossible to %s volume %s'.format(action,
-                    this.volume.get_name()));
-            }
-        } finally {
-            operation.close();
-        }
-    }
-});
-
-const MountAppInfo = GObject.registerClass({
-    Implements: [Gio.AppInfo],
-    Properties: {
-        'mount': GObject.ParamSpec.object(
-            'mount', 'mount', 'mount',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
-            Gio.Mount.$gtype),
-    },
-},
-class MountAppInfo extends LocationAppInfo {
-    _init(mount, cancellable = null) {
-        super._init({
-            mount,
-            location: mount.get_default_location(),
-            name: mount.get_name(),
-            icon: mount.get_icon(),
-            cancellable,
-        });
-        this._updateLocationIcon({ custom: true });
-    }
-
-    vfunc_dup() {
-        return new MountAppInfo({
-            mount: this.mount,
-            cancellable: this.cancellable,
-        });
-    }
-
-    vfunc_get_id() {
-        const uuid = this.mount.get_uuid() ?? this.mount.get_volume()?.get_uuid();
-        return uuid ? 'mount:%s'.format(uuid) : super.vfunc_get_id();
-    }
-
-    vfunc_equal(other) {
-        if (this.mount === other?.mount)
-            return true;
-
-        return this.get_id() === other?.get_id();
-    }
-
-    list_actions() {
-        const actions = [];
-
-        if (this.mount.can_unmount())
-            actions.push('unmount');
-        if (this.mount.can_eject())
-            actions.push('eject');
-
-        return actions;
-    }
-
-    get_action_name(action) {
-        switch (action) {
             case 'unmount':
                 return __('Unmount');
             case 'eject':
@@ -449,22 +380,85 @@ class MountAppInfo extends LocationAppInfo {
         }
     }
 
+    vfunc_launch(files, context) {
+        if (this.mount || files?.length)
+            return super.vfunc_launch(files, context);
+
+        this.mountAndLaunch(files, context);
+        return true;
+    }
+
+    _update() {
+        this.mount = this.volume.get_mount();
+
+        const removable = this.mount ?? this.volume;
+        this.name = removable.get_name();
+        this.icon = removable.get_icon();
+
+        this.location = this.mount?.get_default_location() ??
+            this.volume.get_activation_root();
+
+        this._updateLocationIcon({ custom: true });
+    }
+
+    _monitorChanges() {
+        this._signalsHandler.destroy();
+
+        const removable = this.mount ?? this.volume;
+        this._signalsHandler.add(removable, 'changed', () => this._update());
+
+        if (this.mount) {
+            this._signalsHandler.add(this.mount, 'pre-unmount', () => this._update());
+            this._signalsHandler.add(this.mount, 'unmounted', () => this._update());
+        }
+    }
+
+    async mountAndLaunch(files, context) {
+        if (this.mount)
+            return super.vfunc_launch(files, context);
+
+        try {
+            await this.launchAction('mount');
+            if (!this.mount) {
+                throw new Error('No mounted location to open for %s'.format(
+                    this.get_id()));
+            }
+
+            return super.vfunc_launch(files, context);
+        } catch (e) {
+            logError(e, 'Mount and launch %s'.format(this.get_id()));
+        }
+    }
+
     async launchAction(action) {
         if (!this.list_actions().includes(action))
             throw new Error('Action %s is not supported by %s', action, this);
 
-        const operation = new ShellMountOperation.ShellMountOperation(this.mount);
+        const removable = this.mount ?? this.volume;
+        const operation = new ShellMountOperation.ShellMountOperation(removable);
         try {
-            if (action === 'unmount') {
+            if (action === 'mount') {
+                await this.volume.mount(Gio.MountMountFlags.NONE, operation.mountOp,
+                    this.cancellable);
+            } else if (action === 'unmount') {
                 await this.mount.unmount_with_operation(Gio.MountUnmountFlags.FORCE,
                     operation.mountOp, this.cancellable);
             } else if (action === 'eject') {
-                await this.mount.eject_with_operation(Gio.MountUnmountFlags.FORCE,
+                await removable.eject_with_operation(Gio.MountUnmountFlags.FORCE,
                     operation.mountOp, this.cancellable);
+            } else {
+                logError(new Error(), 'No action %s on removable %s'.format(action,
+                    removable.get_name()));
+                return false;
             }
+
+            return true;
         } catch (e) {
             if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.FAILED)) {
-                if (action === 'unmount') {
+                if (action === 'mount') {
+                    global.notify_error(__("Failed to mount “%s”".format(
+                        this.get_name())), e.message);
+                } else if (action === 'unmount') {
                     global.notify_error(__("Failed to umount “%s”".format(
                         this.get_name())), e.message);
                 } else if (action === 'eject') {
@@ -472,11 +466,15 @@ class MountAppInfo extends LocationAppInfo {
                         this.get_name())), e.message);
                 }
             }
+
             if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) {
-                logError(e, 'Impossible to %s mount %s'.format(action,
-                    this.mount.get_name()));
+                logError(e, 'Impossible to %s removable %s'.format(action,
+                    removable.get_name()));
             }
+
+            return false;
         } finally {
+            this._update();
             operation.close();
         }
     }
@@ -770,6 +768,7 @@ function wrapWindowsBackedApp(shellApp) {
                 try {
                     this.launch(timestamp, workspace, Shell.AppLaunchGpu.APP_PREF);
                 } catch (e) {
+                    logError(e);
                     global.notify_error(_("Failed to launch “%s”".format(
                         this.get_name())), e.message);
                 }
@@ -1008,73 +1007,60 @@ var Removables = class DashToDock_Removables {
 
         this._monitor = Gio.VolumeMonitor.get();
         this._cancellable = new Gio.Cancellable();
-        this._volumeApps = []
-        this._mountApps = []
 
-        this._monitor.get_volumes().forEach(
-            (volume) => {
-                this._onVolumeAdded(this._monitor, volume);
-            }
-        );
-
-        this._monitor.get_mounts().forEach(
-            (mount) => {
-                this._onMountAdded(this._monitor, mount);
-            }
-        );
+        this._monitor.get_mounts().forEach(m => Removables.initMountPromises(m));
+        this._updateVolumes();
 
         this._signalsHandler.add([
             this._monitor,
-            'mount-added',
-            this._onMountAdded.bind(this)
-        ], [
-            this._monitor,
-            'mount-removed',
-            this._onMountRemoved.bind(this)
-        ], [
-            this._monitor,
             'volume-added',
-            this._onVolumeAdded.bind(this)
+            (_, volume) => this._onVolumeAdded(volume),
         ], [
             this._monitor,
             'volume-removed',
-            this._onVolumeRemoved.bind(this)
+            (_, volume) => this._onVolumeRemoved(volume),
+        ], [
+            this._monitor,
+            'mount-added',
+            (_, mount) => this._onMountAdded(mount),
         ]);
     }
 
     destroy() {
-        [...this._volumeApps, ...this._mountApps].forEach(a => a.destroy());
+        this._volumeApps.forEach(a => a.destroy());
         this._volumeApps = [];
-        this._mountApps = [];
         this._cancellable.cancel();
         this._cancellable = null;
         this._signalsHandler.destroy();
         this._monitor = null;
     }
 
-    _onVolumeAdded(monitor, volume) {
+    _updateVolumes() {
+        this._volumeApps?.forEach(a => a.destroy());
+        this._volumeApps = [];
+        this.emit('changed');
+
+        this._monitor.get_volumes().forEach(v => this._onVolumeAdded(v));
+    }
+
+    _onVolumeAdded(volume) {
         Removables.initVolumePromises(volume);
-
-        if (volume.get_mount())
-            return;
-
-        if (!volume.can_mount() && !volume.can_eject()) {
-            return;
-        }
 
         if (volume.get_identifier('class') == 'network') {
             return;
         }
 
-        if (!volume.get_activation_root()) {
-            // Can't offer to mount a device if we don't know
-            // where to mount it.
-            // These devices are usually ejectable so you
-            // don't normally unmount them anyway.
+        const mount = volume.get_mount();
+        if (mount) {
+            if (mount.is_shadowed())
+                return;
+            if (!mount.can_eject() && !mount.can_unmount())
+                return;
+        } else {
             return;
         }
 
-        const appInfo = new VolumeAppInfo(volume, this._cancellable);
+        const appInfo = new MountableVolumeAppInfo(volume, this._cancellable);
         const volumeApp = makeLocationApp({
             appInfo,
             fallbackIconName: FALLBACK_REMOVABLE_MEDIA_ICON,
@@ -1082,11 +1068,13 @@ var Removables = class DashToDock_Removables {
 
         volumeApp._signalConnections.add(volumeApp, 'windows-changed',
             () => this.emit('windows-changed', volumeApp));
+        volumeApp._signalConnections.add(appInfo, 'notify::mount',
+            () => (!appInfo.mount && this._onVolumeRemoved(appInfo.volume)));
         this._volumeApps.push(volumeApp);
         this.emit('changed');
     }
 
-    _onVolumeRemoved(monitor, volume) {
+    _onVolumeRemoved(volume) {
         const volumeIndex = this._volumeApps.findIndex(({ appInfo }) =>
             appInfo.volume === volume);
         if (volumeIndex !== -1) {
@@ -1096,51 +1084,15 @@ var Removables = class DashToDock_Removables {
         }
     }
 
-    _onMountAdded(monitor, mount) {
+    _onMountAdded(mount) {
         Removables.initMountPromises(mount);
 
-        // Filter out uninteresting mounts
-        if (!mount.can_eject() && !mount.can_unmount())
-            return;
-        if (mount.is_shadowed())
-            return;
-
-        let volume = mount.get_volume();
-        if (!volume || volume.get_identifier('class') == 'network') {
-            return;
-        }
-
-        const appInfo = new MountAppInfo(mount, this._cancellable);
-        const mountApp = makeLocationApp({
-            appInfo,
-            fallbackIconName: FALLBACK_REMOVABLE_MEDIA_ICON,
-        });
-        this._mountApps.push(mountApp);
-        this.emit('changed');
-    }
-
-    _onMountRemoved(monitor, mount) {
-        const mountIndex = this._mountApps.findIndex(({ appInfo }) =>
-            appInfo.mount === mount);
-        if (mountIndex !== -1) {
-            const [mountApp] = this._mountApps.splice(mountIndex, 1);
-            mountApp.destroy();
-            this.emit('changed');
-        }
+        if (!this._volumeApps.find(({ appInfo }) => appInfo.mount === mount))
+            this._onVolumeAdded(mount.get_volume());
     }
 
     getApps() {
-        // When we have both a volume app and a mount app, we prefer
-        // the mount app.
-        let apps = new Map();
-        this._volumeApps.map(function(app) {
-           apps.set(app.get_name(), app);
-        });
-        this._mountApps.map(function(app) {
-           apps.set(app.get_name(), app);
-        });
-
-        return [...apps.values()];
+        return this._volumeApps;
     }
 }
 Signals.addSignalMethods(Removables.prototype);

--- a/locations.js
+++ b/locations.js
@@ -596,12 +596,14 @@ function wrapWindowsBackedApp(shellApp) {
 
     m('compare', (_om, other) => shellAppCompare(shellApp, other));
 
+    const { destroy: defaultDestroy } = shellApp;
     shellApp.destroy = function() {
         updateWindowsIdle && GLib.source_remove(updateWindowsIdle);
         this._dtdData.proxyProperties.forEach(p => (delete this[p]));
         this._dtdData.destroy();
         this._dtdData = undefined;
-        this.destroy = undefined;
+        this.destroy = defaultDestroy;
+        defaultDestroy && defaultDestroy.call(this);
     }
 
     return shellApp;

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,8 @@
 {
 "shell-version": [
     "40",
-    "41"
+    "41",
+    "42"
 ],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",

--- a/prefs.js
+++ b/prefs.js
@@ -648,6 +648,10 @@ var Settings = GObject.registerClass({
             this._builder.get_object('show_mounts_switch'),
             'active',
             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-mounts-only-mounted',
+            this._builder.get_object('show_only_mounted_devices_check'),
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('isolate-locations',
             this._builder.get_object('isolate_locations_switch'),
             'active',

--- a/prefs.js
+++ b/prefs.js
@@ -652,6 +652,10 @@ var Settings = GObject.registerClass({
             this._builder.get_object('show_only_mounted_devices_check'),
             'active',
             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-mounts-network',
+            this._builder.get_object('show_network_volumes_check'),
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('isolate-locations',
             this._builder.get_object('isolate_locations_switch'),
             'active',

--- a/prefs.js
+++ b/prefs.js
@@ -224,6 +224,12 @@ var Settings = GObject.registerClass({
         this._icon_size_timeout = 0;
         this._opacity_timeout = 0;
 
+        if (Config.PACKAGE_VERSION.split('.')[0] < 42) {
+            // Remove this when we won't support earlier versions
+            this._builder.get_object('shrink_dash_label1').label =
+                __('Show favorite applications');
+        }
+
         this._monitorsConfig = new MonitorsConfig();
         this._bindSettings();
     }

--- a/prefs.js
+++ b/prefs.js
@@ -26,11 +26,13 @@ try {
     imports.searchPath.push('resource:///org/gnome/Extensions/js');
 }
 
+const Config = imports.misc.config;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 
 const SCALE_UPDATE_TIMEOUT = 500;
 const DEFAULT_ICONS_SIZES = [128, 96, 64, 48, 32, 24, 16];
+const [SHELL_VERSION] = Config?.PACKAGE_VERSION?.split('.') ?? [undefined];
 
 const TransparencyMode = {
     DEFAULT: 0,
@@ -202,14 +204,19 @@ var Settings = GObject.registerClass({
             this._builder.add_from_file('./Settings.ui');
         }
 
-        this.widget = new Gtk.ScrolledWindow({ hscrollbar_policy: Gtk.PolicyType.NEVER });
+        this.widget = new Gtk.ScrolledWindow({
+            hscrollbar_policy: Gtk.PolicyType.NEVER,
+            vscrollbar_policy: (SHELL_VERSION >= 42) ?
+                Gtk.PolicyType.NEVER : Gtk.PolicyType.AUTOMATIC,
+        });
         this._notebook = this._builder.get_object('settings_notebook');
         this.widget.set_child(this._notebook);
 
         // Set a reasonable initial window height
         this.widget.connect('realize', () => {
-            const window = this.widget.get_root();
-            window.set_size_request(-1, 750);
+            this.widget.get_root().set_size_request(-1, 850);
+            if (SHELL_VERSION >= 42)
+                this.widget.set_size_request(-1, 850);
         });
 
         // Timeout to delay the update of the settings

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -247,6 +247,11 @@
       <summary>Show mounted volumes and devices</summary>
       <description>Show or hide mounted volume and device icons in the dash</description>
     </key>
+    <key type="b" name="show-mounts-only-mounted">
+      <default>true</default>
+      <summary>Only show mounted volumes and devices</summary>
+      <description>Show or hide unmounted volume and device icons in the dash</description>
+    </key>
     <key type="b" name="isolate-locations">
       <default>true</default>
       <summary>Isolate volumes, devices and trash windows</summary>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -252,6 +252,11 @@
       <summary>Only show mounted volumes and devices</summary>
       <description>Show or hide unmounted volume and device icons in the dash</description>
     </key>
+    <key type="b" name="show-mounts-network">
+      <default>false</default>
+      <summary>Show network mounted volumes</summary>
+      <description>Show or hide network volumes in the dash</description>
+    </key>
     <key type="b" name="isolate-locations">
       <default>true</default>
       <summary>Isolate volumes, devices and trash windows</summary>

--- a/utils.js
+++ b/utils.js
@@ -50,6 +50,14 @@ const BasicHandler = class DashToDock_BasicHandler {
             this.removeWithLabel(label);
     }
 
+    block() {
+        Object.keys(this._storage).forEach(label => this.blockWithLabel(label));
+    }
+
+    unblock() {
+        Object.keys(this._storage).forEach(label => this.unblockWithLabel(label));
+    }
+
     addWithLabel(label, ...args) {
         let argsArray = [...args];
         if (argsArray.every(arg => !Array.isArray(arg)))
@@ -76,6 +84,14 @@ const BasicHandler = class DashToDock_BasicHandler {
         delete this._storage[label];
     }
 
+    blockWithLabel(label) {
+        (this._storage[label] || []).forEach(item => this._block(item));
+    }
+
+    unblockWithLabel(label) {
+        (this._storage[label] || []).forEach(item => this._unblock(item));
+    }
+
     // Virtual methods to be implemented by subclass
 
     /**
@@ -90,6 +106,20 @@ const BasicHandler = class DashToDock_BasicHandler {
      */
     _remove(_item) {
         throw new GObject.NotImplementedError(`_remove in ${this.constructor.name}`);
+    }
+
+    /**
+     * Block single element
+     */
+    _block(_item) {
+        throw new GObject.NotImplementedError(`_block in ${this.constructor.name}`);
+    }
+
+    /**
+     * Unblock single element
+     */
+    _unblock(_item) {
+        throw new GObject.NotImplementedError(`_unblock in ${this.constructor.name}`);
     }
 };
 
@@ -119,6 +149,20 @@ var GlobalSignalsHandler = class DashToDock_GlobalSignalHandler extends BasicHan
     _remove(item) {
         const [object, id] = item;
         object.disconnect(id);
+    }
+
+    _block(item) {
+        const [object, id] = item;
+
+        if (object instanceof GObject.Object)
+            GObject.Object.prototype.block_signal_handler.call(object, id);
+    }
+
+    _unblock(item) {
+        const [object, id] = item;
+
+        if (object instanceof GObject.Object)
+            GObject.Object.prototype.unblock_signal_handler.call(object, id);
     }
 };
 

--- a/utils.js
+++ b/utils.js
@@ -515,3 +515,25 @@ function shellAppCompare(appA, appB) {
 
     return 0;
 }
+
+// Re-implements shell_app_compare_windows
+function shellWindowsCompare(winA, winB) {
+    const activeWorkspace = global.workspaceManager.get_active_workspace();
+    const wsA = winA.get_workspace() === activeWorkspace;
+    const wsB = winB.get_workspace() === activeWorkspace;
+
+    if (wsA && !wsB)
+        return -1;
+    else if (!wsA && wsB)
+        return 1;
+
+    const visA = winA.showing_on_its_workspace();
+    const visB = winB.showing_on_its_workspace();
+
+    if (visA && !visB)
+        return -1;
+    else if (!visA && visB)
+        return 1;
+
+    return winB.get_user_time() - winA.get_user_time();
+}

--- a/utils.js
+++ b/utils.js
@@ -417,3 +417,23 @@ var IconTheme = class DashToDockIconTheme {
         this._iconTheme = null;
     }
 }
+
+/**
+ * Construct a map of gtk application window object paths to MetaWindows.
+ */
+function getWindowsByObjectPath() {
+    const windowsByObjectPath = new Map();
+    const { workspaceManager } = global;
+    const workspaces = [...new Array(workspaceManager.nWorkspaces)].map(
+        (_c, i) => workspaceManager.get_workspace_by_index(i));
+
+    workspaces.forEach(ws => {
+        ws.list_windows().forEach(w => {
+            const path = w.get_gtk_window_object_path();
+            if (path != null)
+                windowsByObjectPath.set(path, w);
+        });
+    });
+
+    return windowsByObjectPath;
+}


### PR DESCRIPTION
Refactor locations handling to have a more native Shell integration.

A part the various improvements and features, the main trigger for this was (as per the main commit message):

```
As per gjs 1.72 it won't be possible to inject an interface vfunc as it
used to work in previous versions, this would make gnome-shell to crash
as we may try to get the location "apps" ID which is now null (and not
customId anymore).

So, let's re-implement the things in a cleaner way by actually using
real custom AppInfo's that are still based on Gio.DesktopAppInfo
(beause the shell will still need to be such type), but that are
implementing the needed virtual functions of the parent interface.

As per this, we can finally use native shell mount operations to handle
mount options such as mounting encrypted disks.
```