### PR TITLE
Preserve dock opacity when draging window preview in shell overview

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -241,18 +241,6 @@ var DockDash = GObject.registerClass({
             Main.overview,
             'item-drag-cancelled',
             this._onItemDragCancelled.bind(this)
-        ], [
-            Main.overview,
-            'window-drag-begin',
-            this._onWindowDragBegin.bind(this)
-        ], [
-            Main.overview,
-            'window-drag-cancelled',
-            this._onWindowDragEnd.bind(this)
-        ], [
-            Main.overview,
-            'window-drag-end',
-            this._onWindowDragEnd.bind(this)
         ]);
 
         this.connect('destroy', this._onDestroy.bind(this));


### PR DESCRIPTION
In order to maintain visual rhythm, symmetry and consistency I suggest this change that preserves dock opacity during the window preview drag user event.

With this change, the workspace body that allows user to drop the window on to workspace or go to desired workspace by click, gets on both left and right sides visually equal width. I say visually because technically the workspace bodies still differbecause the part of the left one is being hidden under the dock.

During the drag event dock doesn't provide any functionality and it actually prevents dropping the window which can be confusing when is transparent.

By leaving the dock's opacity same as is top bar's we achieve even more consistency.
