### PR TITLE
Fix consistency of full stops in strings

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -520,7 +520,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="multi_monitor_button">
-                                <property name="label" translatable="yes">Show on all monitors.</property>
+                                <property name="label" translatable="yes">Show on all monitors</property>
                                 <property name="margin_top">12</property>
 
                                 <layout>
@@ -974,7 +974,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="application_button_isolation_button">
-                                <property name="label" translatable="yes">Isolate workspaces.</property>
+                                <property name="label" translatable="yes">Isolate workspaces</property>
                                 <property name="halign">start</property>
                                 <property name="margin_top">12</property>
 
@@ -987,7 +987,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="application_button_urgent_button">
-                                <property name="label" translatable="yes">Show urgent windows despite current workspace.</property>
+                                <property name="label" translatable="yes">Show urgent windows despite current workspace</property>
                                 <property name="halign">start</property>
                                 <property name="margin_top">12</property>
 
@@ -1000,7 +1000,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="application_button_monitor_isolation_button">
-                                <property name="label" translatable="yes">Isolate monitors.</property>
+                                <property name="label" translatable="yes">Isolate monitors</property>
                                 <property name="halign">start</property>
                                 <property name="margin_top">12</property>
 
@@ -1014,7 +1014,7 @@
                             <child>
                               <object class="GtkCheckButton" id="windows_preview_button">
                                 <property name="margin_top">3</property>
-                                <property name="label" translatable="yes">Show open windows previews.</property>
+                                <property name="label" translatable="yes">Show open windows' previews</property>
                                 <layout>
                                   <property name="column">0</property>
                                   <property name="row">1</property>
@@ -1116,7 +1116,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="application_button_first_button">
-                                <property name="label" translatable="yes">Move the applications button at the beginning of the dock.</property>
+                                <property name="label" translatable="yes">Move the applications button at the beginning of the dock</property>
                                 <property name="halign">start</property>
                                 <property name="margin_top">12</property>
 
@@ -1137,7 +1137,7 @@
                                   <object class="GtkLabel" id="label3">
                                     <property name="can_focus">0</property>
                                     <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Animate &lt;i&gt;Show Applications&lt;/i&gt;.</property>
+                                    <property name="label" translatable="yes">Animate &lt;i&gt;Show Applications&lt;/i&gt;</property>
                                     <property name="use_markup">1</property>
                                   </object>
                                 </child>
@@ -1401,7 +1401,7 @@
                               <object class="GtkLabel">
                                 <property name="can_focus">0</property>
                                 <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">When enabled application icons will show notification counters and progress-bars (if Unity API is used)</property>
+                                <property name="label" translatable="yes">When enabled application icons will show notification counters and progress-bars (if Unity API is used).</property>
                                 <property name="wrap">1</property>
                                 <property name="xalign">0</property>
                                 <style>

--- a/po/ar.po
+++ b/po/ar.po
@@ -178,7 +178,7 @@ msgstr "أظهر المرساة فوق"
 
 #: Settings.ui.h:24
 #, fuzzy
-msgid "Show on all monitors."
+msgid "Show on all monitors"
 msgstr "الشاشة الثانوية"
 
 #: Settings.ui.h:25
@@ -232,12 +232,12 @@ msgid "Show running applications"
 msgstr "أظهر التطبيقات قيد التشغيل"
 
 #: Settings.ui.h:39
-msgid "Isolate workspaces."
-msgstr "عزل مساحات العمل."
+msgid "Isolate workspaces"
+msgstr "عزل مساحات العمل"
 
 #: Settings.ui.h:40
-msgid "Show open windows previews."
-msgstr "عرض معاينات النوافذ المفتوحة."
+msgid "Show open windows previews"
+msgstr "عرض معاينات النوافذ المفتوحة"
 
 #: Settings.ui.h:41
 msgid ""
@@ -254,12 +254,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "أظهر أيقونة التطبيقات أولا"
 
 #: Settings.ui.h:43
-msgid "Move the applications button at the beginning of the dock."
-msgstr "تحريك زر التطبيقات في بداية الشريط."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "تحريك زر التطبيقات في بداية الشريط"
 
 #: Settings.ui.h:44
 #, fuzzy
-msgid "Animate <i>Show Applications</i>."
+msgid "Animate <i>Show Applications</i>"
 msgstr "أظهر أيقونة التطبيقات أولا"
 
 #: Settings.ui.h:45

--- a/po/cs.po
+++ b/po/cs.po
@@ -186,7 +186,7 @@ msgid "Show the dock on"
 msgstr "Kde zobrazit dok"
 
 #: Settings.ui.h:23
-msgid "Show on all monitors."
+msgid "Show on all monitors"
 msgstr "Zobrazit na všech obrazovkách"
 
 #: Settings.ui.h:24
@@ -243,15 +243,15 @@ msgid "Show running applications"
 msgstr "Zobrazit spuštěné aplikace"
 
 #: Settings.ui.h:38
-msgid "Isolate workspaces."
+msgid "Isolate workspaces"
 msgstr "Izolovat pracovní plochy"
 
 #: Settings.ui.h:39
-msgid "Isolate monitors."
+msgid "Isolate monitors"
 msgstr "Izolovat obrazovky"
 
 #: Settings.ui.h:40
-msgid "Show open windows previews."
+msgid "Show open windows previews"
 msgstr "Zobrazit náhledy oken"
 
 #: Settings.ui.h:41
@@ -267,11 +267,11 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Tlačítko přístupu ke všem aplikacím"
 
 #: Settings.ui.h:43
-msgid "Move the applications button at the beginning of the dock."
+msgid "Move the applications button at the beginning of the dock"
 msgstr "Přesunout tlačítko přístupu ke všem aplikacím na začátek doku"
 
 #: Settings.ui.h:44
-msgid "Animate <i>Show Applications</i>."
+msgid "Animate <i>Show Applications</i>"
 msgstr "Animace při zobrazení všech aplikací"
 
 #: Settings.ui.h:45

--- a/po/de.po
+++ b/po/de.po
@@ -55,8 +55,8 @@ msgid "Reset to defaults"
 msgstr "Auf Vorgaben zurücksetzen"
 
 #: prefs.js:678
-msgid "Managed by GNOME Multitasking's Application Switching setting"
-msgstr "Verwaltet von der Anwendungswechseleinstellung von GNOME-Multitasking"
+msgid "Managed by GNOME Multitasking's Application Switching setting."
+msgstr "Verwaltet von der Anwendungswechseleinstellung von GNOME-Multitasking."
 
 #: prefs.js:807
 msgid "Show dock and application numbers"
@@ -246,8 +246,8 @@ msgid "Show the dock on"
 msgstr "Dock anzeigen auf"
 
 #: Settings.ui.h:27
-msgid "Show on all monitors."
-msgstr "Auf allen Bildschirmen anzeigen."
+msgid "Show on all monitors"
+msgstr "Auf allen Bildschirmen anzeigen"
 
 #: Settings.ui.h:28
 msgid "Position on screen"
@@ -306,20 +306,20 @@ msgid "Show running applications"
 msgstr "Laufende Anwendungen anzeigen"
 
 #: Settings.ui.h:43
-msgid "Isolate workspaces."
-msgstr "Arbeitsflächen isolieren."
+msgid "Isolate workspaces"
+msgstr "Arbeitsflächen isolieren"
 
 #: Settings.ui.h:44
-msgid "Show urgent windows despite current workspace."
-msgstr "Dringende Fenster trotz aktuellem Arbeitsfläche anzeigen."
+msgid "Show urgent windows despite current workspace"
+msgstr "Dringende Fenster trotz aktuellem Arbeitsfläche anzeigen"
 
 #: Settings.ui.h:45
-msgid "Isolate monitors."
-msgstr "Bildschirme isolieren."
+msgid "Isolate monitors"
+msgstr "Bildschirme isolieren"
 
 #: Settings.ui.h:46
-msgid "Show open windows previews."
-msgstr "Vorschauen der geöffneten Fenster anzeigen."
+msgid "Show open windows previews"
+msgstr "Vorschauen der geöffneten Fenster anzeigen"
 
 #: Settings.ui.h:47
 msgid "Keep the focused application always visible in the dash"
@@ -339,12 +339,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Symbol <i>Anwendungen</i> anzeigen"
 
 #: Settings.ui.h:50
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Die Anwendungen-Schaltfläche am Anfang des Docks verschieben."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Die Anwendungen-Schaltfläche am Anfang des Docks verschieben"
 
 #: Settings.ui.h:51
-msgid "Animate <i>Show Applications</i>."
-msgstr "<i>Anwendungen anzeigen</i> animieren."
+msgid "Animate <i>Show Applications</i>"
+msgstr "<i>Anwendungen anzeigen</i> animieren"
 
 #: Settings.ui.h:52
 msgid "Show trash can"
@@ -381,10 +381,10 @@ msgstr "Symbol-Embleme anzeigen"
 #: Settings.ui.h:60
 msgid ""
 "When enabled application icons will show notification counters and progress-"
-"bars (if Unity API is used)"
+"bars (if Unity API is used)."
 msgstr ""
 "Wenn aktiviert, zeigen die Anwendungssymbole Benachrichtigungszähler und "
-"Fortschrittsbalken an (wenn die Unity-API verwendet wird)"
+"Fortschrittsbalken an (wenn die Unity-API verwendet wird)."
 
 #: Settings.ui.h:61
 msgid "Launchers"

--- a/po/el.po
+++ b/po/el.po
@@ -165,8 +165,8 @@ msgid "Show the dock on"
 msgstr "Εμφάνιση της μπάρας στην"
 
 #: Settings.ui.h:24
-msgid "Show on all monitors."
-msgstr "Εμφάνιση σε όλες τις οθόνες."
+msgid "Show on all monitors"
+msgstr "Εμφάνιση σε όλες τις οθόνες"
 
 #: Settings.ui.h:25
 msgid "Position on screen"
@@ -222,12 +222,12 @@ msgid "Show running applications"
 msgstr "Εμφάνιση εκτελούμενων εφαρμογών"
 
 #: Settings.ui.h:39
-msgid "Isolate workspaces."
-msgstr "Απομόνωση χώρων εργασίας."
+msgid "Isolate workspaces"
+msgstr "Απομόνωση χώρων εργασίας"
 
 #: Settings.ui.h:40
-msgid "Show open windows previews."
-msgstr "Εμφάνιση προεπισκόπησης ανοικτών παραθύρων."
+msgid "Show open windows previews"
+msgstr "Εμφάνιση προεπισκόπησης ανοικτών παραθύρων"
 
 #: Settings.ui.h:41
 msgid ""
@@ -242,12 +242,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Εμφάνιση εικονιδίου <i>Εφαρμογές</i>"
 
 #: Settings.ui.h:43
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Μετακίνηση του πλήκτρου εφαρμογών στην αρχή της μπάρας."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Μετακίνηση του πλήκτρου εφαρμογών στην αρχή της μπάρας"
 
 #: Settings.ui.h:44
-msgid "Animate <i>Show Applications</i>."
-msgstr "Ενεργοποίηση γραφικών κατά την <i>Εμφάνιση Εφαρμογών</i>."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Ενεργοποίηση γραφικών κατά την <i>Εμφάνιση Εφαρμογών</i>"
 
 #: Settings.ui.h:45
 msgid "Launchers"

--- a/po/es.po
+++ b/po/es.po
@@ -49,10 +49,10 @@ msgid "Reset to defaults"
 msgstr "Restablecer la configuración predeterminada"
 
 #: prefs.js:678
-msgid "Managed by GNOME Multitasking's Application Switching setting"
+msgid "Managed by GNOME Multitasking's Application Switching setting."
 msgstr ""
 "Gestionado en la configuración Multitarea de GNOME en la opción Cambio de "
-"aplicaciones"
+"aplicaciones."
 
 #: prefs.js:807
 msgid "Show dock and application numbers"
@@ -242,8 +242,8 @@ msgid "Show the dock on"
 msgstr "Mostrar el dock en"
 
 #: Settings.ui.h:27
-msgid "Show on all monitors."
-msgstr "Mostrar en todos los monitores."
+msgid "Show on all monitors"
+msgstr "Mostrar en todos los monitores"
 
 #: Settings.ui.h:28
 msgid "Position on screen"
@@ -302,20 +302,20 @@ msgid "Show running applications"
 msgstr "Mostrar aplicaciones en ejecución"
 
 #: Settings.ui.h:43
-msgid "Isolate workspaces."
-msgstr "Aislar los espacios de trabajo."
+msgid "Isolate workspaces"
+msgstr "Aislar los espacios de trabajo"
 
 #: Settings.ui.h:44
-msgid "Show urgent windows despite current workspace."
-msgstr "Mostrar ventanas urgentes sin importar el espacio de trabajo actual."
+msgid "Show urgent windows despite current workspace"
+msgstr "Mostrar ventanas urgentes sin importar el espacio de trabajo actual"
 
 #: Settings.ui.h:45
-msgid "Isolate monitors."
-msgstr "Aislar los monitores."
+msgid "Isolate monitors"
+msgstr "Aislar los monitores"
 
 #: Settings.ui.h:46
-msgid "Show open windows previews."
-msgstr "Mostrar previsualización de ventanas abiertas."
+msgid "Show open windows previews"
+msgstr "Mostrar previsualización de ventanas abiertas"
 
 #: Settings.ui.h:47
 msgid "Keep the focused application always visible in the dash"
@@ -334,12 +334,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Mostrar el icono <i>Aplicaciones</i>"
 
 #: Settings.ui.h:50
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Mover el botón de aplicaciones al comienzo del dock."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Mover el botón de aplicaciones al comienzo del dock"
 
 #: Settings.ui.h:51
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animar <i>Mostrar aplicaciones</i>."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Animar <i>Mostrar aplicaciones</i>"
 
 #: Settings.ui.h:52
 msgid "Show trash can"
@@ -378,7 +378,7 @@ msgstr ""
 #: Settings.ui.h:60
 msgid ""
 "When enabled application icons will show notification counters and progress-"
-"bars (if Unity API is used)"
+"bars (if Unity API is used)."
 msgstr ""
 
 #: Settings.ui.h:61

--- a/po/eu.po
+++ b/po/eu.po
@@ -183,8 +183,8 @@ msgid "Show the dock on"
 msgstr "Erakutsi atrakea hemen"
 
 #: Settings.ui.h:24
-msgid "Show on all monitors."
-msgstr "Erakutsi monitore guztietan."
+msgid "Show on all monitors"
+msgstr "Erakutsi monitore guztietan"
 
 #: Settings.ui.h:25
 msgid "Position on screen"
@@ -239,16 +239,16 @@ msgid "Show running applications"
 msgstr "Erakutsi martxan dauden aplikazioak"
 
 #: Settings.ui.h:39
-msgid "Isolate workspaces."
-msgstr "Isolatu laneako areak."
+msgid "Isolate workspaces"
+msgstr "Isolatu laneako areak"
 
 #: Settings.ui.h:40
-msgid "Isolate monitors."
-msgstr "Isolatu monitoreak."
+msgid "Isolate monitors"
+msgstr "Isolatu monitoreak"
 
 #: Settings.ui.h:41
-msgid "Show open windows previews."
-msgstr "Erakutsi irekitako leihoen aurrebistak."
+msgid "Show open windows previews"
+msgstr "Erakutsi irekitako leihoen aurrebistak"
 
 #: Settings.ui.h:42
 msgid ""
@@ -263,12 +263,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Erakutsi <i>Aplikazioak</i> ikonoa"
 
 #: Settings.ui.h:44
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Eraman aplikazioen botoia atrakearen hasierara."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Eraman aplikazioen botoia atrakearen hasierara"
 
 #: Settings.ui.h:45
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animatu <i>Erakutsi aplikazioak</i> ekintza."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Animatu <i>Erakutsi aplikazioak</i> ekintza"
 
 #: Settings.ui.h:46
 msgid "Show trash can"

--- a/po/fr.po
+++ b/po/fr.po
@@ -50,7 +50,7 @@ msgid "Reset to defaults"
 msgstr "Restaurer la configuration par défaut"
 
 #: prefs.js:647
-msgid "Managed by GNOME Multitasking's Application Switching setting"
+msgid "Managed by GNOME Multitasking's Application Switching setting."
 msgstr "Géré par le paramètre de changement d’application de GNOME Multitâche."
 
 #: prefs.js:765
@@ -241,8 +241,8 @@ msgid "Show the dock on"
 msgstr "Afficher le dock sur le"
 
 #: Settings.ui.h:27
-msgid "Show on all monitors."
-msgstr "Afficher sur tous les écrans."
+msgid "Show on all monitors"
+msgstr "Afficher sur tous les écrans"
 
 #: Settings.ui.h:28
 msgid "Position on screen"
@@ -301,20 +301,20 @@ msgid "Show running applications"
 msgstr "Afficher les applications en cours"
 
 #: Settings.ui.h:43
-msgid "Isolate workspaces."
-msgstr "Isoler les espaces de travail."
+msgid "Isolate workspaces"
+msgstr "Isoler les espaces de travail"
 
 #: Settings.ui.h:44
-msgid "Show urgent windows despite current workspace."
-msgstr "Afficher les fenêtres urgentes nonobstant l’espace de travail actuel."
+msgid "Show urgent windows despite current workspace"
+msgstr "Afficher les fenêtres urgentes nonobstant l’espace de travail actuel"
 
 #: Settings.ui.h:45
-msgid "Isolate monitors."
-msgstr "Isoler les moniteurs."
+msgid "Isolate monitors"
+msgstr "Isoler les moniteurs"
 
 #: Settings.ui.h:46
-msgid "Show open windows previews."
-msgstr "Afficher des aperçus de fenêtres."
+msgid "Show open windows previews"
+msgstr "Afficher des aperçus de fenêtres"
 
 #: Settings.ui.h:47
 msgid "Keep the focused application always visible in the dash"
@@ -333,12 +333,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Afficher le raccourci <i>Afficher les Applications</i>"
 
 #: Settings.ui.h:50
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Placer le bouton des applications en première position."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Placer le bouton des applications en première position"
 
 #: Settings.ui.h:51
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animer le raccourci <i>Afficher les Applications</i>."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Animer le raccourci <i>Afficher les Applications</i>"
 
 #: Settings.ui.h:52
 msgid "Show trash can"

--- a/po/gl.po
+++ b/po/gl.po
@@ -162,8 +162,8 @@ msgid "Show the dock on"
 msgstr "Mostrar o dock en"
 
 #: Settings.ui.h:24
-msgid "Show on all monitors."
-msgstr "Mostrar en todos os monitores."
+msgid "Show on all monitors"
+msgstr "Mostrar en todos os monitores"
 
 #: Settings.ui.h:25
 msgid "Position on screen"
@@ -218,12 +218,12 @@ msgid "Show running applications"
 msgstr "Mostrar aplicativos en execución"
 
 #: Settings.ui.h:39
-msgid "Isolate workspaces."
-msgstr "Illar os espazos de traballo."
+msgid "Isolate workspaces"
+msgstr "Illar os espazos de traballo"
 
 #: Settings.ui.h:40
-msgid "Show open windows previews."
-msgstr "Mostrar vista rápida de ventás."
+msgid "Show open windows previews"
+msgstr "Mostrar vista rápida de ventás"
 
 #: Settings.ui.h:41
 msgid ""
@@ -238,11 +238,11 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Mostrar a icona <i>Aplicativos</i>"
 
 #: Settings.ui.h:43
-msgid "Move the applications button at the beginning of the dock."
+msgid "Move the applications button at the beginning of the dock"
 msgstr "Mover o botón de aplicativos ao principio do dock"
 
 #: Settings.ui.h:44
-msgid "Animate <i>Show Applications</i>."
+msgid "Animate <i>Show Applications</i>"
 msgstr "Animar <i>Mostrar aplicativos</i>"
 
 #: Settings.ui.h:45

--- a/po/hu.po
+++ b/po/hu.po
@@ -202,8 +202,8 @@ msgid "Show the dock on"
 msgstr "A dokk megjelenítése"
 
 #: Settings.ui.h:25
-msgid "Show on all monitors."
-msgstr "Megjelenítés az összes kijelzőn."
+msgid "Show on all monitors"
+msgstr "Megjelenítés az összes kijelzőn"
 
 #: Settings.ui.h:26
 msgid "Position on screen"
@@ -262,20 +262,20 @@ msgid "Show running applications"
 msgstr "Futó alkalmazások megjelenítése"
 
 #: Settings.ui.h:41
-msgid "Isolate workspaces."
-msgstr "Munkaterületek elkülönítése."
+msgid "Isolate workspaces"
+msgstr "Munkaterületek elkülönítése"
 
 #: Settings.ui.h:42
-msgid "Show urgent windows despite current workspace."
-msgstr "Sürgős ablakok megjelenítése az aktuális munkaterület ellenére."
+msgid "Show urgent windows despite current workspace"
+msgstr "Sürgős ablakok megjelenítése az aktuális munkaterület ellenére"
 
 #: Settings.ui.h:43
-msgid "Isolate monitors."
-msgstr "Kijelzők elkülönítése."
+msgid "Isolate monitors"
+msgstr "Kijelzők elkülönítése"
 
 #: Settings.ui.h:44
-msgid "Show open windows previews."
-msgstr "Nyitott ablakok előnézeteinek megjelenítése."
+msgid "Show open windows previews"
+msgstr "Nyitott ablakok előnézeteinek megjelenítése"
 
 #: Settings.ui.h:45
 msgid "Keep the focused application always visible in the dash"
@@ -294,12 +294,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "<i>Alkalmazások</i> ikon megjelenítése"
 
 #: Settings.ui.h:48
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Az alkalmazások gombjának áthelyezése a dokk elejére."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Az alkalmazások gombjának áthelyezése a dokk elejére"
 
 #: Settings.ui.h:49
-msgid "Animate <i>Show Applications</i>."
-msgstr "<i>Alkalmazások megjelenítése</i> animálása."
+msgid "Animate <i>Show Applications</i>"
+msgstr "<i>Alkalmazások megjelenítése</i> animálása"
 
 #: Settings.ui.h:50
 msgid "Show trash can"

--- a/po/id.po
+++ b/po/id.po
@@ -163,8 +163,8 @@ msgid "Show the dock on"
 msgstr "Tunjukkan dock pada"
 
 #: Settings.ui.h:24
-msgid "Show on all monitors."
-msgstr "Tunjukkan pada semua monitor."
+msgid "Show on all monitors"
+msgstr "Tunjukkan pada semua monitor"
 
 #: Settings.ui.h:25
 msgid "Position on screen"
@@ -219,12 +219,12 @@ msgid "Show running applications"
 msgstr "Tampilkan aplikasi yang sedang berjalan"
 
 #: Settings.ui.h:39
-msgid "Isolate workspaces."
-msgstr "Isolasi ruang kerja."
+msgid "Isolate workspaces"
+msgstr "Isolasi ruang kerja"
 
 #: Settings.ui.h:40
-msgid "Show open windows previews."
-msgstr "Tampilkan pratinjau windows yang terbuka."
+msgid "Show open windows previews"
+msgstr "Tampilkan pratinjau windows yang terbuka"
 
 #: Settings.ui.h:41
 msgid ""
@@ -239,12 +239,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Tampilkan ikon <i>Aplikasi</ i>"
 
 #: Settings.ui.h:43
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Pindahkan tombol aplikasi di awal dock."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Pindahkan tombol aplikasi di awal dock"
 
 #: Settings.ui.h:44
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animasi <i>Tampilkan Aplikasi</ i>."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Animasi <i>Tampilkan Aplikasi</i>"
 
 #: Settings.ui.h:45
 msgid "Launchers"

--- a/po/it.po
+++ b/po/it.po
@@ -202,8 +202,8 @@ msgid "Show the dock on"
 msgstr "Mostra dock su"
 
 #: Settings.ui.h:25
-msgid "Show on all monitors."
-msgstr "Mostra su tutti gli schermi."
+msgid "Show on all monitors"
+msgstr "Mostra su tutti gli schermi"
 
 #: Settings.ui.h:26
 msgid "Position on screen"
@@ -262,20 +262,20 @@ msgid "Show running applications"
 msgstr "Mostra applicazioni in esecuzione"
 
 #: Settings.ui.h:41
-msgid "Isolate workspaces."
-msgstr "Isola spazi di lavoro."
+msgid "Isolate workspaces"
+msgstr "Isola spazi di lavoro"
 
 #: Settings.ui.h:42
-msgid "Show urgent windows despite current workspace."
-msgstr "Mostra finestre urgenti nonostante lo spazio di lavoro corrente."
+msgid "Show urgent windows despite current workspace"
+msgstr "Mostra finestre urgenti nonostante lo spazio di lavoro corrente"
 
 #: Settings.ui.h:43
-msgid "Isolate monitors."
-msgstr "Isola gli schermi."
+msgid "Isolate monitors"
+msgstr "Isola gli schermi"
 
 #: Settings.ui.h:44
-msgid "Show open windows previews."
-msgstr "Mostra anteprime delle finestre aperte."
+msgid "Show open windows previews"
+msgstr "Mostra anteprime delle finestre aperte"
 
 #: Settings.ui.h:45
 msgid "Keep the focused application always visible in the dash"
@@ -294,12 +294,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Mostra icona <i>Applicazioni</i>"
 
 #: Settings.ui.h:48
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Sposta il pulsante delle applicazioni all'inizio della dock."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Sposta il pulsante delle applicazioni all'inizio della dock"
 
 #: Settings.ui.h:49
-msgid "Animate <i>Show Applications</i>."
-msgstr "Anima <i>Mostra applicazioni</i>."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Anima <i>Mostra applicazioni</i>"
 
 #: Settings.ui.h:50
 msgid "Show trash can"

--- a/po/ja.po
+++ b/po/ja.po
@@ -219,7 +219,7 @@ msgid "Show the dock on"
 msgstr "ドックを表示するモニター"
 
 #: Settings.ui.h:23
-msgid "Show on all monitors."
+msgid "Show on all monitors"
 msgstr "すべてのモニターで表示"
 
 #: Settings.ui.h:24
@@ -275,15 +275,15 @@ msgid "Show running applications"
 msgstr "実行中アプリケーションの表示"
 
 #: Settings.ui.h:38
-msgid "Isolate workspaces."
+msgid "Isolate workspaces"
 msgstr "現在のワークスペースのみ表示"
 
 #: Settings.ui.h:39
-msgid "Isolate monitors."
+msgid "Isolate monitors"
 msgstr "現在のモニターのみ表示"
 
 #: Settings.ui.h:40
-msgid "Show open windows previews."
+msgid "Show open windows previews"
 msgstr "ウィンドウのプレビューを右クリックで表示可能にする"
 
 #: Settings.ui.h:41
@@ -299,11 +299,11 @@ msgid "Show <i>Applications</i> icon"
 msgstr "[アプリケーションを表示する] アイコンの表示"
 
 #: Settings.ui.h:43
-msgid "Move the applications button at the beginning of the dock."
+msgid "Move the applications button at the beginning of the dock"
 msgstr "ドックの先頭 (最上段または左端) に表示"
 
 #: Settings.ui.h:44
-msgid "Animate <i>Show Applications</i>."
+msgid "Animate <i>Show Applications</i>"
 msgstr "アニメーションしながらアプリケーション一覧を表示"
 
 #: Settings.ui.h:45

--- a/po/nb.po
+++ b/po/nb.po
@@ -155,8 +155,8 @@ msgid "Show the dock on"
 msgstr "Vis dokken på"
 
 #: Settings.ui.h:21
-msgid "Show on all monitors."
-msgstr "Vis på alle skjermer."
+msgid "Show on all monitors"
+msgstr "Vis på alle skjermer"
 
 #: Settings.ui.h:22
 msgid "Position on screen"
@@ -211,16 +211,16 @@ msgid "Show running applications"
 msgstr "Vis kjørende programmer"
 
 #: Settings.ui.h:36
-msgid "Isolate workspaces."
-msgstr "Isoler arbeidsområder."
+msgid "Isolate workspaces"
+msgstr "Isoler arbeidsområder"
 
 #: Settings.ui.h:37
-msgid "Isolate monitors."
-msgstr "Isoler skjermer."
+msgid "Isolate monitors"
+msgstr "Isoler skjermer"
 
 #: Settings.ui.h:38
-msgid "Show open windows previews."
-msgstr "Vis forhåndsvisning av åpne vinduer."
+msgid "Show open windows previews"
+msgstr "Vis forhåndsvisning av åpne vinduer"
 
 #: Settings.ui.h:39
 msgid ""
@@ -235,12 +235,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Vis <i>programmer</i> ikon"
 
 #: Settings.ui.h:41
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Flytt programmer-knappen til starten av dokken."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Flytt programmer-knappen til starten av dokken"
 
 #: Settings.ui.h:42
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animere <i>Vis programmer</i>."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Animere <i>Vis programmer</i>"
 
 #: Settings.ui.h:43
 msgid "Launchers"

--- a/po/nl.po
+++ b/po/nl.po
@@ -166,8 +166,8 @@ msgid "Show the dock on"
 msgstr "Dock tonen op"
 
 #: Settings.ui.h:23
-msgid "Show on all monitors."
-msgstr "Tonen op alle beeldschermen."
+msgid "Show on all monitors"
+msgstr "Tonen op alle beeldschermen"
 
 #: Settings.ui.h:24
 msgid "Position on screen"
@@ -223,16 +223,16 @@ msgid "Show running applications"
 msgstr "Geopende programma's tonen"
 
 #: Settings.ui.h:38
-msgid "Isolate workspaces."
-msgstr "Werkbladen isoleren."
+msgid "Isolate workspaces"
+msgstr "Werkbladen isoleren"
 
 #: Settings.ui.h:39
-msgid "Isolate monitors."
-msgstr "Beeldschermen isoleren."
+msgid "Isolate monitors"
+msgstr "Beeldschermen isoleren"
 
 #: Settings.ui.h:40
-msgid "Show open windows previews."
-msgstr "Voorbeelden van geopende vensters tonen."
+msgid "Show open windows previews"
+msgstr "Voorbeelden van geopende vensters tonen"
 
 #: Settings.ui.h:41
 msgid ""
@@ -247,12 +247,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Pictogram voor <i>Alle programma's</i> tonen"
 
 #: Settings.ui.h:43
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Verplaatst de 'Alle programma's'-knop naar het begin van het dock."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Verplaatst de 'Alle programma's'-knop naar het begin van het dock"
 
 #: Settings.ui.h:44
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animatie na klikken op <i>Alle programma's tonen</i>."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Animatie na klikken op <i>Alle programma's tonen</i>"
 
 #: Settings.ui.h:45
 msgid "Show trash can"

--- a/po/pl.po
+++ b/po/pl.po
@@ -187,8 +187,8 @@ msgid "Show the dock on"
 msgstr "Ekran wyświetlania doku"
 
 #: Settings.ui.h:23
-msgid "Show on all monitors."
-msgstr "Na wszystkich ekranach."
+msgid "Show on all monitors"
+msgstr "Na wszystkich ekranach"
 
 #: Settings.ui.h:24
 msgid "Position on screen"
@@ -243,16 +243,16 @@ msgid "Show running applications"
 msgstr "Uruchomione programy"
 
 #: Settings.ui.h:38
-msgid "Isolate workspaces."
-msgstr "Izolowanie obszarów roboczych."
+msgid "Isolate workspaces"
+msgstr "Izolowanie obszarów roboczych"
 
 #: Settings.ui.h:39
-msgid "Isolate monitors."
-msgstr "Izolowanie ekranów."
+msgid "Isolate monitors"
+msgstr "Izolowanie ekranów"
 
 #: Settings.ui.h:40
-msgid "Show open windows previews."
-msgstr "Podgląd otwartych okien."
+msgid "Show open windows previews"
+msgstr "Podgląd otwartych okien"
 
 #: Settings.ui.h:41
 msgid ""
@@ -267,12 +267,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Przycisk <i>Wyświetl programy</i>"
 
 #: Settings.ui.h:43
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Przemieszczenie przycisku programów na początek doku."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Przemieszczenie przycisku programów na początek doku"
 
 #: Settings.ui.h:44
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animowanie przycisku <i>Wyświetl programy</i>."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Animowanie przycisku <i>Wyświetl programy</i>"
 
 #: Settings.ui.h:45
 msgid "Show trash can"

--- a/po/pt.po
+++ b/po/pt.po
@@ -163,8 +163,8 @@ msgid "Show the dock on"
 msgstr "Mostrar a dock em"
 
 #: Settings.ui.h:23
-msgid "Show on all monitors."
-msgstr "Mostrar em todos os monitores."
+msgid "Show on all monitors"
+msgstr "Mostrar em todos os monitores"
 
 #: Settings.ui.h:24
 msgid "Position on screen"
@@ -219,16 +219,16 @@ msgid "Show running applications"
 msgstr "Mostrar aplicações em execução"
 
 #: Settings.ui.h:38
-msgid "Isolate workspaces."
-msgstr "Isolar áreas de trabalho."
+msgid "Isolate workspaces"
+msgstr "Isolar áreas de trabalho"
 
 #: Settings.ui.h:39
-msgid "Isolate monitors."
-msgstr "Isolar monitores."
+msgid "Isolate monitors"
+msgstr "Isolar monitores"
 
 #: Settings.ui.h:40
-msgid "Show open windows previews."
-msgstr "Mostrar antevisão das janelas abertas."
+msgid "Show open windows previews"
+msgstr "Mostrar antevisão das janelas abertas"
 
 #: Settings.ui.h:41
 msgid ""
@@ -243,12 +243,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Mostrar ícone das <i>Aplicações</i>"
 
 #: Settings.ui.h:43
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Mover o botão das aplicações para o início da dock."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Mover o botão das aplicações para o início da dock"
 
 #: Settings.ui.h:44
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animar <i>Mostrar aplicações</i>."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Animar <i>Mostrar aplicações</i>"
 
 #: Settings.ui.h:45
 msgid "Launchers"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -52,10 +52,10 @@ msgid "Reset to defaults"
 msgstr "Restaurar o padrão"
 
 #: prefs.js:621
-msgid "Managed by GNOME Multitasking's Application Switching setting"
+msgid "Managed by GNOME Multitasking's Application Switching setting."
 msgstr ""
 "Gerenciado pela configuração de alternância de aplicativos do GNOME "
-"Multitasking"
+"Multitasking."
 
 #: prefs.js:739
 msgid "Show dock and application numbers"
@@ -236,8 +236,8 @@ msgid "Show the dock on"
 msgstr "Exibir o dock"
 
 #: Settings.ui.h:25
-msgid "Show on all monitors."
-msgstr "Mostrar em todos os monitores."
+msgid "Show on all monitors"
+msgstr "Mostrar em todos os monitores"
 
 #: Settings.ui.h:26
 msgid "Position on screen"
@@ -296,20 +296,20 @@ msgid "Show running applications"
 msgstr "Mostrar aplicativos em execução"
 
 #: Settings.ui.h:41
-msgid "Isolate workspaces."
-msgstr "Isolar espaços de trabalho."
+msgid "Isolate workspaces"
+msgstr "Isolar espaços de trabalho"
 
 #: Settings.ui.h:42
-msgid "Show urgent windows despite current workspace."
-msgstr "Mostrar janelas urgentes apesar do espaço de trabalho atual."
+msgid "Show urgent windows despite current workspace"
+msgstr "Mostrar janelas urgentes apesar do espaço de trabalho atual"
 
 #: Settings.ui.h:43
-msgid "Isolate monitors."
-msgstr "Isolar monitores."
+msgid "Isolate monitors"
+msgstr "Isolar monitores"
 
 #: Settings.ui.h:44
-msgid "Show open windows previews."
-msgstr "Mostrar pré-visualizações de janelas abertas."
+msgid "Show open windows previews"
+msgstr "Mostrar pré-visualizações de janelas abertas"
 
 #: Settings.ui.h:45
 msgid "Keep the focused application always visible in the dash"
@@ -328,12 +328,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Exibir ícone dos <i>Aplicativos</i>"
 
 #: Settings.ui.h:48
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Mover o botão de aplicativos para o início do dock."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Mover o botão de aplicativos para o início do dock"
 
 #: Settings.ui.h:49
-msgid "Animate <i>Show Applications</i>."
-msgstr "<i>Mostrar aplicativos</i> com efeitos."
+msgid "Animate <i>Show Applications</i>"
+msgstr "<i>Mostrar aplicativos</i> com efeitos"
 
 #: Settings.ui.h:50
 msgid "Show trash can"

--- a/po/ru.po
+++ b/po/ru.po
@@ -199,8 +199,8 @@ msgid "Show the dock on"
 msgstr "Показывать Док на:"
 
 #: Settings.ui.h:24
-msgid "Show on all monitors."
-msgstr "Показывать на всех мониторах."
+msgid "Show on all monitors"
+msgstr "Показывать на всех мониторах"
 
 #: Settings.ui.h:25
 msgid "Position on screen"
@@ -261,20 +261,20 @@ msgid "Show running applications"
 msgstr "Показывать запущенные приложения"
 
 #: Settings.ui.h:40
-msgid "Isolate workspaces."
-msgstr "Изолировать рабочие столы."
+msgid "Isolate workspaces"
+msgstr "Изолировать рабочие столы"
 
 #: Settings.ui.h:39
-msgid "Show urgent windows despite current workspace."
-msgstr "Показывать срочные окна независимо от текущего рабочего стола."
+msgid "Show urgent windows despite current workspace"
+msgstr "Показывать срочные окна независимо от текущего рабочего стола"
 
 #: Settings.ui.h:39
-msgid "Isolate monitors."
-msgstr "Изолировать мониторы."
+msgid "Isolate monitors"
+msgstr "Изолировать мониторы"
 
 #: Settings.ui.h:43
-msgid "Show open windows previews."
-msgstr "Показывать миниатюры открытых окон."
+msgid "Show open windows previews"
+msgstr "Показывать миниатюры открытых окон"
 
 #: Settings.ui.h:44
 msgid "Keep the focused application always visible in the dash"
@@ -293,11 +293,11 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Показывать иконку <i>«Приложения»</i>"
 
 #: Settings.ui.h:47
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Расположить кнопку «Приложения» с другой стороны Дока."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Расположить кнопку «Приложения» с другой стороны Дока"
 
 #: Settings.ui.h:48
-msgid "Animate <i>Show Applications</i>."
+msgid "Animate <i>Show Applications</i>"
 msgstr "Анимация при показе <i>«Приложений»</i>"
 
 #: Settings.ui.h:49

--- a/po/sk.po
+++ b/po/sk.po
@@ -161,8 +161,8 @@ msgid "Show the dock on"
 msgstr "Zobraziť dok na"
 
 #: Settings.ui.h:24
-msgid "Show on all monitors."
-msgstr "Zobraziť na všetkých monitoroch."
+msgid "Show on all monitors"
+msgstr "Zobraziť na všetkých monitoroch"
 
 #: Settings.ui.h:25
 msgid "Position on screen"
@@ -217,12 +217,12 @@ msgid "Show running applications"
 msgstr "Zobraziť spustené aplikácie"
 
 #: Settings.ui.h:39
-msgid "Isolate workspaces."
-msgstr "Oddelené pracovné priestory."
+msgid "Isolate workspaces"
+msgstr "Oddelené pracovné priestory"
 
 #: Settings.ui.h:40
-msgid "Show open windows previews."
-msgstr "Zobraziť náhľady otvorených okien."
+msgid "Show open windows previews"
+msgstr "Zobraziť náhľady otvorených okien"
 
 #: Settings.ui.h:41
 msgid ""
@@ -237,12 +237,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Zobraziť ikonu <i>Aplikácie</i>"
 
 #: Settings.ui.h:43
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Premiestni tlačidlo aplikácií na začiatok doku."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Premiestni tlačidlo aplikácií na začiatok doku"
 
 #: Settings.ui.h:44
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animovať položku <i>Zobraziť aplikácie</i>."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Animovať položku <i>Zobraziť aplikácie</i>"
 
 #: Settings.ui.h:45
 msgid "Launchers"

--- a/po/sr.po
+++ b/po/sr.po
@@ -179,8 +179,8 @@ msgid "Show the dock on"
 msgstr "Прикажи док на"
 
 #: Settings.ui.h:26
-msgid "Show on all monitors."
-msgstr "Прикажи на свим мониторима."
+msgid "Show on all monitors"
+msgstr "Прикажи на свим мониторима"
 
 #: Settings.ui.h:27
 msgid "Position on screen"
@@ -235,16 +235,16 @@ msgid "Show running applications"
 msgstr "Приказ покренутих програма"
 
 #: Settings.ui.h:41
-msgid "Isolate workspaces."
-msgstr "Изолуј радне просторе."
+msgid "Isolate workspaces"
+msgstr "Изолуј радне просторе"
 
 #: Settings.ui.h:42
-msgid "Isolate monitors."
-msgstr "Изолуј мониторе."
+msgid "Isolate monitors"
+msgstr "Изолуј мониторе"
 
 #: Settings.ui.h:43
-msgid "Show open windows previews."
-msgstr "Прикажи сличице отворених прозора."
+msgid "Show open windows previews"
+msgstr "Прикажи сличице отворених прозора"
 
 #: Settings.ui.h:44
 msgid ""
@@ -259,12 +259,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Приказ иконице <i>Прикажи програме</i>"
 
 #: Settings.ui.h:46
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Помери дугме програма на почетак дока."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Помери дугме програма на почетак дока"
 
 #: Settings.ui.h:47
-msgid "Animate <i>Show Applications</i>."
-msgstr "Анимирај приказ програма."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Анимирај приказ програма"
 
 #: Settings.ui.h:48
 msgid "Launchers"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -178,8 +178,8 @@ msgid "Show the dock on"
 msgstr "Prikaži dok na"
 
 #: Settings.ui.h:26
-msgid "Show on all monitors."
-msgstr "Prikaži na svim monitorima."
+msgid "Show on all monitors"
+msgstr "Prikaži na svim monitorima"
 
 #: Settings.ui.h:27
 msgid "Position on screen"
@@ -234,16 +234,16 @@ msgid "Show running applications"
 msgstr "Prikaz pokrenutih programa"
 
 #: Settings.ui.h:41
-msgid "Isolate workspaces."
-msgstr "Izoluj radne prostore."
+msgid "Isolate workspaces"
+msgstr "Izoluj radne prostore"
 
 #: Settings.ui.h:42
-msgid "Isolate monitors."
-msgstr "Izoluj monitore."
+msgid "Isolate monitors"
+msgstr "Izoluj monitore"
 
 #: Settings.ui.h:43
-msgid "Show open windows previews."
-msgstr "Prikaži sličice otvorenih prozora."
+msgid "Show open windows previews"
+msgstr "Prikaži sličice otvorenih prozora"
 
 #: Settings.ui.h:44
 msgid ""
@@ -258,12 +258,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Prikaz ikonice <i>Prikaži programe</i>"
 
 #: Settings.ui.h:46
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Pomeri dugme programa na početak doka."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Pomeri dugme programa na početak doka"
 
 #: Settings.ui.h:47
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animiraj prikaz programa."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Animiraj prikaz programa"
 
 #: Settings.ui.h:48
 msgid "Launchers"

--- a/po/sv.po
+++ b/po/sv.po
@@ -49,8 +49,8 @@ msgid "Reset to defaults"
 msgstr "Återställ till standardvärden"
 
 #: prefs.js:649
-msgid "Managed by GNOME Multitasking's Application Switching setting"
-msgstr "Hanteras av GNOME Multikörnings programväxlingsinställning"
+msgid "Managed by GNOME Multitasking's Application Switching setting."
+msgstr "Hanteras av GNOME Multikörnings programväxlingsinställning."
 
 #: prefs.js:767
 msgid "Show dock and application numbers"
@@ -240,8 +240,8 @@ msgid "Show the dock on"
 msgstr "Visa dockan på"
 
 #: Settings.ui.h:27
-msgid "Show on all monitors."
-msgstr "Visa på alla skärmar."
+msgid "Show on all monitors"
+msgstr "Visa på alla skärmar"
 
 #: Settings.ui.h:28
 msgid "Position on screen"
@@ -300,20 +300,20 @@ msgid "Show running applications"
 msgstr "Visa körande program"
 
 #: Settings.ui.h:43
-msgid "Isolate workspaces."
-msgstr "Visa endast arbetsytans fönster."
+msgid "Isolate workspaces"
+msgstr "Visa endast arbetsytans fönster"
 
 #: Settings.ui.h:44
-msgid "Show urgent windows despite current workspace."
-msgstr "Visa brådskande fönster även på aktuell arbetsyta."
+msgid "Show urgent windows despite current workspace"
+msgstr "Visa brådskande fönster även på aktuell arbetsyta"
 
 #: Settings.ui.h:45
-msgid "Isolate monitors."
-msgstr "Visa endast skärmens fönster."
+msgid "Isolate monitors"
+msgstr "Visa endast skärmens fönster"
 
 #: Settings.ui.h:46
-msgid "Show open windows previews."
-msgstr "Visa förhandsgranskningar av öppna fönster."
+msgid "Show open windows previews"
+msgstr "Visa förhandsgranskningar av öppna fönster"
 
 #: Settings.ui.h:47
 msgid "Keep the focused application always visible in the dash"
@@ -332,12 +332,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Visa <i>Program</i>-ikon"
 
 #: Settings.ui.h:50
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Flytta programknappen till början av dockan."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Flytta programknappen till början av dockan"
 
 #: Settings.ui.h:51
-msgid "Animate <i>Show Applications</i>."
-msgstr "Animera <i>Visa program</i>."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Animera <i>Visa program</i>"
 
 #: Settings.ui.h:52
 msgid "Show trash can"

--- a/po/tr.po
+++ b/po/tr.po
@@ -57,8 +57,8 @@ msgid "Reset to defaults"
 msgstr "Varsayılan ayarlara dön"
 
 #: prefs.js:649
-msgid "Managed by GNOME Multitasking's Application Switching setting"
-msgstr "GNOME Çoklu Görev'in Uygulama Değiştirme ayarı tarafından yönetilir"
+msgid "Managed by GNOME Multitasking's Application Switching setting."
+msgstr "GNOME Çoklu Görev'in Uygulama Değiştirme ayarı tarafından yönetilir."
 
 #: prefs.js:767
 msgid "Show dock and application numbers"
@@ -297,8 +297,8 @@ msgid "Show the dock on"
 msgstr "Rıhtım'ı göster"
 
 #: Settings.ui.h:27
-msgid "Show on all monitors."
-msgstr "Tüm ekranlarda göster."
+msgid "Show on all monitors"
+msgstr "Tüm ekranlarda göster"
 
 #: Settings.ui.h:28
 msgid "Position on screen"
@@ -359,20 +359,20 @@ msgid "Show running applications"
 msgstr "Çalışan uygulamaları göster"
 
 #: Settings.ui.h:43
-msgid "Isolate workspaces."
-msgstr "Çalışma alanlarını ayır."
+msgid "Isolate workspaces"
+msgstr "Çalışma alanlarını ayır"
 
 #: Settings.ui.h:44
-msgid "Show urgent windows despite current workspace."
-msgstr "Geçerli çalışma alanına rağmen acil pencereleri göster."
+msgid "Show urgent windows despite current workspace"
+msgstr "Geçerli çalışma alanına rağmen acil pencereleri göster"
 
 #: Settings.ui.h:45
-msgid "Isolate monitors."
-msgstr "Ekranları ayır."
+msgid "Isolate monitors"
+msgstr "Ekranları ayır"
 
 #: Settings.ui.h:46
-msgid "Show open windows previews."
-msgstr "Açık pencere önizlemelerini göster."
+msgid "Show open windows previews"
+msgstr "Açık pencere önizlemelerini göster"
 
 #: Settings.ui.h:47
 msgid "Keep the focused application always visible in the dash"
@@ -393,12 +393,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "<i>Uygulamalar</i> simgesini göster"
 
 #: Settings.ui.h:50
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Uygulamalar simgesini rıhtım'ın başlangıcına taşı."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Uygulamalar simgesini rıhtım'ın başlangıcına taşı"
 
 #: Settings.ui.h:51
-msgid "Animate <i>Show Applications</i>."
-msgstr "<i>Uygulamalar</i> açılırken canlandırma göster."
+msgid "Animate <i>Show Applications</i>"
+msgstr "<i>Uygulamalar</i> açılırken canlandırma göster"
 
 #: Settings.ui.h:52
 msgid "Show trash can"

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -174,8 +174,8 @@ msgid "Show the dock on"
 msgstr "Показувати Док на"
 
 #: Settings.ui.h:26
-msgid "Show on all monitors."
-msgstr "Показувати Док на усіх моніторах."
+msgid "Show on all monitors"
+msgstr "Показувати Док на усіх моніторах"
 
 #: Settings.ui.h:27
 msgid "Position on screen"
@@ -232,16 +232,16 @@ msgid "Show running applications"
 msgstr "Показувати запущені програми"
 
 #: Settings.ui.h:41
-msgid "Isolate workspaces."
-msgstr "Обмежити робочим простором."
+msgid "Isolate workspaces"
+msgstr "Обмежити робочим простором"
 
 #: Settings.ui.h:42
-msgid "Isolate monitors."
-msgstr "Обмежити монітором."
+msgid "Isolate monitors"
+msgstr "Обмежити монітором"
 
 #: Settings.ui.h:43
-msgid "Show open windows previews."
-msgstr "Показувати мініатюри відкритих вікон."
+msgid "Show open windows previews"
+msgstr "Показувати мініатюри відкритих вікон"
 
 #: Settings.ui.h:44
 msgid ""
@@ -256,12 +256,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "Показувати піктограму <i>Програми</i>"
 
 #: Settings.ui.h:46
-msgid "Move the applications button at the beginning of the dock."
-msgstr "Кнопка \"Програми\" з іншої сторони Дока."
+msgid "Move the applications button at the beginning of the dock"
+msgstr "Кнопка \"Програми\" з іншої сторони Дока"
 
 #: Settings.ui.h:47
-msgid "Animate <i>Show Applications</i>."
-msgstr "Анімувати показ програм."
+msgid "Animate <i>Show Applications</i>"
+msgstr "Анімувати показ програм"
 
 #: Settings.ui.h:48
 msgid "Launchers"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -191,8 +191,8 @@ msgid "Show the dock on"
 msgstr "显示 Dock 于"
 
 #: Settings.ui.h:24
-msgid "Show on all monitors."
-msgstr "所有显示器上都显示。"
+msgid "Show on all monitors"
+msgstr "所有显示器上都显示"
 
 #: Settings.ui.h:25
 msgid "Position on screen"
@@ -247,16 +247,16 @@ msgid "Show running applications"
 msgstr "显示正在运行的应用程序"
 
 #: Settings.ui.h:39
-msgid "Isolate workspaces."
-msgstr "隔离工作区。"
+msgid "Isolate workspaces"
+msgstr "隔离工作区"
 
 #: Settings.ui.h:40
-msgid "Isolate monitors."
-msgstr "隔离显示器。"
+msgid "Isolate monitors"
+msgstr "隔离显示器"
 
 #: Settings.ui.h:41
-msgid "Show open windows previews."
-msgstr "显示打开窗口预览。"
+msgid "Show open windows previews"
+msgstr "显示打开窗口预览"
 
 #: Settings.ui.h:42
 msgid ""
@@ -269,12 +269,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "显示 <i>应用程序</i> 图标"
 
 #: Settings.ui.h:44
-msgid "Move the applications button at the beginning of the dock."
-msgstr "将应用程序图标移至 Dock 的起始位置。"
+msgid "Move the applications button at the beginning of the dock"
+msgstr "将应用程序图标移至 Dock 的起始位置"
 
 #: Settings.ui.h:45
-msgid "Animate <i>Show Applications</i>."
-msgstr "<i>显示应用程序</i>时播放动画。"
+msgid "Animate <i>Show Applications</i>"
+msgstr "<i>显示应用程序</i>时播放动画"
 
 #: Settings.ui.h:46
 msgid "Show trash can"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -185,8 +185,8 @@ msgid "Show the dock on"
 msgstr "Dock 顯示於"
 
 #: Settings.ui.h:23
-msgid "Show on all monitors."
-msgstr "在所有顯示器顯示。"
+msgid "Show on all monitors"
+msgstr "在所有顯示器顯示"
 
 #: Settings.ui.h:24
 msgid "Position on screen"
@@ -239,16 +239,16 @@ msgid "Show running applications"
 msgstr "顯示執行中應用程式"
 
 #: Settings.ui.h:38
-msgid "Isolate workspaces."
-msgstr "獨立工作區。"
+msgid "Isolate workspaces"
+msgstr "獨立工作區"
 
 #: Settings.ui.h:39
-msgid "Isolate monitors."
-msgstr "獨立顯示器。"
+msgid "Isolate monitors"
+msgstr "獨立顯示器"
 
 #: Settings.ui.h:40
-msgid "Show open windows previews."
-msgstr "顯示開啟視窗的預覽。"
+msgid "Show open windows previews"
+msgstr "顯示開啟視窗的預覽"
 
 #: Settings.ui.h:41
 msgid ""
@@ -261,12 +261,12 @@ msgid "Show <i>Applications</i> icon"
 msgstr "顯示 <i>應用程式</i> 圖示"
 
 #: Settings.ui.h:43
-msgid "Move the applications button at the beginning of the dock."
-msgstr "將應用程式按鈕移動到 Dock 開頭。"
+msgid "Move the applications button at the beginning of the dock"
+msgstr "將應用程式按鈕移動到 Dock 開頭"
 
 #: Settings.ui.h:44
-msgid "Animate <i>Show Applications</i>."
-msgstr "讓 <i>顯示應用程式</i> 有動畫。"
+msgid "Animate <i>Show Applications</i>"
+msgstr "讓 <i>顯示應用程式</i> 有動畫"
 
 #: Settings.ui.h:45
 msgid "Show trash can"

--- a/prefs.js
+++ b/prefs.js
@@ -675,7 +675,7 @@ var Settings = GObject.registerClass({
                     [check.label] = check.label.split('\n');
                 } else {
                     check.label += `\n${
-                        __('Managed by GNOME Multitasking\'s Application Switching setting')}`;
+                        __('Managed by GNOME Multitasking\'s Application Switching setting.')}`;
                 }
             });
         this._appSwitcherSettings.bind('current-workspace-only',


### PR DESCRIPTION
Convention for this extensions seems to be that titles don't have full stops, but descriptions do. This PR just fixes the 9 cases I found that break that convention.