### PR TITLE
locations: Use an external helper to get the location handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ EXTRA_MODULES = \
                 fileManager1API.js \
                 launcherAPI.js \
                 locations.js \
+                locationsWorker.js \
                 notificationsMonitor.js \
                 windowPreview.js \
                 intellihide.js \

--- a/locations.js
+++ b/locations.js
@@ -32,7 +32,7 @@ const FILE_MANAGER_DESKTOP_APP_ID = 'org.gnome.Nautilus.desktop';
 const ATTRIBUTE_METADATA_CUSTOM_ICON = 'metadata::custom-icon';
 const TRASH_URI = 'trash://';
 const UPDATE_TRASH_DELAY = 1000;
-const LAUNCH_HANDLER_MAX_WAIT = 500;
+const LAUNCH_HANDLER_MAX_WAIT = 200;
 
 const NautilusFileOperations2Interface = '<node>\
     <interface name="org.gnome.Nautilus.FileOperations2">\
@@ -114,6 +114,13 @@ var LocationAppInfo = GObject.registerClass({
             Gio.Cancellable.$gtype),
     },
 }, class LocationAppInfo extends Gio.DesktopAppInfo {
+    static get GJS_BINARY_PATH() {
+        if (!this._gjsBinaryPath)
+            this._gjsBinaryPath = GLib.find_program_in_path('gjs');
+
+        return this._gjsBinaryPath;
+    }
+
     list_actions() {
         return [];
     }
@@ -169,13 +176,7 @@ var LocationAppInfo = GObject.registerClass({
                 Gio.IOErrorEnum.NOT_SUPPORTED, 'Launching with files not supported');
         }
 
-        const handler = this.getHandlerApp();
-        if (handler)
-            return handler.launch_uris([this.location.get_uri()], context);
-
-        const [ret] = GLib.spawn_async(null, this._getFallbackCommandLine().split(' '),
-            context?.get_environment() || null, GLib.SpawnFlags.SEARCH_PATH, null);
-        return ret;
+        return this.getHandlerApp().launch_uris([this.location.get_uri()], context);
     }
 
     vfunc_supports_uris() {
@@ -226,8 +227,11 @@ var LocationAppInfo = GObject.registerClass({
     }
 
     vfunc_get_commandline() {
-        return this.getHandlerApp()?.get_commandline() ??
-            this._getFallbackCommandLine();
+        try {
+            return this.getHandlerApp().get_commandline();
+        } catch {
+            return this._getFallbackCommandLine();
+        }
     }
 
     vfunc_get_display_name() {
@@ -345,60 +349,68 @@ var LocationAppInfo = GObject.registerClass({
         }
     }
 
-    getHandlerApp(cancellable) {
+    _getHandlerAppFromWorker(cancellable) {
+        const locationsWorker = GLib.build_filenamev([Me.path,
+            'locationsWorker.js']);
+        const locationsWorkerArgs = [LocationAppInfo.GJS_BINARY_PATH,
+            locationsWorker, 'handler', this.location.get_uri(),
+            '--timeout', `${LAUNCH_HANDLER_MAX_WAIT}`];
+        const subProcess = Gio.Subprocess.new(locationsWorkerArgs,
+            Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
+
+        try {
+            const [, stdOut, stdErr] = subProcess.communicate(null, cancellable);
+            subProcess.wait(cancellable);
+            const errorCode = subProcess.get_exit_status();
+
+            if (errorCode) {
+                const errorLines = imports.byteArray.toString(
+                    stdErr.get_data()).split('\n');
+
+                const error = new GLib.Error(Gio.IOErrorEnum,
+                    errorCode === GLib.MAXUINT8 ? 0 : errorCode, errorLines[0]);
+                error.stack = `${errorLines.slice(3).join('\n')}${error.stack}`;
+                throw error;
+            }
+
+            const desktopId = imports.byteArray.toString(stdOut.get_data()).trim();
+            const handlerApp = Shell.AppSystem.get_default().lookup_app(desktopId)?.appInfo;
+            return handlerApp;
+        } finally {
+            subProcess.force_exit();
+        }
+    }
+
+    getHandlerApp() {
         if (this._handlerApp)
             return this._handlerApp;
 
-        cancellable = cancellable ?? new Utils.CancellableChild(this.cancellable);
+        if (!this.location)
+            return null;
 
-        if (this._launchMaxWaitIds === undefined)
-            this._launchMaxWaitIds = new Set();
+        const cancellable = new Utils.CancellableChild(this.cancellable);
 
-        // GVfs providers could hang when querying the file informations, so we
-        // workaround this by using the async API in a sync way, but we need to
-        // use a timeout to avoid this to hang forever, better than hang the
-        // shell.
-        let handler, error, launchMaxWaitId;
-        Promise.race([
-            this._getHandlerAppAsync(cancellable),
-            new Promise((resolve, reject) => {
-                launchMaxWaitId = GLib.timeout_add(GLib.PRIORITY_DEFAULT,
-                    LAUNCH_HANDLER_MAX_WAIT, () => {
-                        this._launchMaxWaitIds.delete(launchMaxWaitId);
-                        launchMaxWaitId = 0;
-                        cancellable.cancel();
-                        reject(new GLib.Error(Gio.IOErrorEnum,
-                            Gio.IOErrorEnum.TIMED_OUT,
-                            `Searching for ${this.get_id()} handler took too long`));
-                        return GLib.SOURCE_REMOVE;
-                    });
-                this._launchMaxWaitIds.add(launchMaxWaitId);
-            }),
-        ]).then(h => (handler = h)).catch(e => (error = e));
+        try {
+            if (LocationAppInfo.GJS_BINARY_PATH)
+                this._handlerApp = this._getHandlerAppFromWorker(cancellable);
+            else
+                this._handlerApp = this.location.query_default_handler(cancellable);
+        } catch (e) {
+            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_MOUNTED))
+                return getFileManagerApp()?.appInfo;
 
-        while (handler === undefined && error === undefined)
-            GLib.MainContext.default().iteration(false);
+            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) {
+                logError(e, 'Impossible to find an URI handler for %s'.format(
+                    this.get_id()));
+            }
 
-        if (launchMaxWaitId) {
-            GLib.source_remove(launchMaxWaitId);
-            this._launchMaxWaitIds.delete(launchMaxWaitId);
+            throw e;
         }
 
-        if (this._handlerApp && error?.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.TIMED_OUT))
-            return this._handlerApp;
-
-        if (error)
-            throw error;
-
-        if (handler)
-            this._handlerApp = handler;
-
-        return handler;
+        return this._handlerApp;
     }
 
     destroy() {
-        this._launchMaxWaitIds?.forEach(id => GLib.source_remove(id));
-        this._launchMaxWaitIds = null;
         this.location = null;
         this.icon = null;
         this.name = null;

--- a/locations.js
+++ b/locations.js
@@ -327,7 +327,7 @@ var LocationAppInfo = GObject.registerClass({
             if (!GJS_SUPPORTS_FILE_IFACE_PROMISES) {
                 Gio._promisify(this.location.constructor.prototype,
                     'query_default_handler_async',
-                    'query_default_handler_async_finish');
+                    'query_default_handler_finish');
             }
 
             return await this.location.query_default_handler_async(

--- a/locations.js
+++ b/locations.js
@@ -1067,6 +1067,9 @@ function makeLocationApp(params) {
     // FIXME: We need to add a new API to Nautilus to open new windows
     shellApp._mi('can_open_new_window', () => {
         try {
+            if (!shellApp.get_n_windows())
+                return true;
+
             const handlerApp = shellApp.appInfo.getHandlerApp();
 
             if (handlerApp.has_key('SingleMainWindow'))
@@ -1090,6 +1093,10 @@ function makeLocationApp(params) {
 
     shellApp._mi('open_new_window', function (_om, workspace) {
         const context = global.create_app_launch_context(0, workspace);
+        if (!this.get_n_windows()) {
+            this.appInfo.launch([], context);
+            return;
+        }
         const appId = this.appInfo.get_id();
         Gio.AppInfo.create_from_commandline(this.appInfo.get_commandline(),
             this.appInfo.get_id(), appId

--- a/locations.js
+++ b/locations.js
@@ -1078,10 +1078,12 @@ function makeLocationApp(params) {
 
     shellApp._mi('open_new_window', function (_om, workspace) {
         const context = global.create_app_launch_context(0, workspace);
-        GLib.spawn_async(null,
-            [...this.appInfo.get_commandline().split(' ').filter(
-                t => !t.startsWith('%')), this.appInfo.location.get_uri()],
-            context.get_environment(), GLib.SpawnFlags.SEARCH_PATH, null);
+        const appId = this.appInfo.get_id();
+        Gio.AppInfo.create_from_commandline(this.appInfo.get_commandline(),
+            this.appInfo.get_id(), appId
+                ? Gio.AppInfoCreateFlags.SUPPORTS_STARTUP_NOTIFICATION
+                : Gio.AppInfoCreateFlags.NONE).launch_uris(
+            [this.appInfo.location.get_uri()], context);
     });
 
     if (shellApp.appInfo instanceof MountableVolumeAppInfo) {

--- a/locationsWorker.js
+++ b/locationsWorker.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env gjs
+
+const { GLib, Gio } = imports.gi;
+
+const currentPath = GLib.path_get_dirname(new Error().fileName);
+imports.searchPath.unshift(currentPath);
+
+const GJS_SUPPORTS_FILE_IFACE_PROMISES = imports.system.version >= 17101;
+
+if (GJS_SUPPORTS_FILE_IFACE_PROMISES)
+    Gio._promisify(Gio.File.prototype, 'query_default_handler_async');
+
+function getHandlerAppAsync(location, cancellable) {
+    if (!location)
+        return null;
+
+    if (!GJS_SUPPORTS_FILE_IFACE_PROMISES) {
+        Gio._promisify(location.constructor.prototype,
+            'query_default_handler_async',
+            'query_default_handler_finish');
+    }
+
+    return location.query_default_handler_async(
+        GLib.PRIORITY_DEFAULT, cancellable);
+}
+
+function main(argv) {
+    if (argv.length < 1) {
+        const currentBinary = GLib.path_get_basename(new Error().fileName);
+        printerr(`Usage: ${currentBinary} <action> uri [ --timeout <value> ]`);
+        return 1;
+    }
+
+    const [action, uri] = argv;
+    let timeout = 200;
+
+    if (action !== 'handler')
+        throw new TypeError(`Unexpected action ${action}`);
+
+    for (let i = 1; i < argv.length; ++i) {
+        if (argv[i] === '--timeout' && i < argv.length - 1)
+            timeout = argv[++i];
+    }
+
+    const location = Gio.File.new_for_uri(uri);
+    const cancellable = new Gio.Cancellable();
+
+    // GVfs providers could hang when querying the file information, so we
+    // workaround this by using the async API in a sync way, but we need to
+    // use a timeout to avoid this to hang forever, better than hang the
+    // shell.
+    let handler, error, launchMaxWaitId;
+    Promise.race([
+        getHandlerAppAsync(location, cancellable),
+        new Promise((resolve, reject) => {
+            launchMaxWaitId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, timeout, () => {
+                launchMaxWaitId = 0;
+                cancellable.cancel();
+                reject(new GLib.Error(Gio.IOErrorEnum,
+                    Gio.IOErrorEnum.TIMED_OUT,
+                    `Searching for ${location.get_uri()} handler took too long`));
+                return GLib.SOURCE_REMOVE;
+            });
+        }),
+    ]).then(h => (handler = h)).catch(e => (error = e));
+
+    while (handler === undefined && error === undefined)
+        GLib.MainContext.default().iteration(false);
+
+    if (launchMaxWaitId)
+        GLib.source_remove(launchMaxWaitId);
+
+    if (error) {
+        printerr(error.message);
+        logError(error);
+        return error.code ? error.code : GLib.MAXUINT8;
+    }
+
+    print(handler.get_id());
+
+    return 0;
+}
+
+main(ARGV);


### PR DESCRIPTION
Getting the default location handler has to be a sync operation because
the shell uses a sync operations to launch applications.
However, this may have lead to hanging the shell, making it unresponsive.

We handled this within the shell itself, but to get it working we had to
keep keep the main loop busy, leading to other issues (see LP: #2013070)

As per this, use an external helper that queries the files paths so that
we don't have to make the shell main loop to iterate, but all this is done
in an external process that we call still synchronously but with a minimal
timeout so that the main session won't ever hang.

Improves fix for: #1949
LP: #2013070