### PR TITLE
docking: Remove pending show-overlay timeouts on destruction

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1383,6 +1383,13 @@ var KeyboardShortcuts = class DashToDock_KeyboardShortcuts {
     }
 
     destroy() {
+        DockManager.allDocks.forEach(dock => {
+            if (dock._numberOverlayTimeoutId) {
+                GLib.source_remove(dock._numberOverlayTimeoutId);
+                dock._numberOverlayTimeoutId = 0;
+            }
+        });
+
         // Remove keybindings
         this._disableHotKeys();
         this._disableExtraShortcut();


### PR DESCRIPTION
Coming from https://extensions.gnome.org/review/34780