### PR TITLE
Adds an intellihide mode for always-on-top (on non-fullscreen windows)

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -2688,6 +2688,13 @@ See the &lt;a href=&quot;https://www.gnu.org/licenses/old-licenses/gpl-2.0.html&
                             <signal name="toggled" handler="maximized_windows_radio_button_toggled_cb" />
                           </object>
                         </child>
+                        <child>
+                          <object class="GtkCheckButton" id="always_on_top_radio_button">
+                            <property name="label" translatable="yes">Always on top</property>
+                            <property name="group">all_windows_radio_button</property>
+                            <signal name="toggled" handler="always_on_top_radio_button_toggled_cb" />
+                          </object>
+                        </child>
                         <layout>
                           <property name="column">0</property>
                           <property name="row">2</property>

--- a/intellihide.js
+++ b/intellihide.js
@@ -23,7 +23,8 @@ const OverlapStatus = {
 const IntellihideMode = {
     ALL_WINDOWS: 0,
     FOCUS_APPLICATION_WINDOWS: 1,
-    MAXIMIZED_WINDOWS : 2
+    MAXIMIZED_WINDOWS: 2,
+    ALWAYS_ON_TOP: 3,
 };
 
 // List of windows type taken into account. Order is important (keep the original
@@ -283,6 +284,15 @@ var Intellihide = class DashToDock_Intellihide {
                 // Skip unmaximized windows
                 if (!meta_win.maximized_vertically && !meta_win.maximized_horizontally)
                     return false;
+                break;
+
+            case IntellihideMode.ALWAYS_ON_TOP:
+                // Always on top, except for fullscreen windows
+                if (this._focusApp) {
+                    const { focusWindow } = global.display;
+                    if (!focusWindow?.fullscreen)
+                        return false;
+                }
                 break;
         }
 

--- a/prefs.js
+++ b/prefs.js
@@ -342,6 +342,11 @@ var Settings = GObject.registerClass({
             this._settings.set_enum('intellihide-mode', 2);
     }
 
+    always_on_top_radio_button_toggled_cb(button) {
+        if (button.get_active())
+            this._settings.set_enum('intellihide-mode', 3);
+    }
+
     _updateMonitorsSettings() {
         // Monitor options
         const preferredMonitor = this._settings.get_int('preferred-monitor');
@@ -477,7 +482,8 @@ var Settings = GObject.registerClass({
             let intellihideModeRadioButtons = [
                 this._builder.get_object('all_windows_radio_button'),
                 this._builder.get_object('focus_application_windows_radio_button'),
-                this._builder.get_object('maximized_windows_radio_button')
+                this._builder.get_object('maximized_windows_radio_button'),
+                this._builder.get_object('always_on_top_radio_button'),
             ];
 
             intellihideModeRadioButtons[this._settings.get_enum('intellihide-mode')].set_active(true);

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -29,6 +29,7 @@
     <value value='0' nick='ALL_WINDOWS'/>
     <value value='1' nick='FOCUS_APPLICATION_WINDOWS'/>
     <value value='2' nick='MAXIMIZED_WINDOWS'/>
+    <value value='3' nick='ALWAYS_ON_TOP'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-dock.transparency-mode'>
     <value value='0' nick='DEFAULT'/>


### PR DESCRIPTION
Does as indicated in the title, useful for smaller screens where you want dash availability without giving up all of the vertical space.