### PR TITLE
docking: Check for corners availability using standard checks

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2247,14 +2247,16 @@ var DockManager = class DashToDock_DockManager {
                 return box;
             });
 
-        // Ensure we handle Dnd events happening on the dock when we're dragging from AppDisplay
-        // Remove when merged https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2002
-        this._methodInjections.addWithLabel('main-dash', AppDisplay.BaseAppView.prototype,
-            '_pageForCoords', function (originalFunction, ...args) {
-                if (!this._scrollView.has_pointer)
-                    return AppDisplay.SidePages.NONE;
-                return originalFunction.call(this, ...args);
-            });
+        if (AppDisplay.BaseAppView?.prototype?._pageForCoords) {
+            // Ensure we handle Dnd events happening on the dock when we're dragging from AppDisplay
+            // Remove when merged https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2002
+            this._methodInjections.addWithLabel('main-dash', AppDisplay.BaseAppView.prototype,
+                '_pageForCoords', function (originalFunction, ...args) {
+                    if (!this._scrollView.has_pointer)
+                        return AppDisplay.SidePages.NONE;
+                    return originalFunction.call(this, ...args);
+                });
+        }
 
         if (Main.layoutManager._startingUp && Main.sessionMode.hasOverview &&
             this._settings.disableOverviewOnStartup) {

--- a/docking.js
+++ b/docking.js
@@ -2445,14 +2445,7 @@ var DockManager = class DashToDock_DockManager {
     }
 
     _hasPanelCorners() {
-        if (!Object.hasOwn(Main.panel, '_rightCorner') ||
-            !Object.hasOwn(Main.panel, '_leftCorner')) {
-            return false;
-        } else if (!Main.panel._rightCorner || !Main.panel._leftCorner) {
-            return false;
-        }
-
-        return true;
+        return !!Main.panel?._rightCorner && !!Main.panel?._leftCorner;
     }
 };
 Signals.addSignalMethods(DockManager.prototype);


### PR DESCRIPTION
Object.hasOwn isn't supported by mozjs 91