### PR TITLE
Quick fix to allow use on Gnome 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,8 @@
 {
 "shell-version": [
     "40",
-    "41"
+    "41",
+    "42"
 ],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",


### PR DESCRIPTION
This just adds 

`, "42"`

to the extension's metadata so it will load on Gnome 42 (Fedora 36)