### PR TITLE
Make urgent application icon dance toggleable

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1289,6 +1289,43 @@
                         </property>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkListBoxRow" id="dance_urgent_applications_row">
+                        <property name="child">
+                          <object class="GtkGrid">
+                            <property name="can_focus">0</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <property name="column_spacing">32</property>
+                            <child>
+                              <object class="GtkSwitch" id="dance_urgent_applications_switch">
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="can_focus">0</property>
+                                <property name="hexpand">1</property>
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">Dance urgent applications</property>
+
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
                   </object>
                 </property>
                 <child type="label_item">

--- a/appIcons.js
+++ b/appIcons.js
@@ -162,9 +162,11 @@ var DockAbstractAppIcon = GObject.registerClass({
         this.connect('notify::urgent', () => {
             const icon = this.icon._iconBin;
             this._signalsHandler.removeWithLabel(Labels.URGENT_WINDOWS)
-            if (this.urgent && Docking.DockManager.settings.danceUrgentApplications) {
-                icon.set_pivot_point(0.5, 0.5);
-                this.iconAnimator.addAnimation(icon, 'dance');
+            if (this.urgent) {
+                if (Docking.DockManager.settings.danceUrgentApplications) {
+                    icon.set_pivot_point(0.5, 0.5);
+                    this.iconAnimator.addAnimation(icon, 'dance');
+                }
                 if (!this._urgentWindows.size) {
                     const urgentWindows = this.getInterestingWindows();
                     urgentWindows.forEach(w => (w._manualUrgency = true));

--- a/appIcons.js
+++ b/appIcons.js
@@ -162,7 +162,7 @@ var DockAbstractAppIcon = GObject.registerClass({
         this.connect('notify::urgent', () => {
             const icon = this.icon._iconBin;
             this._signalsHandler.removeWithLabel(Labels.URGENT_WINDOWS)
-            if (this.urgent) {
+            if (this.urgent && Docking.DockManager.settings.danceUrgentApplications) {
                 icon.set_pivot_point(0.5, 0.5);
                 this.iconAnimator.addAnimation(icon, 'dance');
                 if (!this._urgentWindows.size) {

--- a/docking.js
+++ b/docking.js
@@ -543,6 +543,11 @@ var DockedDash = GObject.registerClass({
             Utils.SignalsHandlerFlags.CONNECT_AFTER
         ], [
             settings,
+            'changed::dance-urgent-applications',
+            () => this.dash.resetAppIcons(),
+            Utils.SignalsHandlerFlags.CONNECT_AFTER
+        ], [
+            settings,
             'changed::show-running',
             () => { this.dash.resetAppIcons(); }
         ], [

--- a/prefs.js
+++ b/prefs.js
@@ -702,6 +702,10 @@ var Settings = GObject.registerClass({
         updateIsolateLocations();
         isolateLocationsBindings.forEach(s => this._builder.get_object(s).connect(
             'notify::active', () => updateIsolateLocations()));
+        this._settings.bind('dance-urgent-applications',
+            this._builder.get_object('dance_urgent_applications_switch'),
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-show-apps-button',
             this._builder.get_object('show_applications_button_switch'),
             'active',

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -280,6 +280,11 @@
       <summary>Isolate volumes, devices and trash windows</summary>
       <description>Consider volume, devices and trash as different application windows and not part of the file manager</description>
     </key>
+    <key type="b" name="dance-urgent-applications">
+      <default>true</default>
+      <summary>Dance urgent applications</summary>
+      <description>Dance urgent application icons in the dash</description>
+    </key>
     <key type="b" name="show-show-apps-button">
       <default>true</default>
       <summary>Show applications button</summary>


### PR DESCRIPTION
Resolves https://github.com/micheleg/dash-to-dock/issues/1859.

The distracting dance/shake animation for urgent application icons has always really annoyed me. I finally thought I'd do something about it and contribute a setting for whether dancing should be enabled; and being mostly a copy-paste job, was easier than I expected.

Tested using gnuplot, which when not minimised and not the foreground application, makes its icon urgent upon `reread`:

```bash
echo 'plot sin(x); pause 1; reread' > x && gnuplot x; rm x
```

Edit: I wasn't sure what to do about translations. Is there something automated? Should we be using Google Translate?