### PR TITLE
Fix Startup infinite await

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2209,6 +2209,64 @@ var DockManager = class DashToDockDockManager {
                 this._signalsHandler.removeWithLabel(Labels.STARTUP_ANIMATION);
             });
 
+        if (Main.layoutManager._startingUp && Main.layoutManager._waitLoaded) {
+            // Disable this on versions that will include:
+            //  https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2763
+            this._methodInjections.addWithLabel(Labels.STARTUP_ANIMATION,
+                Main.layoutManager.constructor.prototype,
+                '_prepareStartupAnimation', function (originalMethod, ...args) {
+                    /* eslint-disable no-invalid-this */
+                    const dockManager = DockManager.getDefault();
+                    const temporaryInjections = new Utils.InjectionsHandler(
+                        dockManager);
+
+                    const waitLoadedHandlingMonitors = (_, bgManager) => {
+                        return new Promise((resolve, reject) => {
+                            const connections = new Utils.GlobalSignalsHandler(
+                                dockManager);
+                            connections.add(bgManager, 'loaded', () => {
+                                connections.destroy();
+                                resolve();
+                            });
+
+                            connections.add(Utils.getMonitorManager(), 'monitors-changed', () => {
+                                connections.destroy();
+
+                                reject(new GLib.Error(Gio.IOErrorEnum,
+                                    Gio.IOErrorEnum.CANCELLED, 'Loading was cancelled'));
+                            });
+                        });
+                    };
+
+                    async function updateBg(originalUpdateBg, ...bgArgs) {
+                        while (true) {
+                            try {
+                                // eslint-disable-next-line no-await-in-loop
+                                await originalUpdateBg.call(this, ...bgArgs);
+                                break;
+                            } catch (e) {
+                                if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) {
+                                    logError(e);
+                                    return;
+                                }
+                            }
+                        }
+                    }
+
+                    temporaryInjections.add(this.constructor.prototype,
+                        '_waitLoaded', waitLoadedHandlingMonitors);
+                    temporaryInjections.add(this.constructor.prototype,
+                        '_updateBackgrounds', updateBg);
+
+                    try {
+                        originalMethod.call(this, ...args);
+                    } finally {
+                        temporaryInjections.destroy();
+                    }
+                    /* eslint-enable no-invalid-this */
+                });
+        }
+
         this._methodInjections.addWithLabel(Labels.STARTUP_ANIMATION, ControlsManager.prototype,
             'runStartupAnimation', async function (originalMethod, callback) {
                 /* eslint-disable no-invalid-this */

--- a/docking.js
+++ b/docking.js
@@ -2200,7 +2200,16 @@ var DockManager = class DashToDockDockManager {
 
         const { ControlsManager, ControlsManagerLayout } = OverviewControls;
 
-        this._methodInjections.addWithLabel(Labels.MAIN_DASH, ControlsManager.prototype,
+        this._methodInjections.removeWithLabel(Labels.STARTUP_ANIMATION);
+        this._methodInjections.addWithLabel(Labels.STARTUP_ANIMATION,
+            Main.layoutManager.constructor.prototype, '_startupAnimationComplete',
+            originalMethod => {
+                originalMethod.call(Main.layoutManager);
+                this._methodInjections.removeWithLabel(Labels.STARTUP_ANIMATION);
+                this._signalsHandler.removeWithLabel(Labels.STARTUP_ANIMATION);
+            });
+
+        this._methodInjections.addWithLabel(Labels.STARTUP_ANIMATION, ControlsManager.prototype,
             'runStartupAnimation', async function (originalMethod, callback) {
                 /* eslint-disable no-invalid-this */
                 try {
@@ -2422,7 +2431,7 @@ var DockManager = class DashToDockDockManager {
 
         if (Main.layoutManager._startingUp && Main.sessionMode.hasOverview &&
             this._settings.disableOverviewOnStartup) {
-            this._methodInjections.addWithLabel(Labels.MAIN_DASH,
+            this._methodInjections.addWithLabel(Labels.STARTUP_ANIMATION,
                 Overview.Overview.prototype,
                 'runStartupAnimation', (_originalFunction, callback) => {
                     const monitor = Main.layoutManager.primaryMonitor;

--- a/docking.js
+++ b/docking.js
@@ -2258,6 +2258,16 @@ var DockManager = class DashToDockDockManager {
                     temporaryInjections.add(this.constructor.prototype,
                         '_updateBackgrounds', updateBg);
 
+                    dockManager._signalsHandler.addWithLabel(Labels.STARTUP_ANIMATION,
+                        Utils.getMonitorManager(), 'monitors-changed', () => {
+                            const { x, y, width, height } = this.primaryMonitor;
+                            global.window_group.set_clip(x, y, width, height);
+                            this._coverPane?.set({
+                                width: global.screen_width,
+                                height: global.screen_height,
+                            });
+                        });
+
                     try {
                         originalMethod.call(this, ...args);
                     } finally {


### PR DESCRIPTION
Especially under X11 we may get "monitors-changed" event while the startup animation is in progress, while some of them were addressed by [!2269 (merged)](https://github.com/GNOME/gnome-shell/-/merge_requests/2269), we still have an issue happening:

GNOME shell is preparing the animation and awaiting for bg changes
Monitors are changed, during this phase we destroy the current background managers
=> The "loaded" signals we were waiting for, won't ever happen

This implies that we are stuck in `await this._updateBackgrounds()`; and thus we keep staying in broken mode.

Ubuntu issue is https://bugs.launchpad.net/ubuntu/+source/gnome-shell-extension-ubuntu-dock/+bug/2019751 it can be simulated with https://gitlab.gnome.org/3v1n0/gnome-shell/-/snippets/5749

Similar to https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2763 but on the dock side