### PR TITLE
[dash-to-dock] Don't autohide while a menu is open

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -649,6 +649,8 @@ var DockAbstractAppIcon = GObject.registerClass({
 
         }
 
+        this.emit('menu-state-changed', !this._previewMenu.isOpen);
+
         if (this._previewMenu.isOpen)
             this._previewMenu.close();
         else

--- a/dash.js
+++ b/dash.js
@@ -83,6 +83,7 @@ var DockDash = GObject.registerClass({
             false),
     },
     Signals: {
+        'menu-opened': {},
         'menu-closed': {},
         'icon-size-changed': {},
     }
@@ -579,7 +580,9 @@ var DockDash = GObject.registerClass({
     _itemMenuStateChanged(item, opened) {
         Dash.Dash.prototype._itemMenuStateChanged.call(this, item, opened);
 
-        if (!opened) {
+        if (opened) {
+            this.emit('menu-opened');
+        } else {
             // I want to listen from outside when a menu is closed. I used to
             // add a custom signal to the appIcon, since gnome 3.8 the signal
             // calling this callback was added upstream.

--- a/docking.js
+++ b/docking.js
@@ -298,10 +298,14 @@ var DockedDash = GObject.registerClass({
             'status-changed',
             this._updateDashVisibility.bind(this)
         ], [
+            this.dash,
+            'menu-opened',
+            () => { this._onMenuOpened() }
+        ], [
             // sync hover after a popupmenu is closed
             this.dash,
             'menu-closed',
-            () => { this._box.sync_hover() }
+            () => { this._onMenuClosed() }
         ], [
             this.dash,
             'notify::requires-visibility',
@@ -688,6 +692,16 @@ var DockedDash = GObject.registerClass({
 
     _onOverviewHidden() {
         this.remove_style_class_name('overview');
+    }
+
+    _onMenuOpened() {
+        this._ignoreHover = true;
+    }
+
+    _onMenuClosed() {
+        this._ignoreHover = false;
+        this._box.sync_hover();
+        this._hoverChanged();
     }
 
     _hoverChanged() {


### PR DESCRIPTION
Fixes #1714, #1755 and https://launchpad.net/bugs/1967121

Also fixed in ubuntu-dock via #1739