### PR TITLE
Add compatibility with DING for Dynamic Transparency

### DIFF
--- a/theming.js
+++ b/theming.js
@@ -456,7 +456,8 @@ var Transparency = class DashToDock_Transparency {
         let windows = activeWorkspace.list_windows().filter(function(metaWindow) {
             return metaWindow.get_monitor() === dash._monitorIndex &&
                    metaWindow.showing_on_its_workspace() &&
-                   metaWindow.get_window_type() != Meta.WindowType.DESKTOP;
+                   metaWindow.get_window_type() !== Meta.WindowType.DESKTOP &&
+                   (!Meta.is_wayland_compositor() || !metaWindow.skip_taskbar);
         });
 
         /* Check if at least one window is near enough to the panel.


### PR DESCRIPTION
This patch adds compatibility with Desktop Icons NG for Dynamic Transparency functionality by taking into account that, under Wayland, the "skip-taskbar" property can be set only under very specific circumstances (that, currently, only DING does fulfill).

You can read about issue details at https://gitlab.com/rastersoft/desktop-icons-ng/-/issues/230 