### PR TITLE
locations: Make FileManagerApp emit windows-changed on workspace swithes

### DIFF
--- a/locations.js
+++ b/locations.js
@@ -820,7 +820,7 @@ function wrapWindowsBackedApp(shellApp) {
 
         _setWindows: function (windows) {
             const oldState = this.state;
-            const oldWindows = this.get_windows().slice();
+            const oldWindows = this._windows.slice();
             const result = { windowsChanged: false, stateChanged: false };
             this._state = undefined;
 
@@ -1052,6 +1052,13 @@ function wrapFileManagerApp() {
                 return GLib.SOURCE_REMOVE;
             });
             fileManagerApp._sources.add(id);
+        });
+
+    fileManagerApp._signalConnections.add(global.workspaceManager,
+        'workspace-switched', () => {
+            fileManagerApp._signalConnections.blockWithLabel(Labels.WINDOWS_CHANGED);
+            fileManagerApp.emit('windows-changed');
+            fileManagerApp._signalConnections.unblockWithLabel(Labels.WINDOWS_CHANGED);
         });
 
     if (removables) {


### PR DESCRIPTION
This is consistent with what happens with other applications.

LP: #1971012