### PR TITLE
docking: Always affect the input region when adding the dock

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -445,7 +445,6 @@ const DockedDash = GObject.registerClass({
     _trackDock() {
         if (DockManager.settings.dockFixed) {
             Main.layoutManager.addChrome(this, {
-                affectsInputRegion: false,
                 trackFullscreen: true,
                 affectsStruts: true,
             });


### PR DESCRIPTION
We need to ensure that input region is affected by the dock even when it's not in auto-hide mode. In fact before we were not applying this to the dock actor, but still to the scroll one.

Now we're doing it for the whole group.

Closes: #2032, #2024