### PR TITLE
Preserve dock opacity in shell overview when draging window preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,39 @@
 # Basic Makefile
 
 UUID = dash-to-dock@micxgx.gmail.com
-BASE_MODULES = extension.js metadata.json COPYING README.md
-EXTRA_MODULES = dash.js docking.js appIcons.js appIconIndicators.js fileManager1API.js launcherAPI.js locations.js windowPreview.js intellihide.js prefs.js theming.js utils.js dbusmenuUtils.js Settings.ui desktopIconsIntegration.js
-EXTRA_MEDIA = logo.svg glossy.svg highlight_stacked_bg.svg highlight_stacked_bg_h.svg
-TOLOCALIZE =  prefs.js appIcons.js locations.js
+BASE_MODULES = extension.js \
+               metadata.json \
+               COPYING \
+               README.md \
+               $(NULL)
+
+EXTRA_MODULES = dash.js \
+                docking.js \
+                appIcons.js \
+                appIconIndicators.js \
+                fileManager1API.js \
+                launcherAPI.js \
+                locations.js \
+                windowPreview.js \
+                intellihide.js \
+                prefs.js \
+                theming.js \
+                utils.js \
+                dbusmenuUtils.js \
+                Settings.ui desktopIconsIntegration.js \
+                $(NULL)
+
+EXTRA_MEDIA = logo.svg \
+              glossy.svg \
+              highlight_stacked_bg.svg \
+              highlight_stacked_bg_h.svg \
+              $(NULL)
+
+TOLOCALIZE =  prefs.js \
+              appIcons.js \
+              locations.js \
+              $(NULL)
+
 MSGSRC = $(wildcard po/*.po)
 ifeq ($(strip $(DESTDIR)),)
 	INSTALLTYPE = local

--- a/appIcons.js
+++ b/appIcons.js
@@ -41,6 +41,11 @@ const DbusmenuUtils = Me.imports.dbusmenuUtils;
 
 const tracker = Shell.WindowTracker.get_default();
 
+const Labels = Object.freeze({
+    ISOLATE_MONITORS: Symbol('isolate-monitors'),
+    URGENT_WINDOWS: Symbol('urgent-windows'),
+});
+
 const clickAction = {
     SKIP: 0,
     MINIMIZE: 1,
@@ -130,8 +135,8 @@ var DockAbstractAppIcon = GObject.registerClass({
         // and if there are at least 2 monitors.
         if (Docking.DockManager.settings.isolateMonitors &&
             Main.layoutManager.monitors.length > 1) {
-            this._signalsHandler.removeWithLabel('isolate-monitors');
-            this._signalsHandler.addWithLabel('isolate-monitors',
+            this._signalsHandler.removeWithLabel(Labels.ISOLATE_MONITORS);
+            this._signalsHandler.addWithLabel(Labels.ISOLATE_MONITORS,
                 global.display,
                 'window-entered-monitor',
                 this._onWindowEntered.bind(this));
@@ -153,7 +158,7 @@ var DockAbstractAppIcon = GObject.registerClass({
 
         this.connect('notify::urgent', () => {
             const icon = this.icon._iconBin;
-            this._signalsHandler.removeWithLabel('urgent-windows')
+            this._signalsHandler.removeWithLabel(Labels.URGENT_WINDOWS)
             if (this.urgent) {
                 icon.set_pivot_point(0.5, 0.5);
                 this.iconAnimator.addAnimation(icon, 'dance');
@@ -297,7 +302,7 @@ var DockAbstractAppIcon = GObject.registerClass({
     }
 
     _updateUrgentWindows(interestingWindows) {
-        this._signalsHandler.removeWithLabel('urgent-windows')
+        this._signalsHandler.removeWithLabel(Labels.URGENT_WINDOWS)
         this._urgentWindows.clear();
         if (interestingWindows === undefined)
             interestingWindows = this.getInterestingWindows();
@@ -328,13 +333,13 @@ var DockAbstractAppIcon = GObject.registerClass({
         };
 
         if (window.demandsAttention)
-            this._signalsHandler.addWithLabel('urgent-windows', window,
+            this._signalsHandler.addWithLabel(Labels.URGENT_WINDOWS, window,
                 'notify::demands-attention', () => onDemandsAttentionChanged());
         if (window.urgent)
-            this._signalsHandler.addWithLabel('urgent-windows', window,
+            this._signalsHandler.addWithLabel(Labels.URGENT_WINDOWS, window,
                 'notify::urgent', () => onDemandsAttentionChanged());
         if (window._manualUrgency) {
-            this._signalsHandler.addWithLabel('urgent-windows', window,
+            this._signalsHandler.addWithLabel(Labels.URGENT_WINDOWS, window,
                 'focus', () => {
                     delete window._manualUrgency;
                     onDemandsAttentionChanged()

--- a/dash.js
+++ b/dash.js
@@ -285,6 +285,11 @@ var DockDash = GObject.registerClass({
             GLib.source_remove(this._requiresVisibilityTimeout);
             delete this._requiresVisibilityTimeout;
         }
+
+        if (this._ensureActorVisibilityTimeoutId) {
+            GLib.source_remove(this._ensureActorVisibilityTimeoutId);
+            delete this._ensureActorVisibilityTimeoutId;
+        }
     }
 
 

--- a/dash.js
+++ b/dash.js
@@ -29,6 +29,11 @@ const DASH_ITEM_LABEL_HIDE_TIME = Dash.DASH_ITEM_LABEL_HIDE_TIME;
 const DASH_ITEM_HOVER_TIMEOUT = Dash.DASH_ITEM_HOVER_TIMEOUT;
 const DASH_VISIBILITY_TIMEOUT = 3;
 
+const Labels = Object.freeze({
+    SHOW_MOUNTS: Symbol('show-mounts'),
+    FIRST_LAST_CHILD_WORKAROUND: Symbol('first-last-child-workaround'),
+});
+
 /**
  * Extend DashItemContainer
  *
@@ -777,9 +782,9 @@ var DockDash = GObject.registerClass({
             });
         }
 
-        this._signalsHandler.removeWithLabel('show-mounts');
+        this._signalsHandler.removeWithLabel(Labels.SHOW_MOUNTS);
         if (dockManager.removables) {
-            this._signalsHandler.addWithLabel('show-mounts',
+            this._signalsHandler.addWithLabel(Labels.SHOW_MOUNTS,
                 dockManager.removables, 'changed', this._queueRedisplay.bind(this));
             dockManager.removables.getApps().forEach(removable => {
                 if (!newApps.includes(removable))
@@ -1026,7 +1031,7 @@ var DockDash = GObject.registerClass({
 
     updateShowAppsButton() {
         const notifiedProperties = [];
-        this._signalsHandler.addWithLabel('first-last-child-workaround',
+        this._signalsHandler.addWithLabel(Labels.FIRST_LAST_CHILD_WORKAROUND,
             this._dashContainer, 'notify',
             (_obj, pspec) => notifiedProperties.push(pspec.name));
 
@@ -1036,7 +1041,7 @@ var DockDash = GObject.registerClass({
             this._dashContainer.set_child_above_sibling(this._showAppsIcon, null);
         }
 
-        this._signalsHandler.removeWithLabel('first-last-child-workaround');
+        this._signalsHandler.removeWithLabel(Labels.FIRST_LAST_CHILD_WORKAROUND);
 
         // This is indeed ugly, but we need to ensure that the last and first
         // visible widgets are re-computed by St, that is buggy because of a

--- a/dash.js
+++ b/dash.js
@@ -241,18 +241,6 @@ var DockDash = GObject.registerClass({
             Main.overview,
             'item-drag-cancelled',
             this._onItemDragCancelled.bind(this)
-        ], [
-            Main.overview,
-            'window-drag-begin',
-            this._onWindowDragBegin.bind(this)
-        ], [
-            Main.overview,
-            'window-drag-cancelled',
-            this._onWindowDragEnd.bind(this)
-        ], [
-            Main.overview,
-            'window-drag-end',
-            this._onWindowDragEnd.bind(this)
         ]);
 
         this.connect('destroy', this._onDestroy.bind(this));

--- a/dash.js
+++ b/dash.js
@@ -281,8 +281,10 @@ var DockDash = GObject.registerClass({
     _onDestroy() {
         this.iconAnimator.destroy();
 
-        if (this._requiresVisibilityTimeout)
+        if (this._requiresVisibilityTimeout) {
             GLib.source_remove(this._requiresVisibilityTimeout);
+            delete this._requiresVisibilityTimeout;
+        }
     }
 
 

--- a/docking.js
+++ b/docking.js
@@ -2247,14 +2247,16 @@ var DockManager = class DashToDock_DockManager {
                 return box;
             });
 
-        // Ensure we handle Dnd events happening on the dock when we're dragging from AppDisplay
-        // Remove when merged https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2002
-        this._methodInjections.addWithLabel('main-dash', AppDisplay.BaseAppView.prototype,
-            '_pageForCoords', function (originalFunction, ...args) {
-                if (!this._scrollView.has_pointer)
-                    return AppDisplay.SidePages.NONE;
-                return originalFunction.call(this, ...args);
-            });
+        if (AppDisplay.BaseAppView?.prototype?._pageForCoords) {
+            // Ensure we handle Dnd events happening on the dock when we're dragging from AppDisplay
+            // Remove when merged https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2002
+            this._methodInjections.addWithLabel('main-dash', AppDisplay.BaseAppView.prototype,
+                '_pageForCoords', function (originalFunction, ...args) {
+                    if (!this._scrollView.has_pointer)
+                        return AppDisplay.SidePages.NONE;
+                    return originalFunction.call(this, ...args);
+                });
+        }
 
         if (Main.layoutManager._startingUp && Main.sessionMode.hasOverview &&
             this._settings.disableOverviewOnStartup) {

--- a/docking.js
+++ b/docking.js
@@ -2445,14 +2445,7 @@ var DockManager = class DashToDock_DockManager {
     }
 
     _hasPanelCorners() {
-        if (!Object.hasOwn(Main.panel, '_rightCorner') ||
-            !Object.hasOwn(Main.panel, '_leftCorner')) {
-            return false;
-        } else if (!Main.panel._rightCorner || !Main.panel._leftCorner) {
-            return false;
-        }
-
-        return true;
+        return !!Main.panel?._rightCorner && !!Main.panel?._leftCorner;
     }
 };
 Signals.addSignalMethods(DockManager.prototype);

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -13,6 +13,10 @@ const FileManager1Iface = '<node><interface name="org.freedesktop.FileManager1">
 
 const FileManager1Proxy = Gio.DBusProxy.makeProxyWrapper(FileManager1Iface);
 
+const Labels = Object.freeze({
+    WINDOWS: Symbol('windows'),
+});
+
 /**
  * This class implements a client for the org.freedesktop.FileManager1 dbus
  * interface, and specifically for the OpenWindowsWithLocations property
@@ -161,7 +165,7 @@ var FileManager1Client = class DashToDock_FileManager1Client {
         const locationsByWindowsPath = this._proxy.OpenWindowsWithLocations;
 
         const windowsByLocation = new Map();
-        this._signalsHandler.removeWithLabel('windows');
+        this._signalsHandler.removeWithLabel(Labels.WINDOWS);
 
         Object.entries(locationsByWindowsPath).forEach(([windowPath, locations]) => {
             locations.forEach(location => {
@@ -180,7 +184,7 @@ var FileManager1Client = class DashToDock_FileManager1Client {
                     if (windows.size === 1)
                         windowsByLocation.set(location, windows);
 
-                    this._signalsHandler.addWithLabel('windows', window,
+                    this._signalsHandler.addWithLabel(Labels.WINDOWS, window,
                         'unmanaged', () => {
                             const wins = this._windowsByLocation.get(location);
                             wins.delete(window);

--- a/locations.js
+++ b/locations.js
@@ -1218,7 +1218,8 @@ var Removables = class DashToDock_Removables {
                 return;
         }
 
-        const appInfo = new MountableVolumeAppInfo(volume, this._cancellable);
+        const appInfo = new MountableVolumeAppInfo(volume,
+            new Utils.CancellableChild(this._cancellable));
         const volumeApp = makeLocationApp({
             appInfo,
             fallbackIconName: FALLBACK_REMOVABLE_MEDIA_ICON,

--- a/locations.js
+++ b/locations.js
@@ -317,6 +317,13 @@ var LocationAppInfo = GObject.registerClass({
             return null;
         }
     }
+
+    destroy() {
+        this.location = null;
+        this.icon = null;
+        this.name = null;
+        this.cancellable?.cancel();
+    }
 });
 
 const MountableVolumeAppInfo = GObject.registerClass({
@@ -379,6 +386,8 @@ class MountableVolumeAppInfo extends LocationAppInfo {
         this.disconnect(this._mountChanged);
         this.mount = null;
         this._signalsHandler.destroy();
+
+        super.destroy();
     }
 
     vfunc_dup() {
@@ -612,7 +621,8 @@ class TrashAppInfo extends LocationAppInfo {
         this._updateTrashCancellable?.cancel();
         this._monitor?.disconnect(this._monitorChangedId);
         this._monitor = null;
-        this.location = null;
+
+        super.destroy();
     }
 
     list_actions() {

--- a/locations.js
+++ b/locations.js
@@ -1096,13 +1096,7 @@ function unWrapFileManagerApp() {
  * up-to-date as the trash fills and is emptied over time.
  */
 var Trash = class DashToDock_Trash {
-    constructor() {
-        this._cancellable = new Gio.Cancellable();
-    }
-
     destroy() {
-        this._cancellable.cancel();
-        this._cancellable = null;
         this._trashApp?.destroy();
     }
 
@@ -1111,7 +1105,7 @@ var Trash = class DashToDock_Trash {
             return;
 
         this._trashApp = makeLocationApp({
-            appInfo: new TrashAppInfo(this._cancellable),
+            appInfo: new TrashAppInfo(new Gio.Cancellable()),
             fallbackIconName: FALLBACK_TRASH_ICON,
         });
     }

--- a/locations.js
+++ b/locations.js
@@ -37,6 +37,11 @@ const NautilusFileOperations2Interface = '<node>\
 
 const NautilusFileOperations2ProxyInterface = Gio.DBusProxy.makeProxyWrapper(NautilusFileOperations2Interface);
 
+const Labels = Object.freeze({
+    LOCATION_WINDOWS: Symbol('location-windows'),
+    WINDOWS_CHANGED: Symbol('windows-changed'),
+});
+
 if (imports.system.version >= 17101) {
     Gio._promisify(Gio.File.prototype, 'query_info_async', 'query_info_finish');
 }
@@ -991,9 +996,9 @@ function makeLocationApp(params) {
             if (!windowsChanged)
                 return;
 
-            this._signalConnections.removeWithLabel('location-windows');
+            this._signalConnections.removeWithLabel(Labels.LOCATION_WINDOWS);
             windows.forEach(w =>
-                this._signalConnections.addWithLabel('location-windows', w,
+                this._signalConnections.addWithLabel(Labels.LOCATION_WINDOWS, w,
                     'notify::user-time', () => {
                         if (w != this._windows[0])
                             this._windowsOrderChanged();
@@ -1027,7 +1032,7 @@ function wrapFileManagerApp() {
     wrapWindowsBackedApp(fileManagerApp);
 
     const { removables, trash } = Docking.DockManager.getDefault();
-    fileManagerApp._signalConnections.addWithLabel('windowsChanged',
+    fileManagerApp._signalConnections.addWithLabel(Labels.WINDOWS_CHANGED,
         fileManagerApp, 'windows-changed', () => {
             fileManagerApp.stop_emission_by_name('windows-changed');
             // Let's wait for the location app to take control before of us
@@ -1057,9 +1062,9 @@ function wrapFileManagerApp() {
         const windows = originalGetWindows.call(this).filter(w =>
             !locationWindows.includes(w));
 
-        this._signalConnections.blockWithLabel('windowsChanged');
+        this._signalConnections.blockWithLabel(Labels.WINDOWS_CHANGED);
         this._setWindows(windows);
-        this._signalConnections.unblockWithLabel('windowsChanged');
+        this._signalConnections.unblockWithLabel(Labels.WINDOWS_CHANGED);
     };
 
     fileManagerApp._mi('toString', defaultToString =>

--- a/metadata.json
+++ b/metadata.json
@@ -11,5 +11,5 @@
 "original-author": "micxgx@gmail.com",
 "url": "https://micheleg.github.io/dash-to-dock/",
 "gettext-domain": "dashtodock",
-"version": 72
+"version": 73
 }

--- a/po/es.po
+++ b/po/es.po
@@ -7,8 +7,8 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-06 01:57-0600\n"
-"PO-Revision-Date: 2020-03-23 11:25+0100\n"
-"Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
+"PO-Revision-Date: 2022-08-25 10:00+0100\n"
+"Last-Translator: David Astillero Pérez <dastillero@gmail.com>\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -508,6 +508,38 @@ msgstr "Mostrar el icono Papelera"
 #: Settings.ui.h:109
 msgid "Show mounted volumes and devices"
 msgstr "Mostrar los dispositivos montados"
+
+#: Settings.ui.h:115
+msgid "Always on top"
+msgstr "Siempre en primer plano"
+
+#: Settings.ui.h:116
+msgid "Show pinned applications"
+msgstr "Mostrar aplicaciones fijadas"
+
+#: Settings.ui.h:117
+msgid "Show volumes and devices"
+msgstr "Mostrar volúmenes y dispositivos"
+
+#: Settings.ui.h:118
+msgid "Only if mounted"
+msgstr "Sólo montados"
+
+#: Settings.ui.h:119
+msgid "Include network volumes"
+msgstr "Incluir volúmenes de red"
+
+#: Settings.ui.h:120
+msgid "Focus, minimize or show previews"
+msgstr "Focalizar, minimizar o mostrar previsualizaciones"
+
+#: Settings.ui.h:121
+msgid "Show overview on startup"
+msgstr "Mostrar visión general al inicializar"
+
+#: Settings.ui.h:122
+msgid "Apply glossy effect."
+msgstr "Aplicar efecto brillo."
 
 #: appIcons.js:1148
 #, javascript-format

--- a/prefs.js
+++ b/prefs.js
@@ -214,7 +214,9 @@ var Settings = GObject.registerClass({
 
         // Set a reasonable initial window height
         this.widget.connect('realize', () => {
-            this.widget.get_root().set_size_request(-1, 850);
+            const rootWindow = this.widget.get_root();
+            rootWindow.set_size_request(-1, 850);
+            rootWindow.connect('close-request', () => this._onWindowsClosed());
             if (SHELL_VERSION >= 42)
                 this.widget.set_size_request(-1, 850);
         });
@@ -232,6 +234,23 @@ var Settings = GObject.registerClass({
 
         this._monitorsConfig = new MonitorsConfig();
         this._bindSettings();
+    }
+
+    _onWindowsClosed() {
+        if (this._dock_size_timeout) {
+            GLib.source_remove(this._dock_size_timeout);
+            delete this._dock_size_timeout;
+        }
+
+        if (this._icon_size_timeout) {
+            GLib.source_remove(this._icon_size_timeout);
+            delete this._icon_size_timeout;
+        }
+
+        if (this._opacity_timeout) {
+            GLib.source_remove(this._opacity_timeout);
+            delete this._opacity_timeout;
+        }
     }
 
     vfunc_create_closure(builder, handlerName, flags, connectObject) {
@@ -284,13 +303,11 @@ var Settings = GObject.registerClass({
         // Avoid settings the size continuously
         if (this._dock_size_timeout > 0)
             GLib.source_remove(this._dock_size_timeout);
-        const id = this._dock_size_timeout = GLib.timeout_add(
+        this._dock_size_timeout = GLib.timeout_add(
             GLib.PRIORITY_DEFAULT, SCALE_UPDATE_TIMEOUT, () => {
-                if (id === this._dock_size_timeout) {
-                    this._settings.set_double('height-fraction', scale.get_value());
-                    this._dock_size_timeout = 0;
-                    return GLib.SOURCE_REMOVE;
-                }
+                this._settings.set_double('height-fraction', scale.get_value());
+                this._dock_size_timeout = 0;
+                return GLib.SOURCE_REMOVE;
             });
     }
 

--- a/theming.js
+++ b/theming.js
@@ -33,6 +33,10 @@ const TransparencyMode = {
     DYNAMIC:  3
 };
 
+const Labels = Object.freeze({
+    TRANSPARENCY: Symbol('transparency'),
+});
+
 /**
  * Manage theme customization and custom theme support
  */
@@ -352,7 +356,7 @@ var Transparency = class DashToDock_Transparency {
             this._base_actor_style = "";
         }
 
-        this._signalsHandler.addWithLabel('transparency', [
+        this._signalsHandler.addWithLabel(Labels.TRANSPARENCY, [
             global.window_group,
             'actor-added',
             this._onWindowActorAdded.bind(this)
@@ -396,7 +400,7 @@ var Transparency = class DashToDock_Transparency {
     disable() {
         // ensure I never double-register/inject
         // although it should never happen
-        this._signalsHandler.removeWithLabel('transparency');
+        this._signalsHandler.removeWithLabel(Labels.TRANSPARENCY);
 
         for (let key of this._trackedWindows.keys())
             this._trackedWindows.get(key).forEach(id => {

--- a/utils.js
+++ b/utils.js
@@ -45,12 +45,16 @@ const BasicHandler = class DashToDock_BasicHandler {
         this.addWithLabel('generic', ...args);
     }
 
+    clear() {
+        for (let label in this._storage)
+            this.removeWithLabel(label);
+    }
+
     destroy() {
         this._parentObject?.disconnect(this._destroyId);
         this._parentObject = null;
 
-        for( let label in this._storage )
-            this.removeWithLabel(label);
+        this.clear();
     }
 
     block() {

--- a/utils.js
+++ b/utils.js
@@ -18,14 +18,20 @@ var SignalsHandlerFlags = {
     CONNECT_AFTER: 1
 };
 
+const GENERIC_KEY = Symbol('generic');
+
 /**
  * Simplify global signals and function injections handling
  * abstract class
  */
 const BasicHandler = class DashToDock_BasicHandler {
 
+    static get genericKey() {
+        return GENERIC_KEY;
+    }
+
     constructor(parentObject) {
-        this._storage = new Object();
+        this._storage = new Object(null);
 
         if (parentObject) {
             if (!(parentObject.connect instanceof Function))
@@ -42,12 +48,12 @@ const BasicHandler = class DashToDock_BasicHandler {
     add(...args) {
         // Convert arguments object to array, concatenate with generic
         // Call addWithLabel with ags as if they were passed arguments
-        this.addWithLabel('generic', ...args);
+        this.addWithLabel(GENERIC_KEY, ...args);
     }
 
     clear() {
-        for (let label in this._storage)
-            this.removeWithLabel(label);
+        Object.getOwnPropertySymbols(this._storage).forEach(label =>
+            this.removeWithLabel(label));
     }
 
     destroy() {
@@ -58,14 +64,19 @@ const BasicHandler = class DashToDock_BasicHandler {
     }
 
     block() {
-        Object.keys(this._storage).forEach(label => this.blockWithLabel(label));
+        Object.getOwnPropertySymbols(this._storage).forEach(label =>
+            this.blockWithLabel(label));
     }
 
     unblock() {
-        Object.keys(this._storage).forEach(label => this.unblockWithLabel(label));
+        Object.getOwnPropertySymbols(this._storage).forEach(label =>
+            this.unblockWithLabel(label));
     }
 
     addWithLabel(label, ...args) {
+        if (typeof label !== 'symbol')
+            throw new Error(`Invalid label ${label}, must be a symbol`);
+
         let argsArray = [...args];
         if (argsArray.every(arg => !Array.isArray(arg)))
             argsArray = [argsArray];

--- a/utils.js
+++ b/utils.js
@@ -579,7 +579,7 @@ class CancellableChild extends Gio.Cancellable {
     }
 
     _connectToParent() {
-        this._connectId = this?.parent.connect(() => {
+        this._connectId = this.parent?.connect(() => {
             this._realCancel();
 
             if (this._disconnectIdle)


### PR DESCRIPTION
In order to maintain visual rhythm, symmetry and consistency I suggest
this change that preserves dock opacity during the window preview drag
user event.

With this change the workspace body that allows user to drop the window on or go to desired workspace by clicking on it
gets on both left and right sides visually equal width. I say visually because technically the workspace bodies still differ
because the part of the left one is being hidden under the dock.

During the drag event dock doesn't provide any functionality and it actually prevents drop of the window which is confusing.

By leaving the dock's opacity same as is top bar's we achieve even more consistency.