### PR TITLE
Draft: docking: Call back for the overview runStartupAnimation ASAP

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2097,8 +2097,8 @@ var DockManager = class DashToDock_DockManager {
                 DockManager.allDocks.forEach(dock => (dock.opacity = 0));
                 injections.add(dockManager.mainDock.dash, 'ease', () => {});
                 let callbackArgs = [];
-                const ret = await originalMethod.call(this,
-                    (...args) => (callbackArgs = [...args]));
+                const ret = await originalMethod.call(this, () => {});
+                callback();
                 injections.destroy();
 
                 if (!DockManager.allDocks.length) {
@@ -2113,7 +2113,7 @@ var DockManager = class DashToDock_DockManager {
                 }
 
                 dockManager._prepareStartupAnimation();
-                dockManager._runStartupAnimation(() => callback(...callbackArgs));
+                dockManager._runStartupAnimation(() => {});
                 return ret;
             });
 

--- a/docking.js
+++ b/docking.js
@@ -1996,7 +1996,7 @@ var DockManager = class DashToDock_DockManager {
         });
     }
 
-    _runStartupAnimation(callback) {
+    _runStartupAnimation() {
         const { STARTUP_ANIMATION_TIME } = Layout;
 
         DockManager.allDocks.forEach(dock => {
@@ -2017,10 +2017,6 @@ var DockManager = class DashToDock_DockManager {
                     break;
             }
 
-            const mainDockProperties = {};
-            if (dock === this.mainDock)
-                mainDockProperties.onComplete = callback;
-
             dash.ease({
                 opacity: 255,
                 translation_x: 0,
@@ -2028,7 +2024,6 @@ var DockManager = class DashToDock_DockManager {
                 delay: STARTUP_ANIMATION_TIME,
                 duration: STARTUP_ANIMATION_TIME,
                 mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-                ...mainDockProperties,
             });
         });
     }
@@ -2113,7 +2108,7 @@ var DockManager = class DashToDock_DockManager {
                 }
 
                 dockManager._prepareStartupAnimation();
-                dockManager._runStartupAnimation(() => {});
+                dockManager._runStartupAnimation();
                 return ret;
             });
 


### PR DESCRIPTION
docking: Call back for the overview runStartupAnimation ASAP
    
That means when it is finished, before we start our own dock animation.
    
Although it was theoretically OK to call back after we finish our dock
slide animation, it was unnecessary to wait that long and would also fail
to call back under certain conditions:
    
1. Log into a Xorg session in a virtual machine.
    
2. The startup animations begin.
    
3. The hypervisor changes the Xorg display resolution.
    
4. The startup animations continue but never receive any onComplete or
   onStopped.
    
5. global.window_group would never have its 
   set_clip(<old monitor geometry>) removed.
    
Fundamentally this is a bug somewhere in clutter or gnome-shell, but 
working around it in the dock is not a change we will ever need to undo
because this change is also logically correct; the callback for the 
overview animation still occurs after the overview animation. Just more
reliably now.
  
Fixes: https://launchpad.net/bugs/1989170, https://launchpad.net/bugs/1989726
