### PR TITLE
Fix stylesheet for gnome 42

### DIFF
--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -1,26 +1,25 @@
 // From https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/c17dc9c8ecba0b542aab75f13da238f7b0690031/data/theme/gnome-shell-sass/_common.scss#L28
 $base_padding: 6px;
 $base_margin: 4px;
-$base_spacing: 6px;
 
+// border radii
 $base_border_radius: 8px;
-$modal_radius: $base_border_radius * 2;
+
+// radii of things that display over other things, e.g. popovers
+$modal_radius: $base_border_radius*2; // 24px
+
 
 // From https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/c17dc9c8ecba0b542aab75f13da238f7b0690031/data/theme/gnome-shell-sass/widgets/_dash.scss
 $dash_background_color: #3b3b3b;
 $dash_placeholder_size: 32px;
-$dash_padding: $base_padding + 4px; // 10px
-$dash_spacing: round($base_padding / 4);
-$dash_edge_items_padding: $dash_padding - $dash_spacing;
-$dash_bottom_margin: $base_margin * 4;
-$dash_border_radius: $modal_radius * 1.5;
+$dash_padding: $base_padding*2; // 12px
 
-// Stock
-$dock_start_margin: $dash_bottom_margin;
-$dock_side_margin: $dock_start_margin / 4;
-$dock_fixed_inner_margin: $dock_side_margin;
 
-// Adapted to $dock_bottom_margin
+$dash_edge_items_padding: $dash_padding - $base_padding;
+
+$dash_margin: $dash_padding;
+
+$dash_border_radius: $modal_radius + $dash_padding;
 
 @function shrink($val) {
     @return round($val / 4);
@@ -51,12 +50,15 @@ $osd_fg_color: #eeeeec;
 @each $side in bottom, top, left, right {
     #dashtodockContainer.#{$side} {
         #dash {
-            margin: 0px;
             padding: 0px;
+            @if is_horizontal($side) {
+                margin: $dash_margin 0;
+            } @else {
+                margin: 0 $dash_margin;
+            }
 
             .dash-background {
                 margin: 0;
-                margin-#{$side}: $dock_side_margin;
                 padding: 0;
             }
 
@@ -66,22 +68,29 @@ $osd_fg_color: #eeeeec;
                     margin-bottom: 0;
                 } @else {
                     height: 1px;
-                    margin: ($dash_spacing + ($dash_padding / 2)) 0;
                 }
             }
 
             #dashtodockDashContainer {
                 padding: $dash_padding;
-                padding-#{$side}: 0;
-                padding-#{opposite($side)}: 0;
             }
 
             .dash-item-container {
+                > * {
+                    @if is_horizontal($side) {
+                        margin: 0 2px;
+                        &:ltr:first-child { margin-left: 0; }
+                        &:rtl:last-child { margin-right: 0; }
+                    } @else {
+                        margin: 2px 0;
+                        &:ltr:first-child { margin-top: 0; }
+                        &:rtl:last-child { margin-bottom: 0; }
+                    }
+                }
+
                 .app-well-app,
                 .show-apps {
-                    padding: $dash_spacing;
-                    padding-#{$side}: $dash_padding + $dock_side_margin;
-                    padding-#{opposite($side)}: $dash_padding;
+                    padding: 0;
                 }
 
                 .app-well-app {
@@ -98,61 +107,35 @@ $osd_fg_color: #eeeeec;
                     background-size: contain;
                 }
             }
+
+            .app-well-app-running-dot {
+                margin-bottom: 2px;
+            }
         }
 
         &.shrink {
             #dash {
+                @if is_horizontal($side) {
+                    margin: shrink_light($dash_margin) 0;
+                } @else {
+                    margin: 0 shrink_light($dash_margin);
+                }
                 .dash-background {
-                    margin-#{$side}: $dock_side_margin;
-                    padding: shrink($dash_padding);
+                    margin: 0;
+                    padding: 0;
                     border-radius: shrink_light($dash_border_radius);
                 }
 
                 #dashtodockDashContainer {
-                    padding: shrink($dash_padding);
-                }
-
-                .dash-item-container {
-                    .app-well-app,
-                    .show-apps {
-                        padding: shrink($dash_spacing);
-                        padding-#{$side}: shrink($dash_padding) + $dock_side_margin;
-                        padding-#{opposite($side)}: shrink($dash_padding);
-                    }
-                }
-            }
-
-            &.fixed {
-                #dash {
-                    .dash-background {
-                        margin-#{opposite($side)}: shrink($dock_fixed_inner_margin);
-                    }
-
-                    .dash-item-container {
-                        .app-well-app,
-                        .show-apps {
-                            padding-#{opposite($side)}: shrink($dash_padding + $dock_fixed_inner_margin);
-                        }
-                    }
-                }
-            }
-        }
-
-        &.fixed {
-            #dash {
-                .dash-background {
-                    margin-#{opposite($side)}: $dock_fixed_inner_margin;
-                }
-
-                .dash-item-container {
-                    .app-well-app,
-                    .show-apps {
-                        padding-#{opposite($side)}: $dash_padding + $dock_fixed_inner_margin;
-                    }
+                    padding: shrink_light($dash_padding);
                 }
             }
         }
     }
+}
+
+.dash-label {
+    margin: $dash_padding * 1.5;
 }
 
 @mixin padded-edge-child($chid, $side, $padding) {
@@ -201,6 +184,8 @@ $osd_fg_color: #eeeeec;
 @each $side in bottom, top, left, right {
     #dashtodockContainer.extended.#{$side} {
         #dash {
+            margin: 0;
+
             .dash-background {
                 margin: 0;
                 border-radius: 0;

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -340,3 +340,8 @@ $osd_fg_color: #eeeeec;
         background-size: contain;
     }
 }
+
+// Rise volume and workspace-switcher osd dialogs
+.osd-window, .workspace-switcher {
+  margin-bottom: 128px;
+}

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -644,7 +644,7 @@ var UnityIndicator = class DashToDock_UnityIndicator extends IndicatorBase {
 
         super(source);
 
-        this._notificationBadgeLabel = new St.Label();
+        this._notificationBadgeLabel = new St.Label({ style_class: 'dash-label' });
         this._notificationBadgeBin = new St.Bin({
             child: this._notificationBadgeLabel,
             x_align: Clutter.ActorAlign.END,


### PR DESCRIPTION
With the update to gnome 42 the new updated branch ubuntu-dock works great but the stylesheet didn't get completely updated. Some of the spacings and margings look odd. This patch fixes it 

### Old:
![Captura desde 2022-04-21 10-40-23](https://user-images.githubusercontent.com/12565871/164416275-56533e81-ab0a-4678-a6ca-4b827d67f0b1.png)
### New:
![image](https://user-images.githubusercontent.com/12565871/164416520-4fd51f1c-af18-4c37-9eb0-9ed050d6d3d9.png)

