### PR TITLE
docking: Do ControlsManagerLayout allocation with box-adjusted workArea

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2313,8 +2313,10 @@ var DockManager = class DashToDockDockManager {
                 const searchBox = this.overviewControls._searchEntry.get_allocation_box();
                 const { shouldShow: wsThumbnails } = this.overviewControls._thumbnailsBox;
 
-                if (!wsThumbnails)
+                if (!wsThumbnails) {
                     box.y1 += spacing;
+                    box.y2 -= spacing;
+                }
 
                 box.y2 -= searchBox.get_height() + spacing;
                 box.y2 -= spacing;

--- a/docking.js
+++ b/docking.js
@@ -2317,17 +2317,13 @@ var DockManager = class DashToDockDockManager {
                     box.y1 += spacing;
 
                 box.y2 -= searchBox.get_height() + spacing;
-
-                if (!wsThumbnails && this.mainDock.position === St.Side.BOTTOM)
-                    box.y2 -= spacing;
+                box.y2 -= spacing;
             }
 
             return box;
         };
 
         const maybeAdjustBoxToDock = (state, box, spacing) => {
-            const initialRatio = box.get_width() / box.get_height();
-
             maybeAdjustBoxSize(state, box, spacing);
 
             if (this.mainDock.isHorizontal || this.settings.dockFixed)
@@ -2340,11 +2336,6 @@ var DockManager = class DashToDockDockManager {
                 box.x1 += preferredWidth;
             else if (this.mainDock.position === St.Side.RIGHT)
                 box.x2 -= preferredWidth;
-
-            // Reduce the box height too, to keep the initial proportions
-            const heightAdjustment = (preferredWidth / initialRatio) / 2;
-            box.y1 += heightAdjustment;
-            box.y2 -= heightAdjustment;
 
             return box;
         };

--- a/docking.js
+++ b/docking.js
@@ -2308,9 +2308,7 @@ var DockManager = class DashToDockDockManager {
                 /* eslint-enable no-invalid-this */
             });
 
-        const maybeAdjustBoxToDock = (state, box, spacing) => {
-            const initialRatio = box.get_width() / box.get_height();
-
+        const maybeAdjustBoxSize = (state, box, spacing) => {
             if (state === OverviewControls.ControlsState.WINDOW_PICKER) {
                 const searchBox = this.overviewControls._searchEntry.get_allocation_box();
                 const { shouldShow: wsThumbnails } = this.overviewControls._thumbnailsBox;
@@ -2324,19 +2322,24 @@ var DockManager = class DashToDockDockManager {
                     box.y2 -= spacing;
             }
 
+            return box;
+        };
+
+        const maybeAdjustBoxToDock = (state, box, spacing) => {
+            const initialRatio = box.get_width() / box.get_height();
+
+            maybeAdjustBoxSize(state, box, spacing);
+
             if (this.mainDock.isHorizontal || this.settings.dockFixed)
                 return box;
 
-            let [, preferredWidth] = this.mainDock.get_preferred_width(box.get_height());
+            const [, preferredWidth] = this.mainDock.get_preferred_width(
+                box.get_height());
 
-            // For some reason we need to use an even value for the box area
-            // or we may end up in allocation issues:
-            // https://github.com/micheleg/dash-to-dock/issues/1612
-            preferredWidth = Math.floor(preferredWidth / 2.0) * 2;
-
-            box.x2 -= preferredWidth;
             if (this.mainDock.position === St.Side.LEFT)
-                box.set_origin(box.x1 + preferredWidth, box.y1);
+                box.x1 += preferredWidth;
+            else if (this.mainDock.position === St.Side.RIGHT)
+                box.x2 -= preferredWidth;
 
             // Reduce the box height too, to keep the initial proportions
             const heightAdjustment = (preferredWidth / initialRatio) / 2;
@@ -2360,17 +2363,19 @@ var DockManager = class DashToDockDockManager {
                 workAreaBox.set_origin(startX, startY);
                 workAreaBox.set_size(workArea.width, workArea.height);
 
+                maybeAdjustBoxToDock(undefined, workAreaBox, this.spacing);
+                const oldStartY = workAreaBox.y1;
+
                 const propertyInjections = new Utils.PropertyInjectionsHandler();
-                propertyInjections.add(Main.layoutManager.panelBox, 'height', { value: workAreaBox.y1 });
+                propertyInjections.add(Main.layoutManager.panelBox, 'height', { value: startY });
 
                 if (Main.layoutManager.panelBox.y === Main.layoutManager.primaryMonitor.y)
-                    workAreaBox.y1 -= startY;
+                    workAreaBox.y1 -= oldStartY;
 
                 this.vfunc_allocate(container, workAreaBox);
 
                 propertyInjections.destroy();
-                workAreaBox.y1 = startY;
-                maybeAdjustBoxToDock(undefined, workAreaBox, this.spacing);
+                workAreaBox.y1 = oldStartY;
 
                 const adjustActorHorizontalAllocation = actor => {
                     if (!actor.visible || !workAreaBox.x1)
@@ -2411,20 +2416,19 @@ var DockManager = class DashToDockDockManager {
             '_computeWorkspacesBoxForState',
             function (originalFunction, state, ...args) {
                 /* eslint-disable no-invalid-this */
+                if (state === OverviewControls.ControlsState.HIDDEN)
+                    return originalFunction.call(this, state, ...args);
+
                 const box = workspaceBoxOriginFixer.call(this, originalFunction, state, ...args);
-                if (state !== OverviewControls.ControlsState.HIDDEN)
-                    maybeAdjustBoxToDock(state, box, this.spacing);
-                return box;
+                return maybeAdjustBoxSize(state, box, this.spacing);
                 /* eslint-enable no-invalid-this */
             },
         ], [
             ControlsManagerLayout.prototype,
             '_getAppDisplayBoxForState',
-            function (originalFunction, state, ...args) {
+            function (originalFunction, ...args) {
                 /* eslint-disable no-invalid-this */
-                const { spacing } = this;
-                const box = workspaceBoxOriginFixer.call(this, originalFunction, state, ...args);
-                return maybeAdjustBoxToDock(state, box, spacing);
+                return workspaceBoxOriginFixer.call(this, originalFunction, ...args);
                 /* eslint-enable no-invalid-this */
             },
         ]);


### PR DESCRIPTION
We were allocating the ControlsManagerLayout using the whole work area geometry but then in the auto-hide mode we were reducing the size of the available area again, creating problems when the available space was reduced. Leading to non-clickable or activatable search results.

To prevent this, perform layout allocation using the available space even when the dock is in autohide mode.

Closes: #1612
LP: #1979096