### PR TITLE
cleanup: Always use deconstruction to perform imports

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -1,17 +1,22 @@
 /* exported AppIconIndicator */
 
-const Cairo = imports.cairo;
-const { Clutter } = imports.gi;
-const { GdkPixbuf } = imports.gi;
-const { Gio } = imports.gi;
-const { GObject } = imports.gi;
-const Main = imports.ui.main;
-const { Pango } = imports.gi;
-const { St } = imports.gi;
+const { cairo: Cairo } = imports;
+const { main: Main } = imports.ui;
+
+const {
+    Clutter,
+    GdkPixbuf,
+    Gio,
+    GObject,
+    Pango,
+    St,
+} = imports.gi;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Docking = Me.imports.docking;
-const Utils = Me.imports.utils;
+const {
+    docking: Docking,
+    utils: Utils,
+} = Me.imports;
 
 const RunningIndicatorStyle = Object.freeze({
     DEFAULT: 0,

--- a/appIcons.js
+++ b/appIcons.js
@@ -2,13 +2,15 @@
 
 /* exported DockShowAppsIcon, makeAppIcon, itemShowLabel, getInterestingWindows */
 
-const { Clutter } = imports.gi;
-const { Gio } = imports.gi;
-const { GLib } = imports.gi;
-const { GObject } = imports.gi;
-const { Meta } = imports.gi;
-const { Shell } = imports.gi;
-const { St } = imports.gi;
+const {
+    Clutter,
+    Gio,
+    GLib,
+    GObject,
+    Meta,
+    Shell,
+    St,
+} = imports.gi;
 
 // Use __ () and N__() for the extension gettext domain, and reuse
 // the shell domain with the default _() and N_()
@@ -18,23 +20,30 @@ const N__ = e => e;
 
 const Config = imports.misc.config;
 
-const AppDisplay = imports.ui.appDisplay;
-const AppFavorites = imports.ui.appFavorites;
-const BoxPointer = imports.ui.boxpointer;
-const Dash = imports.ui.dash;
-const Main = imports.ui.main;
-const ParentalControlsManager = imports.misc.parentalControlsManager;
-const PopupMenu = imports.ui.popupMenu;
+const {
+    appDisplay: AppDisplay,
+    appFavorites: AppFavorites,
+    boxpointer: BoxPointer,
+    dash: Dash,
+    main: Main,
+    popupMenu: PopupMenu,
+} = imports.ui;
+
+const {
+    parentalControlsManager: ParentalControlsManager,
+} = imports.misc;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
-const Docking = Me.imports.docking;
-const Locations = Me.imports.locations;
-const Utils = Me.imports.utils;
-const WindowPreview = Me.imports.windowPreview;
-const AppIconIndicators = Me.imports.appIconIndicators;
-const DbusmenuUtils = Me.imports.dbusmenuUtils;
-const Theming = Me.imports.theming;
+const {
+    appIconIndicators: AppIconIndicators,
+    dbusmenuUtils: DbusmenuUtils,
+    docking: Docking,
+    locations: Locations,
+    theming: Theming,
+    utils: Utils,
+    windowPreview: WindowPreview,
+} = Me.imports;
 
 const tracker = Shell.WindowTracker.get_default();
 

--- a/dash.js
+++ b/dash.js
@@ -2,24 +2,33 @@
 
 /* exported DockDash */
 
-const { Clutter } = imports.gi;
-const { Gio } = imports.gi;
-const { GLib } = imports.gi;
-const { GObject } = imports.gi;
-const { Shell } = imports.gi;
-const { St } = imports.gi;
+const {
+    Clutter,
+    Gio,
+    GLib,
+    GObject,
+    Shell,
+    St,
+} = imports.gi;
 
-const AppFavorites = imports.ui.appFavorites;
-const Dash = imports.ui.dash;
-const DND = imports.ui.dnd;
-const Main = imports.ui.main;
-const Util = imports.misc.util;
+const {
+    appFavorites: AppFavorites,
+    dash: Dash,
+    dnd: DND,
+    main: Main,
+} = imports.ui;
+
+const {
+    util: Util,
+} = imports.misc;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Docking = Me.imports.docking;
-const Utils = Me.imports.utils;
-const AppIcons = Me.imports.appIcons;
-const Theming = Me.imports.theming;
+const {
+    appIcons: AppIcons,
+    docking: Docking,
+    theming: Theming,
+    utils: Utils,
+} = Me.imports;
 
 const { DASH_ANIMATION_TIME } = Dash;
 const DASH_VISIBILITY_TIMEOUT = 3;

--- a/dbusmenuUtils.js
+++ b/dbusmenuUtils.js
@@ -2,17 +2,20 @@
 
 /* exported haveDBusMenu, makePopupMenuItem */
 
-const { Atk } = imports.gi;
-const { Clutter } = imports.gi;
-let Dbusmenu = null; /* Dynamically imported */
-const { Gio } = imports.gi;
-const { GLib } = imports.gi;
-const { St } = imports.gi;
+const {
+    Atk,
+    Clutter,
+    Gio,
+    GLib,
+    St,
+} = imports.gi;
 
-const PopupMenu = imports.ui.popupMenu;
+let Dbusmenu = null; /* Dynamically imported */
+
+const { popupMenu: PopupMenu } = imports.ui;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Utils = Me.imports.utils;
+const { utils: Utils } = Me.imports;
 
 // Dbusmenu features not (yet) supported:
 //

--- a/desktopIconsIntegration.js
+++ b/desktopIconsIntegration.js
@@ -58,7 +58,7 @@
 /* exported DesktopIconsUsableAreaClass */
 
 const { GLib } = imports.gi;
-const Main = imports.ui.main;
+const { main: Main } = imports.ui;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();

--- a/docking.js
+++ b/docking.js
@@ -2,37 +2,46 @@
 
 /* exported DockManager, IconAnimator */
 
-const { Clutter } = imports.gi;
-const { GLib } = imports.gi;
-const { Gio } = imports.gi;
-const { GObject } = imports.gi;
-const { Meta } = imports.gi;
-const { Shell } = imports.gi;
-const { St } = imports.gi;
+const {
+    Clutter,
+    GLib,
+    Gio,
+    GObject,
+    Meta,
+    Shell,
+    St,
+} = imports.gi;
 
-const Main = imports.ui.main;
-const AppDisplay = imports.ui.appDisplay;
-const Environment = imports.ui.environment;
-const Overview = imports.ui.overview;
-const OverviewControls = imports.ui.overviewControls;
-const PointerWatcher = imports.ui.pointerWatcher;
-const Signals = imports.signals;
-const WorkspaceSwitcherPopup = imports.ui.workspaceSwitcherPopup;
-const Layout = imports.ui.layout;
-const Workspace = imports.ui.workspace;
-const WorkspacesView = imports.ui.workspacesView;
+const { signals: Signals } = imports;
+
+const {
+    appDisplay: AppDisplay,
+    environment: Environment,
+    layout: Layout,
+    main: Main,
+    overview: Overview,
+    overviewControls: OverviewControls,
+    pointerWatcher: PointerWatcher,
+    workspace: Workspace,
+    workspacesView: WorkspacesView,
+    workspaceSwitcherPopup: WorkspaceSwitcherPopup,
+} = imports.ui;
+
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
-const AppSpread = Me.imports.appSpread;
-const Utils = Me.imports.utils;
-const Intellihide = Me.imports.intellihide;
-const Theming = Me.imports.theming;
-const DockDash = Me.imports.dash;
-const Locations = Me.imports.locations;
-const LauncherAPI = Me.imports.launcherAPI;
-const FileManager1API = Me.imports.fileManager1API;
-const DesktopIconsIntegration = Me.imports.desktopIconsIntegration;
+
+const {
+    appSpread: AppSpread,
+    dash: DockDash,
+    desktopIconsIntegration: DesktopIconsIntegration,
+    fileManager1API: FileManager1API,
+    intellihide: Intellihide,
+    launcherAPI: LauncherAPI,
+    locations: Locations,
+    theming: Theming,
+    utils: Utils,
+} = Me.imports;
 
 const DOCK_DWELL_CHECK_INTERVAL = 100;
 const ICON_ANIMATOR_DURATION = 3000;

--- a/extension.js
+++ b/extension.js
@@ -4,7 +4,7 @@
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
-const Docking = Me.imports.docking;
+const { docking: Docking } = Me.imports;
 
 // We declare this with var so it can be accessed by other extensions in
 // GNOME Shell 3.26+ (mozjs52+).

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -1,11 +1,10 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-const { GLib } = imports.gi;
-const { Gio } = imports.gi;
-const Signals = imports.signals;
+const { GLib, Gio } = imports.gi;
+const { signals: Signals } = imports;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Utils = Me.imports.utils;
+const { utils: Utils } = Me.imports;
 
 const FileManager1Iface = '<node><interface name="org.freedesktop.FileManager1">\
                                <property name="OpenWindowsWithLocations" type="a{sas}" access="read"/>\

--- a/intellihide.js
+++ b/intellihide.js
@@ -1,14 +1,18 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-const { GLib } = imports.gi;
-const { Meta } = imports.gi;
-const { Shell } = imports.gi;
+const {
+    GLib,
+    Meta,
+    Shell,
+} = imports.gi;
 
-const Signals = imports.signals;
+const { signals: Signals } = imports;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Docking = Me.imports.docking;
-const Utils = Me.imports.utils;
+const {
+    docking: Docking,
+    utils: Utils,
+} = Me.imports;
 
 // A good compromise between reactivity and efficiency; to be tuned.
 const INTELLIHIDE_CHECK_INTERVAL = 100;

--- a/launcherAPI.js
+++ b/launcherAPI.js
@@ -5,7 +5,7 @@
 const { Gio } = imports.gi;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const DbusmenuUtils = Me.imports.dbusmenuUtils;
+const { dbusmenuUtils: DbusmenuUtils } = Me.imports;
 
 const Dbusmenu = DbusmenuUtils.haveDBusMenu();
 

--- a/locations.js
+++ b/locations.js
@@ -3,13 +3,16 @@
 /* exported LocationAppInfo, Trash, wrapFileManagerApp,
             unWrapFileManagerApp, getStartingApps */
 
-const { Gio } = imports.gi;
-const { GLib } = imports.gi;
-const { GObject } = imports.gi;
-const { Shell } = imports.gi;
-const ShellMountOperation = imports.ui.shellMountOperation;
-const Signals = imports.signals;
-const { St } = imports.gi;
+const {
+    Gio,
+    GLib,
+    GObject,
+    Shell,
+    St,
+} = imports.gi;
+
+const { shellMountOperation: ShellMountOperation } = imports.ui;
+const { signals: Signals } = imports;
 
 // Use __ () and N__() for the extension gettext domain, and reuse
 // the shell domain with the default _() and N_()

--- a/theming.js
+++ b/theming.js
@@ -2,16 +2,21 @@
 
 /* exported PositionStyleClass */
 
-const Signals = imports.signals;
-const { Meta } = imports.gi;
-const { St } = imports.gi;
-const { Clutter } = imports.gi;
+const { signals: Signals } = imports;
 
-const Main = imports.ui.main;
+const {
+    Clutter,
+    Meta,
+    St,
+} = imports.gi;
+
+const { main: Main } = imports.ui;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Docking = Me.imports.docking;
-const Utils = Me.imports.utils;
+const {
+    docking: Docking,
+    utils: Utils,
+} = Me.imports;
 
 /*
  * DEFAULT:  transparency given by theme

--- a/utils.js
+++ b/utils.js
@@ -4,19 +4,21 @@
             getWindowsByObjectPath, shellAppCompare, shellWindowsCompare,
             splitHandler, getMonitorManager, laterAdd, laterRemove */
 
-const Gi = imports._gi;
+const {
+    Clutter,
+    GLib,
+    Gio,
+    GObject,
+    Gtk,
+    Meta,
+    Shell,
+    St,
+} = imports.gi;
 
-const { Clutter } = imports.gi;
-const { GLib } = imports.gi;
-const { Gio } = imports.gi;
-const { GObject } = imports.gi;
-const { Gtk } = imports.gi;
-const { Meta } = imports.gi;
-const { Shell } = imports.gi;
-const { St } = imports.gi;
+const { _gi: Gi } = imports;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Docking = Me.imports.docking;
+const { docking: Docking } = Me.imports;
 
 var SignalsHandlerFlags = Object.freeze({
     NONE: 0,

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -7,21 +7,27 @@
 
 /* exported WindowPreviewMenu */
 
-const { Clutter } = imports.gi;
-const { GLib } = imports.gi;
-const { GObject } = imports.gi;
-const { Meta } = imports.gi;
-const { St } = imports.gi;
-const Main = imports.ui.main;
+const {
+    Clutter,
+    GLib,
+    GObject,
+    Meta,
+    St,
+} = imports.gi;
 
-const BoxPointer = imports.ui.boxpointer;
-const PopupMenu = imports.ui.popupMenu;
-const Workspace = imports.ui.workspace;
+const {
+    boxpointer: BoxPointer,
+    main: Main,
+    popupMenu: PopupMenu,
+    workspace: Workspace,
+} = imports.ui;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Docking = Me.imports.docking;
-const Theming = Me.imports.theming;
-const Utils = Me.imports.utils;
+const {
+    docking: Docking,
+    theming: Theming,
+    utils: Utils,
+} = Me.imports;
 
 const PREVIEW_MAX_WIDTH = 250;
 const PREVIEW_MAX_HEIGHT = 150;


### PR DESCRIPTION
These are safer because they perform an implicit existence check.