### PR TITLE
Ensure that PanelCorner has given properties before checking the value

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2415,7 +2415,7 @@ var DockManager = class DashToDock_DockManager {
      * Adjust Panel corners, remove this when 41 won't be supported anymore
      */
     _adjustPanelCorners() {
-        if (!Main.panel._rightCorner || !Main.panel._leftCorner)
+        if (!this._hasPanelCorners())
             return;
 
         let position = Utils.getPosition();
@@ -2432,8 +2432,22 @@ var DockManager = class DashToDock_DockManager {
     }
 
     _revertPanelCorners() {
-        Main.panel._leftCorner?.show();
-        Main.panel._rightCorner?.show();
+        if (!this._hasPanelCorners())
+            return;
+
+        Main.panel._leftCorner.show();
+        Main.panel._rightCorner.show();
+    }
+
+    _hasPanelCorners() {
+        if (!Object.hasOwn(Main.panel, '_rightCorner') ||
+            !Object.hasOwn(Main.panel, '_leftCorner')) {
+            return false;
+        } else if (!Main.panel._rightCorner || !Main.panel._leftCorner) {
+            return false;
+        }
+
+        return true;
     }
 };
 Signals.addSignalMethods(DockManager.prototype);


### PR DESCRIPTION
Since Gnome42 has deprecated panel corners, for optimum backwards compatibility the method `_adjustPanelCorners` and `_revertPanelCorners` should first check if the `PanelCorner` has the left and right corner, and only then check for its value.

Source for Gnome42 port documentation: https://gjs.guide/extensions/upgrading/gnome-shell-42.html#panel-corner