### PR TITLE
Add more options to control the emblems visibility

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1414,6 +1414,20 @@
                               </object>
                             </child>
 
+                            <child>
+                              <object class="GtkCheckButton" id="notifications_counter_check">
+                                <property name="label" translatable="yes">Show the number of unread notifications</property>
+                                <property name="halign">start</property>
+                                <property name="margin_top">12</property>
+
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">2</property>
+                                  <property name="column-span">2</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
                           </object>
                         </property>
                       </object>

--- a/Settings.ui
+++ b/Settings.ui
@@ -1428,6 +1428,26 @@
                               </object>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="applications_override_counter">
+                                <style>
+                                  <class name="text-button"/>
+                                </style>
+                                <property name="margin_top">3</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="can_focus">0</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Application-provided counter overrides the notifications counter</property>
+                                  </object>
+                                </child>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">3</property>
+                                  <property name="column-span">2</property>
+                                </layout>
+                              </object>
+                            </child>
+
                           </object>
                         </property>
                       </object>

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -789,6 +789,13 @@ var UnityIndicator = class DashToDockUnityIndicator extends IndicatorBase {
     _updateNotificationsCount() {
         const remoteCount = this._remoteEntry['count-visible']
             ? this._remoteEntry.count ?? 0 : 0;
+
+        if (remoteCount > 0 &&
+            Docking.DockManager.settings.applicationCounterOverridesNotifications) {
+            this.setNotificationCount(remoteCount);
+            return;
+        }
+
         const { notificationsMonitor } = Docking.DockManager.getDefault();
         const notificationsCount = notificationsMonitor.getAppNotificationsCount(
             this._source.app.id);

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -53,7 +53,7 @@ var AppIconIndicator = class DashToDockAppIconIndicator {
             ({ runningIndicatorStyle } = settings);
 
         if (settings.showIconsEmblems &&
-            Docking.DockManager.getDefault().notificationsMonitor.enabled) {
+            !Docking.DockManager.getDefault().notificationsMonitor.dndMode) {
             const unityIndicator = new UnityIndicator(source);
             this._indicators.push(unityIndicator);
         }

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -748,8 +748,16 @@ var UnityIndicator = class DashToDockUnityIndicator extends IndicatorBase {
             fontSize /= 0.75;
         }
 
-        fontSize = Math.round((iconSize / defaultIconSize) * fontSize);
-        const leftMargin = Math.round((iconSize / defaultIconSize) * 3);
+        let sizeMultiplier;
+        if (iconSize < defaultIconSize) {
+            sizeMultiplier = Math.max(24, Math.min(iconSize +
+                iconSize * 0.3, defaultIconSize)) / defaultIconSize;
+        } else {
+            sizeMultiplier = iconSize / defaultIconSize;
+        }
+
+        fontSize = Math.round(sizeMultiplier * fontSize);
+        const leftMargin = Math.round(sizeMultiplier * 3);
 
         this._notificationBadgeLabel.set_style(
             `font-size: ${fontSize}px;` +

--- a/appIcons.js
+++ b/appIcons.js
@@ -197,6 +197,7 @@ var DockAbstractAppIcon = GObject.registerClass({
             'running-indicator-style',
             'show-icons-emblems',
             'show-icons-notifications-counter',
+            'application-counter-overrides-notifications',
         ].forEach(key => {
             this._signalsHandler.add(
                 Docking.DockManager.settings,

--- a/appIcons.js
+++ b/appIcons.js
@@ -196,6 +196,7 @@ var DockAbstractAppIcon = GObject.registerClass({
             'apply-custom-theme',
             'running-indicator-style',
             'show-icons-emblems',
+            'show-icons-notifications-counter',
         ].forEach(key => {
             this._signalsHandler.add(
                 Docking.DockManager.settings,

--- a/docking.js
+++ b/docking.js
@@ -2604,7 +2604,7 @@ var IconAnimator = class DashToDockIconAnimator {
             wiggle: [],
         };
         this._timeline = new Clutter.Timeline({
-            duration: Environment.adjustAnimationTime(ICON_ANIMATOR_DURATION),
+            duration: Environment.adjustAnimationTime(ICON_ANIMATOR_DURATION) || 1,
             repeat_count: -1,
             actor,
         });
@@ -2623,7 +2623,8 @@ var IconAnimator = class DashToDockIconAnimator {
     }
 
     _updateSettings() {
-        this._timeline.set_duration(Environment.adjustAnimationTime(ICON_ANIMATOR_DURATION));
+        this._timeline.set_duration(
+            Environment.adjustAnimationTime(ICON_ANIMATOR_DURATION) || 1);
     }
 
     destroy() {

--- a/docking.js
+++ b/docking.js
@@ -1652,14 +1652,17 @@ var DockManager = class DashToDockDockManager {
 
         Me.imports.extension.dockManager = this;
 
-        this._iconTheme = new Utils.IconTheme();
-        this._remoteModel = new LauncherAPI.LauncherEntryRemoteModel();
         this._signalsHandler = new Utils.GlobalSignalsHandler(this);
         this._methodInjections = new Utils.InjectionsHandler(this);
         this._vfuncInjections = new Utils.VFuncInjectionsHandler(this);
         this._propertyInjections = new Utils.PropertyInjectionsHandler(this);
         this._settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.dash-to-dock');
         this._appSwitcherSettings = new Gio.Settings({ schema_id: 'org.gnome.shell.app-switcher' });
+        this._mapSettingsValues();
+
+        this._iconTheme = new Utils.IconTheme();
+        this._remoteModel = new LauncherAPI.LauncherEntryRemoteModel();
+
         this._desktopIconsUsableArea = new DesktopIconsIntegration.DesktopIconsUsableAreaClass();
         this._oldDash = Main.overview.isDummy ? null : Main.overview.dash;
         this._discreteGpuAvailable = AppDisplay.discreteGpuAvailable;
@@ -1885,7 +1888,7 @@ var DockManager = class DashToDockDockManager {
             });
     }
 
-    _bindSettingsChanges() {
+    _mapSettingsValues() {
         this.settings.settingsSchema.list_keys().forEach(key => {
             const camelKey = key.replace(/-([a-z\d])/g, k => k[1].toUpperCase());
             const updateSetting = () => {
@@ -1906,7 +1909,9 @@ var DockManager = class DashToDockDockManager {
         Object.defineProperties(this.settings, {
             dockExtended: { get: () => this.settings.extendHeight },
         });
+    }
 
+    _bindSettingsChanges() {
         // Connect relevant signals to the toggling function
         this._signalsHandler.addWithLabel(Labels.SETTINGS, [
             Utils.getMonitorManager(),

--- a/notificationsMonitor.js
+++ b/notificationsMonitor.js
@@ -91,6 +91,15 @@ var NotificationsMonitor = class NotificationsManagerImpl {
                     const app = notification.source?.app ?? notification.source?._app;
 
                     if (app?.id) {
+                        if (notification.resident) {
+                            if (notification.acknowledged)
+                                return;
+
+                            this._signalsHandler.addWithLabel(Labels.NOTIFICATIONS,
+                                notification, 'notify::acknowledged',
+                                () => this._checkNotifications());
+                        }
+
                         this._signalsHandler.addWithLabel(Labels.NOTIFICATIONS,
                             notification, 'destroy', () => this._checkNotifications());
 

--- a/prefs.js
+++ b/prefs.js
@@ -743,6 +743,16 @@ var Settings = GObject.registerClass({
             this._builder.get_object('show_icons_emblems_switch'),
             'active',
             Gio.SettingsBindFlags.DEFAULT);
+        const notificationsCounterCheck = this._builder.get_object(
+            'notifications_counter_check');
+        this._settings.bind('show-icons-notifications-counter',
+            notificationsCounterCheck,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-icons-emblems',
+            notificationsCounterCheck,
+            'sensitive',
+            Gio.SettingsBindFlags.GET);
         this._settings.bind('show-show-apps-button',
             this._builder.get_object('show_applications_button_switch'),
             'active',

--- a/prefs.js
+++ b/prefs.js
@@ -753,6 +753,22 @@ var Settings = GObject.registerClass({
             notificationsCounterCheck,
             'sensitive',
             Gio.SettingsBindFlags.GET);
+
+        const applicationsOverrideCounter =
+            this._builder.get_object('applications_override_counter');
+        this._settings.bind('application-counter-overrides-notifications',
+            applicationsOverrideCounter,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        notificationsCounterCheck.bind_property('active',
+            applicationsOverrideCounter, 'sensitive',
+            GObject.BindingFlags.SYNC_CREATE);
+        this._settings.connect('changed::show-icons-emblems', () => {
+            if (this._settings.get_boolean('show-icons-emblems'))
+                applicationsOverrideCounter.sensitive = notificationsCounterCheck.active;
+            else
+                applicationsOverrideCounter.sensitive = false;
+        });
         this._settings.bind('show-show-apps-button',
             this._builder.get_object('show_applications_button_switch'),
             'active',

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -631,5 +631,10 @@
       <summary>Show the number of unread notifications in icons</summary>
       <description>Show application icons emblems such as notification</description>
     </key>
+    <key name="application-counter-overrides-notifications" type="b">
+      <default>true</default>
+      <summary>Wether the application-provioded counter via Unity API should override the notifications or be summed to it</summary>
+      <description>If an application provides a counter through the Unity API, then such value will be used. Otherwise the counter will be summed with the unread notification numbers (if enabled)</description>
+    </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -626,5 +626,10 @@
       <summary>Show application icons emblems</summary>
       <description>Show application icons emblems such as notification counters an progress bars.</description>
     </key>
+    <key name="show-icons-notifications-counter" type="b">
+      <default>true</default>
+      <summary>Show the number of unread notifications in icons</summary>
+      <description>Show application icons emblems such as notification</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
It's now possible to:
 - Toggle the emblems at all
 - Disable the notification counters
 - Control whether the notification numbers are summed with the applications-provided counts (no by default)

Closes: #1964