### PR TITLE
Fix missing dominant color

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -974,26 +974,27 @@ var DominantColorExtractor = class DashToDockDominantColorExtractor {
         if (!iconTexture)
             return null;
 
-
         if (iconTexture instanceof Gio.FileIcon) {
             // Use GdkPixBuf to load the pixel buffer from the provided file path
             return GdkPixbuf.Pixbuf.new_from_file(iconTexture.get_file().get_path());
         } else if (iconTexture instanceof Gio.ThemedIcon) {
-            // Get the pixel buffer from the icon theme
-            const [iconName] = iconTexture.get_names();
-            const iconInfo = themeLoader.lookup_icon(iconName,
-                DOMINANT_COLOR_ICON_SIZE, 0);
+            // Get the first pixel buffer available in the icon theme
+            const iconNames = iconTexture.get_names();
+            const iconInfo = themeLoader.choose_icon(iconNames, DOMINANT_COLOR_ICON_SIZE, 0);
 
-            if (iconInfo)
-                return iconInfo.load_icon();            
+            if (iconInfo) {
+                return iconInfo.load_icon();
+            } else {
+                return null;
+            }   
         }
 
         // Use GdkPixBuf to load the pixel buffer from memory
-        const [iconInfo] = iconTexture.load(DOMINANT_COLOR_ICON_SIZE, null);
-        if (iconInfo)
-            return GdkPixbuf.Pixbuf.new_from_stream(iconInfo, null);
-        else
-            return null;
+        // iconTexture.load is available unless iconTexture is not an instance of Gio.LoadableIcon
+        // this means that iconTexture is an instance of Gio.EmblemedIcon,
+        // which may be converted to a normal icon via iconTexture.get_icon?
+        const [iconBuffer] = iconTexture.load(DOMINANT_COLOR_ICON_SIZE, null);
+        return GdkPixbuf.Pixbuf.new_from_stream(iconBuffer, null);
     }
 
     /**

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -375,6 +375,9 @@ var RunningIndicatorDots = class DashToDockRunningIndicatorDots extends RunningI
                 const colorPalette = this._dominantColorExtractor._getColorPalette();
                 if (colorPalette)
                     [, this._bodyColor] = Clutter.color_from_string(colorPalette.original);
+                else
+                    // Fallback
+                    [, this._bodyColor] = Clutter.color_from_string(settings.customThemeRunningDotsColor);
             }
 
             // Finally, use customize style if requested

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -975,15 +975,20 @@ var DominantColorExtractor = class DashToDockDominantColorExtractor {
         if (iconTexture instanceof Gio.FileIcon) {
             // Use GdkPixBuf to load the pixel buffer from the provided file path
             return GdkPixbuf.Pixbuf.new_from_file(iconTexture.get_file().get_path());
+        } else if (iconTexture instanceof Gio.ThemedIcon) {
+            // Get the pixel buffer from the icon theme
+            const [iconName] = iconTexture.get_names();
+            const iconInfo = themeLoader.lookup_icon(iconName,
+                DOMINANT_COLOR_ICON_SIZE, 0);
+
+            if (iconInfo)
+                return iconInfo.load_icon();            
         }
 
-        // Get the pixel buffer from the icon theme
-        const [iconName] = iconTexture.get_names();
-        const iconInfo = themeLoader.lookup_icon(iconName,
-            DOMINANT_COLOR_ICON_SIZE, 0);
-
+        // Use GdkPixBuf to load the pixel buffer from memory
+        const [iconInfo] = iconTexture.load(DOMINANT_COLOR_ICON_SIZE, null);
         if (iconInfo)
-            return iconInfo.load_icon();
+            return GdkPixbuf.Pixbuf.new_from_stream(iconInfo, null);
         else
             return null;
     }


### PR DESCRIPTION
This is the same attempt to fix https://github.com/micheleg/dash-to-dock/issues/1493, in which we separate `Gio.ThemedIcon` from `Gio.LoadableIcon` but now with the `const` keyword and using list unpacking, as is done in similar pieces around the file.

I apologise for closing the previous merge request, GitHub asked to remove my previous commit when I clicked to sync my branch.

I read the documentation on how to cache and async it, but I couldn't make sense of the documentation, sorry.

When `iconTexture` is a `Gio.ThemedIcon`, it seems we can use [choose_icon](https://lazka.github.io/pgi-docs/Gtk-3.0/classes/IconTheme.html#Gtk.IconTheme.choose_icon) or [lookup_icon](https://lazka.github.io/pgi-docs/Gtk-3.0/classes/IconTheme.html#Gtk.IconTheme.lookup_icon), and the former is better suited as it's able to check for all possible names (which is useful as Papirus theme doesn't use the first name available for `drive-harddisk`).

~There's also a fourth case that I have trouble replicating, in which the icon is an emblem (I don't know the icon type), such as when an external HD is mounted. This doesn't apply to other emblem-like icons, such as mounted network devices and the trash can. This emblem raises a `iconTexture.load is not a function` error.~