### PR TITLE
Removed favorites fix

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -825,6 +825,7 @@ var DockDash = GObject.registerClass({
         }
 
         // Temporary remove the separator so that we don't compute to position icons
+        const oldSeparatorPos = this._box.get_children().indexOf(this._separator);
         if (this._separator)
             this._box.remove_child(this._separator);
 
@@ -939,6 +940,9 @@ var DockDash = GObject.registerClass({
             let pos = nFavorites + this._animatingPlaceholdersCount;
             if (this._dragPlaceholder)
                 pos++;
+            const removedFavorites = removedActors.filter(a =>
+                children.indexOf(a) < oldSeparatorPos);
+            pos += removedFavorites.length;
             this._box.insert_child_at_index(this._separator, pos);
         } else if (this._separator) {
             this._separator.destroy();

--- a/dash.js
+++ b/dash.js
@@ -920,7 +920,7 @@ var DockDash = GObject.registerClass({
 
         // Update separator
         const nFavorites = Object.keys(favorites).length;
-        const nIcons = this._box.get_n_children() - removedActors.length;
+        const nIcons = children.length + addedItems.length - removedActors.length;
         if (nFavorites > 0 && nFavorites < nIcons) {
             if (!this._separator) {
                 this._separator = new St.Widget({


### PR DESCRIPTION
dash: Take in account the number of removed favorites to add the separator

When a favorite is removed the separator should be shifted accordingly,
so use the old separator position as reference