### PR TITLE
docking: Remember the parameter to _runStartupAnimation()

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2313,7 +2313,7 @@ var DockManager = class DashToDock_DockManager {
                         mode: Clutter.AnimationMode.EASE_OUT_QUAD,
                         onComplete: () => {
                             callback();
-                            this._runStartupAnimation();
+                            this._runStartupAnimation(() => {});
                         },
                     });
                 });


### PR DESCRIPTION
It was never meant to be optional.