### PR TITLE
Fix Transparency for Gtk4 DING

### DIFF
--- a/theming.js
+++ b/theming.js
@@ -468,7 +468,7 @@ var Transparency = class DashToDock_Transparency {
             return metaWindow.get_monitor() === dash._monitorIndex &&
                    metaWindow.showing_on_its_workspace() &&
                    metaWindow.get_window_type() !== Meta.WindowType.DESKTOP &&
-                   (!Meta.is_wayland_compositor() || !metaWindow.skip_taskbar);
+                   !metaWindow.skip_taskbar;
         });
 
         /* Check if at least one window is near enough to the panel.


### PR DESCRIPTION
In Gtk4-DING, the Gtk4 port of the desktop icons extension, the desktop X11 window cannot be detected by "DESKTOP" type. It is handled by the same code as wayland windows, and needs to be detected by the skip_taskbar hint. This enables correct transparency of the dock when on X11 with Gtk4-DING.

This, works with #1879, which is needed for fixing intellihide of Dock with Gtk4-DING.