### PR TITLE
Support centered icons in panel mode

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1126,7 +1126,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="application_button_first_button">
-                                <property name="label" translatable="yes">Move the applications button at the beginning of the dock</property>
+                                <property name="label" translatable="yes">Move at beginning of the dock</property>
                                 <property name="halign">start</property>
                                 <property name="margin_top">12</property>
 

--- a/Settings.ui
+++ b/Settings.ui
@@ -764,6 +764,16 @@
                                 </layout>
                               </object>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="dock_center_icons_check">
+                                <property name="label" translatable="yes">Place icons to the center</property>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">2</property>
+                                  <property name="column-span">2</property>
+                                </layout>
+                              </object>
+                            </child>
                           </object>
                         </property>
                       </object>

--- a/Settings.ui
+++ b/Settings.ui
@@ -1158,6 +1158,27 @@
                                 </layout>
                               </object>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="show_apps_always_in_the_edge">
+                                <style>
+                                  <class name="text-button"/>
+                                </style>
+                                <property name="margin_top">3</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="can_focus">0</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Put &lt;i&gt;Show Applications&lt;/i&gt; in a dock edge when using Panel mode</property>
+                                    <property name="use_markup">1</property>
+                                  </object>
+                                </child>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">4</property>
+                                  <property name="column-span">2</property>
+                                </layout>
+                              </object>
+                            </child>
                           </object>
                         </property>
                       </object>

--- a/dash.js
+++ b/dash.js
@@ -152,13 +152,6 @@ var DockDash = GObject.registerClass({
             enable_mouse_scrolling: false,
         });
 
-        if (Docking.DockManager.settings.dockExtended) {
-            if (!this._isHorizontal)
-                this._scrollView.y_align = Clutter.ActorAlign.START;
-            else
-                this._scrollView.x_align = Clutter.ActorAlign.START;
-        }
-
         this._scrollView.connect('scroll-event', this._onScrollEvent.bind(this));
 
         const rtl = Clutter.get_default_text_direction() === Clutter.TextDirection.RTL;
@@ -746,6 +739,20 @@ var DockDash = GObject.registerClass({
         let running = this._appSystem.get_running();
         const dockManager = Docking.DockManager.getDefault();
         const { settings } = dockManager;
+
+        this._scrollView.set({
+            xAlign: Clutter.ActorAlign.FILL,
+            yAlign: Clutter.ActorAlign.FILL,
+        });
+        if (dockManager.settings.dockExtended) {
+            if (!this._isHorizontal) {
+                this._scrollView.yAlign = dockManager.settings.alwaysCenterIcons
+                    ? Clutter.ActorAlign.CENTER : Clutter.ActorAlign.START;
+            } else {
+                this._scrollView.xAlign = dockManager.settings.alwaysCenterIcons
+                    ? Clutter.ActorAlign.CENTER : Clutter.ActorAlign.START;
+            }
+        }
 
         if (settings.isolateWorkspaces ||
             settings.isolateMonitors) {

--- a/dash.js
+++ b/dash.js
@@ -106,12 +106,19 @@ var DockDash = GObject.registerClass({
 }, class DockDash extends St.Widget {
     _init(monitorIndex) {
         // Initialize icon variables and size
+        super._init({
+            name: 'dash',
+            offscreen_redirect: Clutter.OffscreenRedirect.ALWAYS,
+            layout_manager: new Clutter.BinLayout(),
+        });
+
         this._maxWidth = -1;
         this._maxHeight = -1;
         this.iconSize = Docking.DockManager.settings.dashMaxIconSize;
         this._availableIconSizes = baseIconSizes;
         this._shownInitially = false;
         this._initializeIconSize(this.iconSize);
+        this._signalsHandler = new Utils.GlobalSignalsHandler(this);
 
         this._separator = null;
 
@@ -126,12 +133,6 @@ var DockDash = GObject.registerClass({
         this._showLabelTimeoutId = 0;
         this._resetHoverTimeoutId = 0;
         this._labelShowing = false;
-
-        super._init({
-            name: 'dash',
-            offscreen_redirect: Clutter.OffscreenRedirect.ALWAYS,
-            layout_manager: new Clutter.BinLayout(),
-        });
 
         this._dashContainer = new St.BoxLayout({
             name: 'dashtodockDashContainer',
@@ -222,7 +223,6 @@ var DockDash = GObject.registerClass({
 
         this.iconAnimator = new Docking.IconAnimator(this);
 
-        this._signalsHandler = new Utils.GlobalSignalsHandler(this);
         this._signalsHandler.add([
             this._appSystem,
             'installed-changed',

--- a/docking.js
+++ b/docking.js
@@ -655,6 +655,10 @@ const DockedDash = GObject.registerClass({
             this._resetPosition.bind(this),
         ], [
             settings,
+            'changed::always-center-icons',
+            () => this.dash.resetAppIcons(),
+        ], [
+            settings,
             'changed::require-pressure-to-show',
             () => this._updateAutoHideBarriers(),
         ], [

--- a/docking.js
+++ b/docking.js
@@ -583,6 +583,12 @@ const DockedDash = GObject.registerClass({
             },
         ], [
             settings,
+            'changed::show-apps-always-in-the-edge',
+            () => {
+                this.dash.updateShowAppsButton();
+            },
+        ], [
+            settings,
             'changed::show-apps-at-top',
             () => {
                 this.dash.updateShowAppsButton();

--- a/docking.js
+++ b/docking.js
@@ -1146,15 +1146,12 @@ const DockedDash = GObject.registerClass({
         else
             this.remove_style_class_name('fixed');
 
-
         // Note: do not use the workarea coordinates in the direction on which the dock is placed,
         // to avoid a loop [position change -> workArea change -> position change] with
         // fixed dock.
         const workArea = Main.layoutManager.getWorkAreaForMonitor(this.monitorIndex);
 
-
         let fraction = DockManager.settings.heightFraction;
-
         if (extendHeight)
             fraction = 1;
         else if ((fraction < 0) || (fraction > 1))

--- a/notificationsMonitor.js
+++ b/notificationsMonitor.js
@@ -19,14 +19,10 @@ const {
     docking: Docking,
     utils: Utils,
 } = Me.imports;
-
-
 const Labels = Object.freeze({
     SOURCES: Symbol('sources'),
     NOTIFICATIONS: Symbol('notifications'),
 });
-
-
 var NotificationsMonitor = class NotificationsManagerImpl {
     constructor() {
         this._settings = new Gio.Settings({

--- a/prefs.js
+++ b/prefs.js
@@ -797,6 +797,14 @@ var Settings = GObject.registerClass({
             this._builder.get_object('application_button_animation_button'),
             'sensitive',
             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-apps-always-in-the-edge',
+            this._builder.get_object('show_apps_always_in_the_edge'),
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-show-apps-button',
+            this._builder.get_object('show_apps_always_in_the_edge'),
+            'sensitive',
+            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('scroll-to-focused-application',
             this._builder.get_object('scroll_to_icon_switch'),
             'active',

--- a/prefs.js
+++ b/prefs.js
@@ -650,6 +650,14 @@ var Settings = GObject.registerClass({
             this._builder.get_object('dock_size_scale'),
             'sensitive',
             Gio.SettingsBindFlags.INVERT_BOOLEAN);
+        this._settings.bind('always-center-icons',
+            this._builder.get_object('dock_center_icons_check'),
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('extend-height',
+            this._builder.get_object('dock_center_icons_check'),
+            'sensitive',
+            Gio.SettingsBindFlags.DEFAULT);
 
         this._settings.bind('multi-monitor',
             this._builder.get_object('dock_monitor_combo'),

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -313,6 +313,10 @@
       <default>false</default>
       <summary>Extend the dock container to all the available height/width</summary>
     </key>
+    <key type="b" name="always-center-icons">
+      <default>false</default>
+      <summary>Center icons when dock container is extended to all the available size</summary>
+    </key>
     <key type="i" name="preferred-monitor">
       <default>-2</default>
       <summary>DEPRECATED: Monitor on which putting the dock (by index)</summary>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -295,6 +295,10 @@
       <summary>Show application button on the left</summary>
       <description>Show application button on the left of the dash</description>
     </key>
+    <key type="b" name="show-apps-always-in-the-edge">
+      <default>true</default>
+      <summary>Show application button on the edge when using centered panel mode</summary>
+    </key>
     <key type="b" name="animate-show-apps">
       <default>true</default>
       <summary>Animate Show Applications from the desktop</summary>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -307,11 +307,11 @@
     </key>
     <key type="d" name="height-fraction">
       <default>0.90</default>
-      <summary>Dock max height (fraction of available space)</summary>
+      <summary>Dock max height/width (fraction of available space)</summary>
     </key>
     <key type="b" name="extend-height">
       <default>false</default>
-      <summary>Extend the dock container to all the available height</summary>
+      <summary>Extend the dock container to all the available height/width</summary>
     </key>
     <key type="i" name="preferred-monitor">
       <default>-2</default>


### PR DESCRIPTION
Added two options:
 - Keep icons always centered when in panel mode (under Position and Size)
 - Show _Show Apps_ button in the edge when using Panel mode (under Launchers)

This allows getting these results (same when show-apps is shown at the beginning):

![image](https://user-images.githubusercontent.com/345675/233165524-2e99ad46-b06a-486f-84c3-a1524e420379.png)

![image](https://user-images.githubusercontent.com/345675/233165567-623aa314-c4ad-4ff8-941e-e64590ca853d.png)

![image](https://user-images.githubusercontent.com/345675/233165631-6fa1012e-ef3d-4688-8e88-5fd272a2ba0a.png)

![image](https://user-images.githubusercontent.com/345675/233165692-89479cf9-6cab-4088-8381-01197ea679c7.png)

Closing: #1746 
