### PR TITLE
dash: Use a different container to hold floating ShowAppsIcon

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -950,7 +950,7 @@ var DockDash = GObject.registerClass({
         // Skip animations on first run when adding the initial set
         // of items, to avoid all items zooming in at once
         const animate = this._shownInitially &&
-            !Main.overview.animationInProgress;
+            !Main.layoutManager._startingUp;
 
         if (!this._shownInitially)
             this._shownInitially = true;

--- a/dash.js
+++ b/dash.js
@@ -916,7 +916,7 @@ var DockDash = GObject.registerClass({
 
         // Update separator
         const nFavorites = Object.keys(favorites).length;
-        const nIcons = children.length + addedItems.length - removedActors.length;
+        const nIcons = this._box.get_n_children() - removedActors.length;
         if (nFavorites > 0 && nFavorites < nIcons) {
             if (!this._separator) {
                 this._separator = new St.Widget({

--- a/dash.js
+++ b/dash.js
@@ -851,8 +851,8 @@ var DockDash = GObject.registerClass({
         let newIndex = 0;
         let oldIndex = 0;
         while (newIndex < newApps.length || oldIndex < oldApps.length) {
-            const oldApp = oldApps.length > oldIndex ? oldApps[oldIndex] : null;
-            const newApp = newApps.length > newIndex ? newApps[newIndex] : null;
+            const oldApp = oldApps.at(oldIndex);
+            const newApp = newApps.at(newIndex);
 
             // No change at oldIndex/newIndex
             if (oldApp === newApp) {
@@ -870,9 +870,11 @@ var DockDash = GObject.registerClass({
 
             // App added at newIndex
             if (newApp && !oldApps.includes(newApp)) {
-                addedItems.push({ app: newApp,
+                addedItems.push({
+                    app: newApp,
                     item: this._createAppItem(newApp),
-                    pos: newIndex });
+                    pos: newIndex,
+                });
                 newIndex++;
                 continue;
             }
@@ -888,9 +890,11 @@ var DockDash = GObject.registerClass({
 
             if (insertHere || alreadyRemoved) {
                 const newItem = this._createAppItem(newApp);
-                addedItems.push({ app: newApp,
+                addedItems.push({
+                    app: newApp,
                     item: newItem,
-                    pos: newIndex + removedActors.length });
+                    pos: newIndex + removedActors.length,
+                });
                 newIndex++;
             } else {
                 removedActors.push(children[oldIndex]);
@@ -951,8 +955,7 @@ var DockDash = GObject.registerClass({
         if (!this._shownInitially)
             this._shownInitially = true;
 
-        for (let i = 0; i < addedItems.length; i++)
-            addedItems[i].item.show(animate);
+        addedItems.forEach(({ item }) => item.show(animate));
 
         // Workaround for https://bugzilla.gnome.org/show_bug.cgi?id=692744
         // Without it, StBoxLayout may use a stale size cache

--- a/dash.js
+++ b/dash.js
@@ -824,6 +824,10 @@ var DockDash = GObject.registerClass({
             oldApps = oldApps.filter(app => !app.isTrash);
         }
 
+        // Temporary remove the separator so that we don't compute to position icons
+        if (this._separator)
+            this._box.remove_child(this._separator);
+
         // Figure out the actual changes to the list of items; we iterate
         // over both the list of items currently in the dash and the list
         // of items expected there, and collect additions and removals.
@@ -910,20 +914,6 @@ var DockDash = GObject.registerClass({
                 item.destroy();
         }
 
-        this._adjustIconSize();
-
-        // Skip animations on first run when adding the initial set
-        // of items, to avoid all items zooming in at once
-
-        const animate = this._shownInitially &&
-            !Main.overview.animationInProgress;
-
-        if (!this._shownInitially)
-            this._shownInitially = true;
-
-        for (let i = 0; i < addedItems.length; i++)
-            addedItems[i].item.show(animate);
-
         // Update separator
         const nFavorites = Object.keys(favorites).length;
         const nIcons = children.length + addedItems.length - removedActors.length;
@@ -941,16 +931,28 @@ var DockDash = GObject.registerClass({
                     track_hover: true,
                 });
                 this._separator.connect('notify::hover', a => this._ensureItemVisibility(a));
-                this._box.add_child(this._separator);
             }
             let pos = nFavorites + this._animatingPlaceholdersCount;
             if (this._dragPlaceholder)
                 pos++;
-            this._box.set_child_at_index(this._separator, pos);
+            this._box.insert_child_at_index(this._separator, pos);
         } else if (this._separator) {
             this._separator.destroy();
             this._separator = null;
         }
+
+        this._adjustIconSize();
+
+        // Skip animations on first run when adding the initial set
+        // of items, to avoid all items zooming in at once
+        const animate = this._shownInitially &&
+            !Main.overview.animationInProgress;
+
+        if (!this._shownInitially)
+            this._shownInitially = true;
+
+        for (let i = 0; i < addedItems.length; i++)
+            addedItems[i].item.show(animate);
 
         // Workaround for https://bugzilla.gnome.org/show_bug.cgi?id=692744
         // Without it, StBoxLayout may use a stale size cache


### PR DESCRIPTION
When using a floating show apps icon setup, it needs to be at the same level of the dash box, but we can't use the same container because upstream code only uses that for application icons, and this assumption may break things such as DnD and potentially other things.

So move things in a new container.

Closes: #2010