### PR TITLE
docking: Handle when dash is destroyed during the login animation

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2018,8 +2018,14 @@ var DockManager = class DashToDock_DockManager {
             }
 
             const mainDockProperties = {};
-            if (dock === this.mainDock)
-                mainDockProperties.onComplete = callback;
+            if (dock === this.mainDock && callback !== undefined) {
+                const destroyId = dash.connect('destroy',
+                    () => mainDockProperties.onStopped(false));
+                mainDockProperties.onStopped = (finished) => {
+                    dash.disconnect(destroyId);
+                    callback();
+                }
+            }
 
             dash.ease({
                 opacity: 255,


### PR DESCRIPTION
This can happen in a VM where the hypervisor changes the Xorg display resolution at startup, during the login animation.

Fixes: https://launchpad.net/bugs/1989170, https://launchpad.net/bugs/1989726