### PR TITLE
metadata: Add support for gnome-shell 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
 "shell-version": [
     "40",
     "41",
-    "42"
+    "42",
+    "43"
 ],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",


### PR DESCRIPTION
Works without a hitch (functionality wise, afaict) in GNOME 43.alpha.

Using [FCGU](https://gitlab.com/fabiscafe/gnome-unstable) repo and [AUR](https://wiki.archlinux.org/title/Arch_User_Repository) package [gnome-shell-extension-dash-to-dock43](https://aur.archlinux.org/packages/gnome-shell-extension-dash-to-dock43) to test.

![Schermafdruk van 2022-07-14 18-09-27](https://user-images.githubusercontent.com/981494/179027848-26686683-0b2d-4678-b362-f1b415148aaa.png)

There's a JS error reported in the logs, however, this doesn't seem to hinder functionality.

```shell
jul 14 17:58:19 x11sslf gnome-shell[256233]: JS ERROR: Exception in callback for signal: open-state-changed: TypeError: this.setForcedHighlight is not a function
                                             _onMenuPoppedDown@resource:///org/gnome/shell/ui/appDisplay.js:3209:14
                                             _onMenuPoppedDown@/usr/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIcons.js:1292:56
                                             popupMenu/<@/usr/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIcons.js:1311:26
                                             _emit@resource:///org/gnome/gjs/modules/core/_signals.js:114:47
                                             close@resource:///org/gnome/shell/ui/popupMenu.js:941:14
                                             itemActivated@resource:///org/gnome/shell/ui/popupMenu.js:603:28
                                             _connectItemSignals/<@resource:///org/gnome/shell/ui/popupMenu.js:640:22
                                             activate@resource:///org/gnome/shell/ui/popupMenu.js:197:14
                                             vfunc_button_release_event@resource:///org/gnome/shell/ui/popupMenu.js:141:14

```
