### PR TITLE
Don't detect and track DING windows for intellihide

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -40,6 +40,9 @@ const handledWindowTypes = [
     Meta.WindowType.SPLASHSCREEN
 ];
 
+// List of applications, ignore windows of these applications in considering intellihide
+const ignoreApps = [ "com.rastersoft.ding", "com.desktop.ding" ];
+
 /**
  * A rough and ugly implementation of the intellihide behaviour.
  * Intallihide object: emit 'status-changed' signal when the overlap of windows
@@ -313,7 +316,6 @@ var Intellihide = class DashToDock_Intellihide {
 
         // The DING extension desktop window needs to be excluded
         // so we match its window by application id and window property.
-        const ignoreApps = [ "com.rastersoft.ding", "com.desktop.ding" ];
         const wmApp = metaWindow.get_gtk_application_id();
         if (ignoreApps.includes(wmApp) && metaWindow.is_skip_taskbar())
             return false;

--- a/intellihide.js
+++ b/intellihide.js
@@ -311,6 +311,13 @@ var Intellihide = class DashToDock_Intellihide {
         if (!metaWindow)
             return false;
 
+        // The DING extension desktop window needs to be excluded
+        // so we match its window by application id and window property.
+        const ignoreApps = [ "com.rastersoft.ding", "com.desktop.ding" ];
+        const wmApp = metaWindow.get_gtk_application_id();
+        if (ignoreApps.includes(wmApp) && metaWindow.is_skip_taskbar())
+            return false;
+
         // The DropDownTerminal extension uses the POPUP_MENU window type hint
         // so we match its window by wm class instead
         if (metaWindow.get_wm_class() == 'DropDownTerminalWindow')


### PR DESCRIPTION
Currently the dock hides when the desktop window from the DING extension is shown, and the dock is in case IntellihideMode.ALL_WINDOWS:

This proposed fix, excludes the DING extension windows specifically, both the Gtk3 and Gtk4 versions from handled windows, so uses resource usage and takes it out of consideration for any case statement when considering hiding the dock.

This is more specific than #1879 and works in all cases. Also works in conjunction with #1888 which is needed to fix transparency. 