### PR TITLE
appIconIndicators: Do not load theme node for off-stage widgets

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -780,34 +780,16 @@ var UnityIndicator = class DashToDockUnityIndicator extends IndicatorBase {
         });
 
         this._source._iconContainer.add_child(this._progressOverlayArea);
-        const node = this._progressOverlayArea.get_theme_node();
-
-        let [hasColor, color] = node.lookup_color('-progress-bar-background', false);
-        if (hasColor)
-            this._progressbar_background = color;
-        else
-            this._progressbar_background = new Clutter.Color({ red: 204, green: 204, blue: 204, alpha: 255 });
-
-        [hasColor, color] = node.lookup_color('-progress-bar-border', false);
-        if (hasColor)
-            this._progressbar_border = color;
-        else
-            this._progressbar_border = new Clutter.Color({ red: 230, green: 230, blue: 230, alpha: 255 });
-
         this._updateProgressOverlay();
     }
 
     _hideProgressOverlay() {
-        if (this._progressOverlayArea)
-            this._progressOverlayArea.destroy();
+        this._progressOverlayArea?.destroy();
         this._progressOverlayArea = null;
-        this._progressbar_background = null;
-        this._progressbar_border = null;
     }
 
     _updateProgressOverlay() {
-        if (this._progressOverlayArea)
-            this._progressOverlayArea.queue_repaint();
+        this._progressOverlayArea?.queue_repaint();
     }
 
     _drawProgressOverlay(area) {
@@ -858,8 +840,16 @@ var UnityIndicator = class DashToDockUnityIndicator extends IndicatorBase {
 
         const finishedWidth = Math.ceil(this._progress * width);
 
-        const bg = this._progressbar_background;
-        const bd = this._progressbar_border;
+        let hasColor, bg, bd;
+        const node = this._progressOverlayArea.get_theme_node();
+
+        [hasColor, bg] = node.lookup_color('-progress-bar-background', false);
+        if (!hasColor)
+            bg = new Clutter.Color({ red: 204, green: 204, blue: 204, alpha: 255 });
+
+        [hasColor, bd] = node.lookup_color('-progress-bar-border', false);
+        if (!hasColor)
+            bd = new Clutter.Color({ red: 230, green: 230, blue: 230, alpha: 255 });
 
         stroke = Cairo.SolidPattern.createRGBA(
             bd.red / 255, bd.green / 255, bd.blue / 255, bd.alpha / 255);


### PR DESCRIPTION
These information are only available when a widget is on the stage.

Avoids errors such as:

```
(gnome-shell:1188360): St-CRITICAL **: 16:17:59.545: st_widget_get_theme_node called on the widget [0x55e8f933c050 StDrawingArea.progress-bar:insensitive] which is not in the stage.
== Stack trace for context 0x55e8f6e9cc50 ==
#0   7ffedefee410 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIconIndicators.js:783 (b2170e811f0 @ 222)
#1   7ffedefeeb20 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIconIndicators.js:886 (b2170e81380 @ 86)
#2   7ffedefeebf0 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIconIndicators.js:700 (b2170e81060 @ 75)
#3   7ffedefeecc0 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/launcherAPI.js:183 (b2170e81d80 @ 74)
#4   7ffedefeedd0 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/utils.js:175 (b2170e5c3d0 @ 358)
#5   7ffedefeef10 I   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/utils.js:97 (b2170e57fb0 @ 555)
#6   7ffedefeefe0 I   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/utils.js:55 (b2170e57d30 @ 121)
#7   7ffedefef0f0 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIconIndicators.js:691 (b2170e7cf60 @ 706)
#8   7ffedefef1e0 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIconIndicators.js:41 (b2170e7c150 @ 52)
#9   7ffedefef2c0 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIcons.js:115 (b2170e680b0 @ 121)
#10   7ffedefef3a0 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIcons.js:899 (b2170e693d0 @ 30)
#11   7ffedefefb00 b   /data/GNOME/gnome-shell/js/ui/appDisplay.js:1879 (285e53963d0 @ 27)
#12   7ffedefefbf0 b   /data/GNOME/gnome-shell/js/ui/appDisplay.js:2987 (285e53985b0 @ 27)
#13   7ffedefefce0 b   /data/GNOME/gnome-shell/js/ui/dash.js:26 (285e53c5510 @ 27)
#14   7ffedefefdd0 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIcons.js:106 (b2170e69380 @ 27)
#15   7ffedefefec0 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIcons.js:897 (b2170e69470 @ 27)
#16   7ffedefeffb0 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/appIcons.js:946 (b2170e696f0 @ 76)
#17   7ffedeff00a0 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/dash.js:496 (b2170e640b0 @ 50)
#18   7ffedeff01f0 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/dash.js:848 (b2170e646f0 @ 1394)
#19   7ffedeff0910 b   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/dash.js:1005 (b2170e64c90 @ 175)
#20   55e8f9243ce0 i   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/docking.js:360 (b2170e1ee70 @ 17)
#21   7ffedeff1600 b   resource:///org/gnome/gjs/modules/core/_signals.js:130 (1715409a0f60 @ 126)
#22   7ffedeff16f0 b   resource:///org/gnome/gjs/modules/core/_signals.js:119 (1715409a0e70 @ 286)
#23   55e8f9243c48 i   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/theming.js:228 (b2170e5dd80 @ 141)
#24   55e8f9243bb8 i   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/docking.js:462 (b2170e53240 @ 52)
#25   55e8f9243b38 i   /data/GNOME/JHBUILD_HOME/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/docking.js:388 (b2170e1ef10 @ 12)
```