### PR TITLE
docking: Update dock visibility after overview hide animation is done

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -754,6 +754,7 @@ const DockedDash = GObject.registerClass({
 
     _onOverviewHidden() {
         this.remove_style_class_name('overview');
+        this._updateDashVisibility();
     }
 
     _onMenuOpened() {


### PR DESCRIPTION
If the overview was closed by clicking on the dash, and the cursor left the dash before the animation finished, the dock would still be visible after it should also be hidden.

Updating the dock visibility ensures the visibility isn't impacted by ignored signals during the animation.

I couldn't see any open issues for this, and since it was a simple fix I just made a PR instead of an issue. If I've missed the open issues, I can add them to the commit message if required :)