### PR TITLE
Added option to turn on/off show dock for urgent notifications

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -2663,6 +2663,18 @@ See the &lt;a href=&quot;https://www.gnu.org/licenses/old-licenses/gpl-2.0.html&
                         </layout>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkCheckButton" id="show_dock_urgent_notify_checkbutton">
+                        <property name="label" translatable="yes">Show dock for urgent notifications</property>
+                        <property name="margin_top">12</property>
+
+                        <layout>
+                          <property name="column">0</property>
+                          <property name="row">4</property>
+                          <property name="column-span">2</property>
+                        </layout>
+                      </object>
+                    </child>
                   </object>
                 </property>
               </object>

--- a/dash.js
+++ b/dash.js
@@ -525,7 +525,12 @@ var DockDash = GObject.registerClass({
         appIcon.connect('notify::urgent', () => {
             if (appIcon.urgent) {
                 ensureActorVisibleInScrollView(this._scrollView, item);
-                this._requireVisibility();
+                const { settings } = Docking.DockManager;
+                const showDockUrgentNotify = settings.showDockUrgentNotify;
+                
+                if (showDockUrgentNotify) {
+                    this._requireVisibility();
+                }
             }
         });
 

--- a/docking.js
+++ b/docking.js
@@ -585,6 +585,11 @@ var DockedDash = GObject.registerClass({
             settings,
             'changed::autohide-in-fullscreen',
             this._updateBarrier.bind(this)
+        ], [
+            settings,
+            'changed::show-dock-urgent-notify',
+            () => { 
+                this.dash.resetAppIcons(); }
         ],
         [
             settings,

--- a/prefs.js
+++ b/prefs.js
@@ -452,6 +452,10 @@ var Settings = GObject.registerClass({
             this._builder.get_object('autohide_enable_in_fullscreen_checkbutton'),
             'active',
             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-dock-urgent-notify',
+            this._builder.get_object('show_dock_urgent_notify_checkbutton'),
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('require-pressure-to-show',
             this._builder.get_object('require_pressure_checkbutton'),
             'active',
@@ -522,6 +526,11 @@ var Settings = GObject.registerClass({
                 'sensitive',
                 Gio.SettingsBindFlags.GET);
 
+            this._settings.bind('autohide',
+                this._builder.get_object('show_dock_urgent_notify_checkbutton'),
+                'sensitive',
+                Gio.SettingsBindFlags.GET);
+
             this._settings.bind('require-pressure-to-show',
                 this._builder.get_object('show_timeout_spinbutton'),
                 'sensitive',
@@ -542,7 +551,7 @@ var Settings = GObject.registerClass({
             dialog.connect('response', (dialog, id) => {
                 if (id == 1) {
                     // restore default settings for the relevant keys
-                    let keys = ['intellihide', 'autohide', 'intellihide-mode', 'autohide-in-fullscreen', 'require-pressure-to-show',
+                    let keys = ['intellihide', 'autohide', 'intellihide-mode', 'autohide-in-fullscreen', 'show-dock-urgent-notify', 'require-pressure-to-show',
                         'animation-time', 'show-delay', 'hide-delay', 'pressure-threshold'];
                     keys.forEach(function (val) {
                         this._settings.set_value(val, this._settings.get_default_value(val));

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -153,6 +153,11 @@
       <summary>Enable autohide in fullscreen mode.</summary>
       <description>Enable autohide in fullscreen mode.</description>
     </key>
+    <key type="b" name="show-dock-urgent-notify">
+      <default>true</default>
+      <summary>Show dock for urgent notifications.</summary>
+      <description>Show dock when urgent notifications are received.</description>
+    </key>
     <key type="b" name="dock-fixed">
       <default>false</default>
       <summary>Dock always visible</summary>


### PR DESCRIPTION
This is to fix the issue: Prevent dock from popping out when gnome is in do-not-disturb   #1634 

The users will be able to choose in the intelligent hide settings whether they want the dock to be shown for urgent notifications or not. 