### PR TITLE
docking: Ensure we perform the startup animation completely on docks updates

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2123,19 +2123,23 @@ var DockManager = class DashToDock_DockManager {
 
         this._methodInjections.addWithLabel(Labels.MAIN_DASH, ControlsManager.prototype,
             'runStartupAnimation', async function (originalMethod, callback) {
-                const injections = new Utils.InjectionsHandler();
-                const dockManager = DockManager.getDefault();
-                dockManager._prepareStartupAnimation(callback);
-                injections.add(dockManager.mainDock.dash, 'ease', () => {});
-                let callbackArgs = [];
-                const ret = await originalMethod.call(this,
-                    (...args) => (callbackArgs = [...args]));
-                injections.destroy();
+                try {
+                    const injections = new Utils.InjectionsHandler();
+                    const dockManager = DockManager.getDefault();
+                    dockManager._prepareStartupAnimation(callback);
+                    injections.add(dockManager.mainDock.dash, 'ease', () => {});
+                    let callbackArgs = [];
+                    const ret = await originalMethod.call(this,
+                        (...args) => (callbackArgs = [...args]));
+                    injections.destroy();
 
-                const onComplete = () => callback(...callbackArgs);
-                dockManager._prepareStartupAnimation(onComplete);
-                dockManager._runStartupAnimation(onComplete);
-                return ret;
+                    const onComplete = () => callback(...callbackArgs);
+                    dockManager._prepareStartupAnimation(onComplete);
+                    dockManager._runStartupAnimation(onComplete);
+                    return ret;
+                } catch (e) {
+                    logError(e);
+                }
             });
 
         const maybeAdjustBoxToDock = (state, box, spacing) => {

--- a/docking.js
+++ b/docking.js
@@ -61,6 +61,7 @@ const Labels = Object.freeze({
     MAIN_DASH: Symbol('main-dash'),
     OLD_DASH_CHANGES: Symbol('old-dash-changes'),
     SETTINGS: Symbol('settings'),
+    STARTUP_ANIMATION: Symbol('startup-animation'),
     WORKSPACE_SWITCH_SCROLL: Symbol('workspace-switch-scroll'),
 });
 
@@ -1983,7 +1984,7 @@ var DockManager = class DashToDock_DockManager {
         this.emit('docks-ready');
     }
 
-    _prepareStartupAnimation() {
+    _prepareStartupAnimation(callback) {
         DockManager.allDocks.forEach(dock => {
             const { dash } = dock;
 
@@ -1994,6 +1995,31 @@ var DockManager = class DashToDock_DockManager {
                 translation_y: 0,
             });
         });
+
+        // We need to ensure that if docks are destroyed before animation is
+        // completed, then we still ensure the animation runs anyways.
+        const label = Labels.STARTUP_ANIMATION;
+        this._signalsHandler.removeWithLabel(label);
+
+        // This shouldn't really ever happen, but in theory the manager
+        // could be destroyed at any time, in such case complete the animation
+        this._signalsHandler.addWithLabel(label, this, 'destroy', () =>
+            Main.overview.runStartupAnimation(callback));
+
+        const waitForDocksReady = () => {
+            global.window_group.remove_clip();
+            this._signalsHandler.addWithLabel(label, this, 'docks-ready', () => {
+                this._signalsHandler.removeWithLabel(label);
+                Main.overview.runStartupAnimation(callback);
+            });
+        };
+
+        if (this._allDocks.length) {
+            this._signalsHandler.addWithLabel(label, this, 'docks-destroyed',
+                () => waitForDocksReady());
+        } else {
+            waitForDocksReady();
+        }
     }
 
     _runStartupAnimation(callback) {
@@ -2018,12 +2044,11 @@ var DockManager = class DashToDock_DockManager {
             }
 
             const mainDockProperties = {};
-            if (dock === this.mainDock && callback) {
-                const destroyId = dash.connect('destroy',
-                    () => mainDockProperties.onStopped(false));
-                mainDockProperties.onStopped = _finished => {
-                    dash.disconnect(destroyId);
-                    callback();
+            if (dock === this.mainDock) {
+                mainDockProperties.onComplete = () => {
+                    this._signalsHandler.removeWithLabel(Labels.STARTUP_ANIMATION);
+                    if (callback)
+                        callback();
                 };
             }
 
@@ -2100,26 +2125,16 @@ var DockManager = class DashToDock_DockManager {
             'runStartupAnimation', async function (originalMethod, callback) {
                 const injections = new Utils.InjectionsHandler();
                 const dockManager = DockManager.getDefault();
-                DockManager.allDocks.forEach(dock => (dock.opacity = 0));
+                dockManager._prepareStartupAnimation(callback);
                 injections.add(dockManager.mainDock.dash, 'ease', () => {});
                 let callbackArgs = [];
                 const ret = await originalMethod.call(this,
                     (...args) => (callbackArgs = [...args]));
                 injections.destroy();
 
-                if (!DockManager.allDocks.length) {
-                    // Docks may have been destroyed, let's wait till we've one again
-                    const readyPromise = new Promise(resolve => {
-                        const id = dockManager.connect('docks-ready', () => {
-                            dockManager.disconnect(id);
-                            resolve();
-                        });
-                    })
-                    await readyPromise;
-                }
-
-                dockManager._prepareStartupAnimation();
-                dockManager._runStartupAnimation(() => callback(...callbackArgs));
+                const onComplete = () => callback(...callbackArgs);
+                dockManager._prepareStartupAnimation(onComplete);
+                dockManager._runStartupAnimation(onComplete);
                 return ret;
             });
 
@@ -2295,7 +2310,7 @@ var DockManager = class DashToDock_DockManager {
                     const y = monitor.y + monitor.height / 2.0;
                     const { STARTUP_ANIMATION_TIME } = Layout;
 
-                    this._prepareStartupAnimation();
+                    this._prepareStartupAnimation(callback);
                     Main.uiGroup.set_pivot_point(
                         x / global.screen_width,
                         y / global.screen_height);
@@ -2331,6 +2346,8 @@ var DockManager = class DashToDock_DockManager {
         // Delete all docks
         this._allDocks.forEach(d => d.destroy());
         this._allDocks = [];
+
+        this.emit('docks-destroyed');
     }
 
     _restoreDash() {

--- a/docking.js
+++ b/docking.js
@@ -2311,11 +2311,10 @@ var DockManager = class DashToDock_DockManager {
                         opacity: 255,
                         duration: STARTUP_ANIMATION_TIME,
                         mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-                        onComplete: () => {
-                            callback();
-                            this._runStartupAnimation();
-                        },
+                        onComplete: callback,
                     });
+
+                    this._runStartupAnimation();
                 });
         }
     }

--- a/utils.js
+++ b/utils.js
@@ -161,6 +161,12 @@ var GlobalSignalsHandler = class DashToDock_GlobalSignalHandler extends BasicHan
 
         let id = connector.call(object, event, callback);
 
+        if (event === 'destroy' && object === this._parentObject) {
+            this._parentObject.disconnect(this._destroyId);
+            this._destroyId =
+                this._parentObject.connect('destroy', () => this.destroy());
+        }
+
         return [object, id];
     }
 


### PR DESCRIPTION
If docks gets destroyed early during startup animation (as it may happen
when there are resolution or other monitor changes), we need to
completely finish the animation, but we can safely perform a new one in
these cases, as this happens early enough.

Closes: #1770
LP: #1965208