### PR TITLE
[DNM]metadata.json: Add 42 to shell version list

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,8 @@
 {
 "shell-version": [
     "40",
-    "41"
+    "41",
+    "42"
 ],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",


### PR DESCRIPTION
This extension works absolutely flawlessly on GNOME 42.

So lets add GNOME 42 to the supported shell version.