### PR TITLE
intellihide: add dropdown menu to handled window types

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -41,6 +41,7 @@ const handledWindowTypes = [
     Meta.WindowType.MENU,
     Meta.WindowType.UTILITY,
     Meta.WindowType.SPLASHSCREEN,
+    Meta.WindowType.DROPDOWN_MENU,
 ];
 
 // List of applications, ignore windows of these applications in considering intellihide


### PR DESCRIPTION
This is a workaround for issue #2013. As far as I could tell this works in most cases of popup menus (by right clicks) in GNOME wayland session. The only exception I meet is the multilevel popup menu from Telegram (illustrated in #2013), but with showing urgent notifications off it also works without problems.

`Meta.WindowType.POPUP_MENU` is not added to this list as I find that it has side effects for Qt xwayland programs: on my machine the intellihide is triggered every time I right-clicked in Okular (xwayland). However I could not reproduce this within my GNOME OS VM so it might be caused by other factors.