### PR TITLE
GNOME 45 support - ESM porting

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -23,3 +23,6 @@ overrides:
         - code: 110
           ignoreUrls: true
           ignoreTemplateLiterals: true
+
+parserOptions:
+  sourceType: module

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ EXTRA_MODULES = \
                 appIcons.js \
                 appIconIndicators.js \
                 fileManager1API.js \
+                imports.js \
                 launcherAPI.js \
                 locations.js \
                 locationsWorker.js \
@@ -126,6 +127,7 @@ _build: all
 	-rm -fR ./_build
 	mkdir -p _build
 	cp $(BASE_MODULES) $(EXTRA_MODULES) _build
+	cp -a dependencies _build
 	cp stylesheet.css _build
 	mkdir -p _build/media
 	cd media ; cp $(EXTRA_MEDIA) ../_build/media/

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -982,11 +982,10 @@ var DominantColorExtractor = class DashToDockDominantColorExtractor {
             const iconNames = iconTexture.get_names();
             const iconInfo = themeLoader.choose_icon(iconNames, DOMINANT_COLOR_ICON_SIZE, 0);
 
-            if (iconInfo) {
+            if (iconInfo)
                 return iconInfo.load_icon();
-            } else {
+            else
                 return null;
-            }   
         }
 
         // Use GdkPixBuf to load the pixel buffer from memory

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -1,22 +1,20 @@
-/* exported AppIconIndicator */
-
-const { cairo: Cairo } = imports;
-const { main: Main } = imports.ui;
-
-const {
+import {
     Clutter,
     GdkPixbuf,
     Gio,
     GObject,
     Pango,
-    St,
-} = imports.gi;
+    St
+} from './dependencies/gi.js';
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const {
-    docking: Docking,
-    utils: Utils,
-} = Me.imports;
+import { Main } from './dependencies/shell/ui.js';
+
+import {
+    Docking,
+    Utils
+} from './imports.js';
+
+const { cairo: Cairo } = imports;
 
 const RunningIndicatorStyle = Object.freeze({
     DEFAULT: 0,
@@ -38,7 +36,7 @@ const MAX_WINDOWS_CLASSES = 4;
  * obtained by composing the desired classes below based on the settings.
  *
  */
-var AppIconIndicator = class DashToDockAppIconIndicator {
+export class AppIconIndicator {
     constructor(source) {
         this._indicators = [];
 
@@ -114,12 +112,12 @@ var AppIconIndicator = class DashToDockAppIconIndicator {
             indicator.destroy();
         }
     }
-};
+}
 
 /*
  * Base class to be inherited by all indicators of any kind
 */
-var IndicatorBase = class DashToDockIndicatorBase {
+class IndicatorBase {
     constructor(source) {
         this._source = source;
         this._signalsHandler = new Utils.GlobalSignalsHandler(this._source);
@@ -133,14 +131,14 @@ var IndicatorBase = class DashToDockIndicatorBase {
         this._signalsHandler.destroy();
         this._signalsHandler = null;
     }
-};
+}
 
 /*
  * A base indicator class for running style, from which all other EunningIndicators should derive,
  * providing some basic methods, variables definitions and their update,  css style classes handling.
  *
  */
-var RunningIndicatorBase = class DashToDockRunningIndicatorBase extends IndicatorBase {
+class RunningIndicatorBase extends IndicatorBase {
     constructor(source) {
         super(source);
 
@@ -224,11 +222,11 @@ var RunningIndicatorBase = class DashToDockRunningIndicatorBase extends Indicato
 
         super.destroy();
     }
-};
+}
 
 // We add a css class so third parties themes can limit their indicaor customization
 // to the case we do nothing
-var RunningIndicatorDefault = class DashToDockRunningIndicatorDefault extends RunningIndicatorBase {
+class RunningIndicatorDefault extends RunningIndicatorBase {
     constructor(source) {
         super(source);
         this._source.add_style_class_name('default');
@@ -238,9 +236,9 @@ var RunningIndicatorDefault = class DashToDockRunningIndicatorDefault extends Ru
         this._source.remove_style_class_name('default');
         super.destroy();
     }
-};
+}
 
-var IndicatorDrawingArea = GObject.registerClass(
+const IndicatorDrawingArea = GObject.registerClass(
 class IndicatorDrawingArea extends St.DrawingArea {
     vfunc_allocate(box) {
         if (box.x1 !== 0 || box.y1 !== 0)
@@ -256,7 +254,7 @@ class IndicatorDrawingArea extends St.DrawingArea {
     }
 });
 
-var RunningIndicatorDots = class DashToDockRunningIndicatorDots extends RunningIndicatorBase {
+class RunningIndicatorDots extends RunningIndicatorBase {
     constructor(source) {
         super(source);
 
@@ -311,7 +309,8 @@ var RunningIndicatorDots = class DashToDockRunningIndicatorDots extends RunningI
         // Apply glossy background
         // TODO: move to enable/disableBacklit to apply itonly to the running apps?
         // TODO: move to css class for theming support
-        this._glossyBackgroundStyle = `background-image: url('${Me.path}/media/glossy.svg');` +
+        const { extension } = Docking.DockManager;
+        this._glossyBackgroundStyle = `background-image: url('${extension.path}/media/glossy.svg');` +
                                       'background-size: contain;';
     }
 
@@ -431,11 +430,11 @@ var RunningIndicatorDots = class DashToDockRunningIndicatorDots extends RunningI
         this._area.destroy();
         super.destroy();
     }
-};
+}
 
 // Adapted from dash-to-panel by Jason DeRose
 // https://github.com/jderose9/dash-to-panel
-var RunningIndicatorCiliora = class DashToDockRunningIndicatorCiliora extends RunningIndicatorDots {
+class RunningIndicatorCiliora extends RunningIndicatorDots {
     _drawIndicator(cr) {
         if (this._source.running) {
             const size =  Math.max(this._width / 20, this._borderWidth);
@@ -464,11 +463,11 @@ var RunningIndicatorCiliora = class DashToDockRunningIndicatorCiliora extends Ru
             cr.fill();
         }
     }
-};
+}
 
 // Adapted from dash-to-panel by Jason DeRose
 // https://github.com/jderose9/dash-to-panel
-var RunningIndicatorSegmented = class DashToDockRunningIndicatorSegmented extends RunningIndicatorDots {
+class RunningIndicatorSegmented extends RunningIndicatorDots {
     _drawIndicator(cr) {
         if (this._source.running) {
             const size =  Math.max(this._width / 20, this._borderWidth);
@@ -495,11 +494,11 @@ var RunningIndicatorSegmented = class DashToDockRunningIndicatorSegmented extend
             cr.fill();
         }
     }
-};
+}
 
 // Adapted from dash-to-panel by Jason DeRose
 // https://github.com/jderose9/dash-to-panel
-var RunningIndicatorSolid = class DashToDockRunningIndicatorSolid extends RunningIndicatorDots {
+class RunningIndicatorSolid extends RunningIndicatorDots {
     _drawIndicator(cr) {
         if (this._source.running) {
             const size =  Math.max(this._width / 20, this._borderWidth);
@@ -522,11 +521,11 @@ var RunningIndicatorSolid = class DashToDockRunningIndicatorSolid extends Runnin
             cr.fill();
         }
     }
-};
+}
 
 // Adapted from dash-to-panel by Jason DeRose
 // https://github.com/jderose9/dash-to-panel
-var RunningIndicatorSquares = class DashToDockRunningIndicatorSquares extends RunningIndicatorDots {
+class RunningIndicatorSquares extends RunningIndicatorDots {
     _drawIndicator(cr) {
         if (this._source.running) {
             const size =  Math.max(this._width / 11, this._borderWidth);
@@ -550,11 +549,11 @@ var RunningIndicatorSquares = class DashToDockRunningIndicatorSquares extends Ru
             cr.fill();
         }
     }
-};
+}
 
 // Adapted from dash-to-panel by Jason DeRose
 // https://github.com/jderose9/dash-to-panel
-var RunningIndicatorDashes = class DashToDockRunningIndicatorDashes extends RunningIndicatorDots {
+class RunningIndicatorDashes extends RunningIndicatorDots {
     _drawIndicator(cr) {
         if (this._source.running) {
             const size =  Math.max(this._width / 20, this._borderWidth);
@@ -580,11 +579,11 @@ var RunningIndicatorDashes = class DashToDockRunningIndicatorDashes extends Runn
             cr.fill();
         }
     }
-};
+}
 
 // Adapted from dash-to-panel by Jason DeRose
 // https://github.com/jderose9/dash-to-panel
-var RunningIndicatorMetro = class DashToDockRunningIndicatorMetro extends RunningIndicatorDots {
+class RunningIndicatorMetro extends RunningIndicatorDots {
     constructor(source) {
         super(source);
         this._source.add_style_class_name('metro');
@@ -637,9 +636,9 @@ var RunningIndicatorMetro = class DashToDockRunningIndicatorMetro extends Runnin
             }
         }
     }
-};
+}
 
-var RunningIndicatorBinary = class DashToDockRunningIndicatorBinary extends RunningIndicatorDots {
+class RunningIndicatorBinary extends RunningIndicatorDots {
     _drawIndicator(cr) {
         // Draw the required numbers of dots
         const n = Math.min(15, this._source.windowsCount);
@@ -672,12 +671,12 @@ var RunningIndicatorBinary = class DashToDockRunningIndicatorBinary extends Runn
             cr.fill();
         }
     }
-};
+}
 
 /*
  * Unity like notification and progress indicators
  */
-var UnityIndicator = class DashToDockUnityIndicator extends IndicatorBase {
+class UnityIndicator extends IndicatorBase {
     constructor(source) {
         super(source);
 
@@ -935,7 +934,7 @@ var UnityIndicator = class DashToDockUnityIndicator extends IndicatorBase {
         else
             delete this._isUrgent;
     }
-};
+}
 
 
 // Global icon cache. Used for Unity7 styling.
@@ -951,7 +950,7 @@ const DOMINANT_COLOR_ICON_SIZE = 64;
 
 // Compute dominant color frim the app icon.
 // The color is cached for efficiency.
-var DominantColorExtractor = class DashToDockDominantColorExtractor {
+class DominantColorExtractor {
     constructor(app) {
         this._app = app;
     }
@@ -1123,4 +1122,4 @@ var DominantColorExtractor = class DashToDockDominantColorExtractor {
 
         return resampledPixels;
     }
-};
+}

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -7,14 +7,14 @@ import {
     St
 } from './dependencies/gi.js';
 
-import { Main } from './dependencies/shell/ui.js';
+import {Main} from './dependencies/shell/ui.js';
 
 import {
     Docking,
     Utils
 } from './imports.js';
 
-const { cairo: Cairo } = imports;
+const {cairo: Cairo} = imports;
 
 const RunningIndicatorStyle = Object.freeze({
     DEFAULT: 0,
@@ -44,11 +44,11 @@ export class AppIconIndicator {
         let runningIndicator = null;
         let runningIndicatorStyle;
 
-        const { settings } = Docking.DockManager;
+        const {settings} = Docking.DockManager;
         if (settings.applyCustomTheme)
             runningIndicatorStyle = RunningIndicatorStyle.DOTS;
         else
-            ({ runningIndicatorStyle } = settings);
+            ({runningIndicatorStyle} = settings);
 
         if (settings.showIconsEmblems &&
             !Docking.DockManager.getDefault().notificationsMonitor.dndMode) {
@@ -309,7 +309,7 @@ class RunningIndicatorDots extends RunningIndicatorBase {
         // Apply glossy background
         // TODO: move to enable/disableBacklit to apply itonly to the running apps?
         // TODO: move to css class for theming support
-        const { extension } = Docking.DockManager;
+        const {extension} = Docking.DockManager;
         this._glossyBackgroundStyle = `background-image: url('${extension.path}/media/glossy.svg');` +
                                       'background-size: contain;';
     }
@@ -349,7 +349,7 @@ class RunningIndicatorDots extends RunningIndicatorBase {
         this._borderWidth = themeNode.get_border_width(this._side);
         this._bodyColor = themeNode.get_background_color();
 
-        const { settings } = Docking.DockManager;
+        const {settings} = Docking.DockManager;
         if (!settings.applyCustomTheme) {
             // Adjust for the backlit case
             if (settings.unityBacklitItems) {
@@ -694,7 +694,7 @@ class UnityIndicator extends IndicatorBase {
         this._source._iconContainer.add_child(this._notificationBadgeBin);
         this.updateNotificationBadgeStyle();
 
-        const { remoteModel, notificationsMonitor } = Docking.DockManager.getDefault();
+        const {remoteModel, notificationsMonitor} = Docking.DockManager.getDefault();
         const remoteEntry = remoteModel.lookupById(this._source.app.id);
         this._remoteEntry = remoteEntry;
 
@@ -705,12 +705,12 @@ class UnityIndicator extends IndicatorBase {
         ], [
             remoteEntry,
             ['progress-changed', 'progress-visible-changed'],
-            (sender, { progress, progress_visible: progressVisible }) =>
+            (sender, {progress, progress_visible: progressVisible}) =>
                 this.setProgress(progressVisible ? progress : -1),
         ], [
             remoteEntry,
             'urgent-changed',
-            (sender, { urgent }) => this.setUrgent(urgent),
+            (sender, {urgent}) => this.setUrgent(urgent),
         ], [
             notificationsMonitor,
             'changed',
@@ -741,7 +741,7 @@ class UnityIndicator extends IndicatorBase {
         const fontDesc = themeContext.get_font();
         const defaultFontSize = fontDesc.get_size() / 1024;
         let fontSize = defaultFontSize * 0.9;
-        const { iconSize } = Main.overview.dash;
+        const {iconSize} = Main.overview.dash;
         const defaultIconSize = Docking.DockManager.settings.get_default_value(
             'dash-max-icon-size').unpack();
 
@@ -798,7 +798,7 @@ class UnityIndicator extends IndicatorBase {
             return;
         }
 
-        const { notificationsMonitor } = Docking.DockManager.getDefault();
+        const {notificationsMonitor} = Docking.DockManager.getDefault();
         const notificationsCount = notificationsMonitor.getAppNotificationsCount(
             this._source.app.id);
 
@@ -821,7 +821,7 @@ class UnityIndicator extends IndicatorBase {
             return;
         }
 
-        this._progressOverlayArea = new St.DrawingArea({ x_expand: true, y_expand: true });
+        this._progressOverlayArea = new St.DrawingArea({x_expand: true, y_expand: true});
         this._progressOverlayArea.add_style_class_name('progress-bar');
         this._progressOverlayArea.connect('repaint', () => {
             this._drawProgressOverlay(this._progressOverlayArea);
@@ -841,7 +841,7 @@ class UnityIndicator extends IndicatorBase {
     }
 
     _drawProgressOverlay(area) {
-        const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
+        const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
         const [surfaceWidth, surfaceHeight] = area.get_surface_size();
         const cr = area.get_context();
 
@@ -893,11 +893,11 @@ class UnityIndicator extends IndicatorBase {
 
         [hasColor, bg] = node.lookup_color('-progress-bar-background', false);
         if (!hasColor)
-            bg = new Clutter.Color({ red: 204, green: 204, blue: 204, alpha: 255 });
+            bg = new Clutter.Color({red: 204, green: 204, blue: 204, alpha: 255});
 
         [hasColor, bd] = node.lookup_color('-progress-bar-border', false);
         if (!hasColor)
-            bd = new Clutter.Color({ red: 230, green: 230, blue: 230, alpha: 255 });
+            bd = new Clutter.Color({red: 230, green: 230, blue: 230, alpha: 255});
 
         stroke = Cairo.SolidPattern.createRGBA(
             bd.red / 255, bd.green / 255, bd.blue / 255, bd.alpha / 255);

--- a/appIcons.js
+++ b/appIcons.js
@@ -23,7 +23,7 @@ import {
     ParentalControlsManager
 } from './dependencies/shell/misc.js';
 
-import { Config } from './dependencies/shell/misc.js';
+import {Config} from './dependencies/shell/misc.js';
 
 import {
     AppIconIndicators,
@@ -35,11 +35,11 @@ import {
     WindowPreview
 } from './imports.js';
 
-import { Extension } from './dependencies/shell/extensions/extension.js';
+import {Extension} from './dependencies/shell/extensions/extension.js';
 
 // Use __ () and N__() for the extension gettext domain, and reuse
 // the shell domain with the default _() and N_()
-const { gettext: __ } = Extension;
+const {gettext: __} = Extension;
 
 const DBusMenu = await DBusMenuUtils.haveDBusMenu();
 
@@ -162,7 +162,7 @@ const DockAbstractAppIcon = GObject.registerClass({
                 this.remove_style_class_name('focused');
         });
 
-        const { notificationsMonitor } = Docking.DockManager.getDefault();
+        const {notificationsMonitor} = Docking.DockManager.getDefault();
 
         this.connect('notify::urgent', () => {
             const icon = this.icon._iconBin;
@@ -238,7 +238,7 @@ const DockAbstractAppIcon = GObject.registerClass({
     }
 
     vfunc_scroll_event(scrollEvent) {
-        const { settings } = Docking.DockManager;
+        const {settings} = Docking.DockManager;
         const isEnabled = settings.scrollAction === scrollAction.CYCLE_WINDOWS;
         if (!isEnabled)
             return Clutter.EVENT_PROPAGATE;
@@ -393,7 +393,7 @@ const DockAbstractAppIcon = GObject.registerClass({
 
         let windows = this.getWindows();
         if (Docking.DockManager.settings.multiMonitor) {
-            const { monitorIndex } = this;
+            const {monitorIndex} = this;
             windows = windows.filter(w => w.get_monitor() === monitorIndex);
         }
         windows.forEach(w => w.set_icon_geometry(rect));
@@ -429,10 +429,10 @@ const DockAbstractAppIcon = GObject.registerClass({
                     const monitorIndex = Main.layoutManager.findIndexForActor(this);
                     const workArea = Main.layoutManager.getWorkAreaForMonitor(monitorIndex);
                     const position = Utils.getPosition();
-                    const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
+                    const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
                     const isHorizontal = position === St.Side.TOP || position === St.Side.BOTTOM;
                     // If horizontal also remove the height of the dash
-                    const { dockFixed: fixedDock } = Docking.DockManager.settings;
+                    const {dockFixed: fixedDock} = Docking.DockManager.settings;
                     const additionalMargin = isHorizontal && !fixedDock ? Main.overview.dash.height : 0;
                     const verticalMargins = this._menu.actor.margin_top + this._menu.actor.margin_bottom;
                     const maxMenuHeight = workArea.height - additionalMargin - verticalMargins;
@@ -482,7 +482,7 @@ const DockAbstractAppIcon = GObject.registerClass({
         // being used. We then define what buttonAction should be for this
         // event.
         let buttonAction = 0;
-        const { settings } = Docking.DockManager;
+        const {settings} = Docking.DockManager;
         if (button && button === 2) {
             if (modifiers & Clutter.ModifierType.SHIFT_MASK)
                 buttonAction = settings.shiftMiddleClickAction;
@@ -998,11 +998,11 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
 
         Main.uiGroup.add_actor(this.actor);
 
-        const { remoteModel } = Docking.DockManager.getDefault();
+        const {remoteModel} = Docking.DockManager.getDefault();
         const remoteModelApp = remoteModel?.lookupById(this._source?.app?.id);
         if (remoteModelApp && DBusMenu) {
             const [onQuicklist, onDynamicSection] = Utils.splitHandler((sender,
-                { quicklist }, dynamicSection) => {
+                {quicklist}, dynamicSection) => {
                 dynamicSection.removeAll();
                 if (quicklist) {
                     quicklist.get_children().forEach(remoteItem =>
@@ -1295,7 +1295,7 @@ function isWindowUrgent(w) {
  * @param monitorIndex
  */
 export function getInterestingWindows(windows, monitorIndex) {
-    const { settings } = Docking.DockManager;
+    const {settings} = Docking.DockManager;
 
     // When using workspace isolation, we filter out windows
     // that are neither in the current workspace nor marked urgent
@@ -1329,7 +1329,7 @@ export function getInterestingWindows(windows, monitorIndex) {
 
 export const DockShowAppsIcon = GObject.registerClass({
     Signals: {
-        'menu-state-changed': { param_types: [GObject.TYPE_BOOLEAN] },
+        'menu-state-changed': {param_types: [GObject.TYPE_BOOLEAN]},
         'sync-tooltip': {},
     },
 }
@@ -1338,7 +1338,7 @@ export const DockShowAppsIcon = GObject.registerClass({
         super._init();
 
         // Re-use appIcon methods
-        const { prototype: appIconPrototype } = AppDisplay.AppIcon;
+        const {prototype: appIconPrototype} = AppDisplay.AppIcon;
         this.toggleButton.y_expand = false;
         this.toggleButton.connect('popup-menu', () =>
             appIconPrototype._onKeyboardPopupMenu.call(this));

--- a/appSpread.js
+++ b/appSpread.js
@@ -1,4 +1,4 @@
-import { Atk, Clutter } from './dependencies/gi.js';
+import {Atk, Clutter} from './dependencies/gi.js';
 
 import {
     Main,
@@ -7,7 +7,7 @@ import {
     WorkspaceThumbnail
 } from './dependencies/shell/ui.js';
 
-import { Utils } from './imports.js';
+import {Utils} from './imports.js';
 
 export class AppSpread {
     constructor() {
@@ -57,7 +57,7 @@ export class AppSpread {
     }
 
     _restoreDefaultWindows() {
-        const { workspaceManager } = global;
+        const {workspaceManager} = global;
 
         for (let i = 0; i < workspaceManager.nWorkspaces; i++) {
             const metaWorkspace = workspaceManager.get_workspace_by_index(i);
@@ -66,7 +66,7 @@ export class AppSpread {
     }
 
     _filterWindows() {
-        const { workspaceManager } = global;
+        const {workspaceManager} = global;
 
         for (let i = 0; i < workspaceManager.nWorkspaces; i++) {
             const metaWorkspace = workspaceManager.get_workspace_by_index(i);
@@ -139,7 +139,7 @@ export class AppSpread {
                 activitiesButton.constructor.prototype,
                 'key_release_event',
                 function (keyEvent) {
-                    const { keyval } = keyEvent;
+                    const {keyval} = keyEvent;
                     if (keyval === Clutter.KEY_Return || keyval === Clutter.KEY_space) {
                         if (Main.overview.shouldToggleByCornerOrButton())
                             appSpread._restoreDefaultOverview();

--- a/appSpread.js
+++ b/appSpread.js
@@ -1,16 +1,15 @@
-/* exported AppSpread */
+import { Atk, Clutter } from './dependencies/gi.js';
 
-const { Atk, Clutter } = imports.gi;
+import {
+    Main,
+    SearchController,
+    Workspace,
+    WorkspaceThumbnail
+} from './dependencies/shell/ui.js';
 
-const Main = imports.ui.main;
-const SearchController = imports.ui.searchController;
-const Workspace = imports.ui.workspace;
-const WorkspaceThumbnail = imports.ui.workspaceThumbnail;
+import { Utils } from './imports.js';
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const { utils: Utils } = Me.imports;
-
-var AppSpread = class AppSpread {
+export class AppSpread {
     constructor() {
         this.app = null;
         this.supported = true;
@@ -208,4 +207,4 @@ var AppSpread = class AppSpread {
         if (Main.overview.searchEntry)
             Main.overview.searchEntry.opacity = 255;
     }
-};
+}

--- a/dash.js
+++ b/dash.js
@@ -1,34 +1,31 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-/* exported DockDash */
-
-const {
+import {
     Clutter,
     Gio,
     GLib,
     GObject,
     Shell,
-    St,
-} = imports.gi;
+    St
+} from './dependencies/gi.js';
 
-const {
-    appFavorites: AppFavorites,
-    dash: Dash,
-    dnd: DND,
-    main: Main,
-} = imports.ui;
+import {
+    AppFavorites,
+    Dash,
+    DND,
+    Main
+} from './dependencies/shell/ui.js';
 
-const {
-    util: Util,
-} = imports.misc;
+import {
+    Util
+} from './dependencies/shell/misc.js';
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const {
-    appIcons: AppIcons,
-    docking: Docking,
-    theming: Theming,
-    utils: Utils,
-} = Me.imports;
+import {
+    AppIcons,
+    Docking,
+    Theming,
+    Utils
+} from './imports.js';
 
 const { DASH_ANIMATION_TIME } = Dash;
 const DASH_VISIBILITY_TIMEOUT = 3;
@@ -44,7 +41,7 @@ const Labels = Object.freeze({
  * - set label position based on dash orientation
  *
  */
-var DockDashItemContainer = GObject.registerClass(
+const DockDashItemContainer = GObject.registerClass(
 class DockDashItemContainer extends Dash.DashItemContainer {
     _init(position) {
         super._init();
@@ -91,7 +88,7 @@ const baseIconSizes = [16, 22, 24, 32, 48, 64, 96, 128];
  * - sync minimization application target position.
  * - keep running apps ordered.
  */
-var DockDash = GObject.registerClass({
+export const DockDash = GObject.registerClass({
     Properties: {
         'requires-visibility': GObject.ParamSpec.boolean(
             'requires-visibility', 'requires-visibility', 'requires-visibility',

--- a/dash.js
+++ b/dash.js
@@ -27,7 +27,7 @@ import {
     Utils
 } from './imports.js';
 
-const { DASH_ANIMATION_TIME } = Dash;
+const {DASH_ANIMATION_TIME} = Dash;
 const DASH_VISIBILITY_TIMEOUT = 3;
 
 const Labels = Object.freeze({
@@ -161,7 +161,7 @@ export const DockDash = GObject.registerClass({
         this._box = new St.BoxLayout({
             vertical: !this._isHorizontal,
             clip_to_allocation: false,
-            ...!this._isHorizontal ? { layout_manager: new DockDashIconsVerticalLayout() } : {},
+            ...!this._isHorizontal ? {layout_manager: new DockDashIconsVerticalLayout()} : {},
             x_align: rtl ? Clutter.ActorAlign.END : Clutter.ActorAlign.START,
             y_align: this._isHorizontal ? Clutter.ActorAlign.CENTER : Clutter.ActorAlign.START,
             y_expand: !this._isHorizontal,
@@ -533,7 +533,7 @@ export const DockDash = GObject.registerClass({
         });
 
         appIcon.connect('notify::focused', () => {
-            const { settings } = Docking.DockManager;
+            const {settings} = Docking.DockManager;
             if (appIcon.focused && settings.scrollToFocusedApplication)
                 ensureActorVisibleInScrollView(this._scrollView, item);
         });
@@ -645,8 +645,8 @@ export const DockDash = GObject.registerClass({
 
         const spacing = themeNode.get_length('spacing');
 
-        const [{ child: firstButton }] = iconChildren;
-        const { child: firstIcon } = firstButton?.icon ?? { child: null };
+        const [{child: firstButton}] = iconChildren;
+        const {child: firstIcon} = firstButton?.icon ?? {child: null};
 
         // if no icons there's nothing to adjust
         if (!firstIcon)
@@ -678,7 +678,7 @@ export const DockDash = GObject.registerClass({
         }
 
         const maxIconSize = availSpace / iconChildren.length;
-        const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
+        const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
         const iconSizes = this._availableIconSizes.map(s => s * scaleFactor);
 
         let [newIconSize] = this._availableIconSizes;
@@ -696,7 +696,7 @@ export const DockDash = GObject.registerClass({
 
         const scale = oldIconSize / newIconSize;
         for (let i = 0; i < iconChildren.length; i++) {
-            const { icon } = iconChildren[i].child._delegate;
+            const {icon} = iconChildren[i].child._delegate;
 
             // Set the new size immediately, to keep the icons' sizes
             // in sync with this.iconSize
@@ -726,7 +726,7 @@ export const DockDash = GObject.registerClass({
 
         if (this._separator) {
             const animateProperties = this._isHorizontal
-                ? { height: this.iconSize } : { width: this.iconSize };
+                ? {height: this.iconSize} : {width: this.iconSize};
 
             this._separator.ease({
                 ...animateProperties,
@@ -741,7 +741,7 @@ export const DockDash = GObject.registerClass({
 
         let running = this._appSystem.get_running();
         const dockManager = Docking.DockManager.getDefault();
-        const { settings } = dockManager;
+        const {settings} = dockManager;
 
         this._scrollView.set({
             xAlign: Clutter.ActorAlign.FILL,
@@ -776,7 +776,7 @@ export const DockDash = GObject.registerClass({
         // Apps supposed to be in the dash
         const newApps = [];
 
-        const { showFavorites } = settings;
+        const {showFavorites} = settings;
         if (showFavorites)
             newApps.push(...Object.values(favorites));
 
@@ -956,7 +956,7 @@ export const DockDash = GObject.registerClass({
         if (!this._shownInitially)
             this._shownInitially = true;
 
-        addedItems.forEach(({ item }) => item.show(animate));
+        addedItems.forEach(({item}) => item.show(animate));
 
         // Workaround for https://bugzilla.gnome.org/show_bug.cgi?id=692744
         // Without it, StBoxLayout may use a stale size cache
@@ -1063,7 +1063,7 @@ export const DockDash = GObject.registerClass({
         if (this._showAppsIcon.get_parent() && !this._showAppsIcon.visible)
             return;
 
-        const { settings } = Docking.DockManager;
+        const {settings} = Docking.DockManager;
         const notifiedProperties = [];
         const showAppsContainer = settings.showAppsAlwaysInTheEdge || !settings.dockExtended
             ? this._dashContainer : this._boxContainer;
@@ -1109,10 +1109,10 @@ export const DockDash = GObject.registerClass({
  * @param actor
  */
 function ensureActorVisibleInScrollView(scrollView, actor) {
-    const { adjustment: vAdjustment } = scrollView.vscroll;
-    const { adjustment: hAdjustment } = scrollView.hscroll;
-    const { value: vValue0, pageSize: vPageSize, upper: vUpper } = vAdjustment;
-    const { value: hValue0, pageSize: hPageSize, upper: hUpper } = hAdjustment;
+    const {adjustment: vAdjustment} = scrollView.vscroll;
+    const {adjustment: hAdjustment} = scrollView.hscroll;
+    const {value: vValue0, pageSize: vPageSize, upper: vUpper} = vAdjustment;
+    const {value: hValue0, pageSize: hPageSize, upper: hUpper} = hAdjustment;
     let [hValue, vValue] = [hValue0, vValue0];
     let vOffset = 0;
     let hOffset = 0;
@@ -1123,7 +1123,7 @@ function ensureActorVisibleInScrollView(scrollView, actor) {
     }
 
     const box = actor.get_allocation_box();
-    let { y1 } = box, { y2 } = box, { x1 } = box, { x2 } = box;
+    let {y1} = box, {y2} = box, {x1} = box, {x2} = box;
 
     let parent = actor.get_parent();
     while (parent !== scrollView) {

--- a/dbusmenuUtils.js
+++ b/dbusmenuUtils.js
@@ -8,9 +8,9 @@ import {
     St
 } from './dependencies/gi.js';
 
-import { PopupMenu } from './dependencies/shell/ui.js';
+import {PopupMenu} from './dependencies/shell/ui.js';
 
-import { Utils } from './imports.js';
+import {Utils} from './imports.js';
 
 // Dbusmenu features not (yet) supported:
 //
@@ -40,7 +40,7 @@ import { Utils } from './imports.js';
  */
 export async function haveDBusMenu() {
     try {
-        const { default: DBusMenu } = await import('gi://Dbusmenu');
+        const {default: DBusMenu} = await import('gi://Dbusmenu');
         return DBusMenu;
     } catch (e) {
         log(`Failed to import DBusMenu, quicklists are not available: ${e}`);

--- a/dbusmenuUtils.js
+++ b/dbusmenuUtils.js
@@ -1,21 +1,16 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-/* exported haveDBusMenu, makePopupMenuItem */
-
-const {
+import {
     Atk,
     Clutter,
     Gio,
     GLib,
-    St,
-} = imports.gi;
+    St
+} from './dependencies/gi.js';
 
-let Dbusmenu = null; /* Dynamically imported */
+import { PopupMenu } from './dependencies/shell/ui.js';
 
-const { popupMenu: PopupMenu } = imports.ui;
-
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const { utils: Utils } = Me.imports;
+import { Utils } from './imports.js';
 
 // Dbusmenu features not (yet) supported:
 //
@@ -43,39 +38,37 @@ const { utils: Utils } = Me.imports;
 /**
  *
  */
-function haveDBusMenu() {
-    if (Dbusmenu)
-        return Dbusmenu;
-
+export async function haveDBusMenu() {
     try {
-        ({ Dbusmenu } = imports.gi);
-        return Dbusmenu;
+        const { default: DBusMenu } = await import('gi://Dbusmenu');
+        return DBusMenu;
     } catch (e) {
-        log(`Failed to import DBusMenu, quicklists are not avaialble: ${e}`);
+        log(`Failed to import DBusMenu, quicklists are not available: ${e}`);
         return null;
     }
 }
 
+const DBusMenu = await haveDBusMenu();
 
 /**
  * @param dbusmenuItem
  * @param deep
  */
-function makePopupMenuItem(dbusmenuItem, deep) {
+export function makePopupMenuItem(dbusmenuItem, deep) {
     // These are the only properties guaranteed to be available when the root
     // item is first announced. Other properties might be loaded already, but
     // be sure to connect to Dbusmenu.MENUITEM_SIGNAL_PROPERTY_CHANGED to get
     // the most up-to-date values in case they aren't.
-    const itemType = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_TYPE);
-    const label = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_LABEL);
-    const visible = dbusmenuItem.property_get_bool(Dbusmenu.MENUITEM_PROP_VISIBLE);
-    const enabled = dbusmenuItem.property_get_bool(Dbusmenu.MENUITEM_PROP_ENABLED);
-    const accessibleDesc = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_ACCESSIBLE_DESC);
+    const itemType = dbusmenuItem.property_get(DBusMenu.MENUITEM_PROP_TYPE);
+    const label = dbusmenuItem.property_get(DBusMenu.MENUITEM_PROP_LABEL);
+    const visible = dbusmenuItem.property_get_bool(DBusMenu.MENUITEM_PROP_VISIBLE);
+    const enabled = dbusmenuItem.property_get_bool(DBusMenu.MENUITEM_PROP_ENABLED);
+    const accessibleDesc = dbusmenuItem.property_get(DBusMenu.MENUITEM_PROP_ACCESSIBLE_DESC);
     // const childDisplay = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_CHILD_DISPLAY);
 
     let item;
     const signalsHandler = new Utils.GlobalSignalsHandler();
-    const wantIcon = itemType === Dbusmenu.CLIENT_TYPES_IMAGE;
+    const wantIcon = itemType === DBusMenu.CLIENT_TYPES_IMAGE;
 
     // If the basic type of the menu item needs to change, call this.
     const recreateItem = () => {
@@ -95,14 +88,14 @@ function makePopupMenuItem(dbusmenuItem, deep) {
     };
 
     const updateDisposition = () => {
-        const disposition = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_DISPOSITION);
+        const disposition = dbusmenuItem.property_get(DBusMenu.MENUITEM_PROP_DISPOSITION);
         let iconName = null;
         switch (disposition) {
-        case Dbusmenu.MENUITEM_DISPOSITION_ALERT:
-        case Dbusmenu.MENUITEM_DISPOSITION_WARNING:
+        case DBusMenu.MENUITEM_DISPOSITION_ALERT:
+        case DBusMenu.MENUITEM_DISPOSITION_WARNING:
             iconName = 'dialog-warning-symbolic';
             break;
-        case Dbusmenu.MENUITEM_DISPOSITION_INFORMATIVE:
+        case DBusMenu.MENUITEM_DISPOSITION_INFORMATIVE:
             iconName = 'dialog-information-symbolic';
             break;
         }
@@ -139,8 +132,8 @@ function makePopupMenuItem(dbusmenuItem, deep) {
         if (!wantIcon)
             return;
 
-        const iconData = dbusmenuItem.property_get_byte_array(Dbusmenu.MENUITEM_PROP_ICON_DATA);
-        const iconName = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_ICON_NAME);
+        const iconData = dbusmenuItem.property_get_byte_array(DBusMenu.MENUITEM_PROP_ICON_DATA);
+        const iconName = dbusmenuItem.property_get(DBusMenu.MENUITEM_PROP_ICON_NAME);
         if (iconName)
             item.icon.icon_name = iconName;
         else if (iconData.length)
@@ -148,20 +141,20 @@ function makePopupMenuItem(dbusmenuItem, deep) {
     };
 
     const updateOrnament = () => {
-        const toggleType = dbusmenuItem.property_get(Dbusmenu.MENUITEM_PROP_TOGGLE_TYPE);
+        const toggleType = dbusmenuItem.property_get(DBusMenu.MENUITEM_PROP_TOGGLE_TYPE);
         switch (toggleType) {
-        case Dbusmenu.MENUITEM_TOGGLE_CHECK:
+        case DBusMenu.MENUITEM_TOGGLE_CHECK:
             item.actor.accessible_role = Atk.Role.CHECK_MENU_ITEM;
             break;
-        case Dbusmenu.MENUITEM_TOGGLE_RADIO:
+        case DBusMenu.MENUITEM_TOGGLE_RADIO:
             item.actor.accessible_role = Atk.Role.RADIO_MENU_ITEM;
             break;
         default:
             item.actor.accessible_role = Atk.Role.MENU_ITEM;
         }
         let ornament = PopupMenu.Ornament.NONE;
-        const state = dbusmenuItem.property_get_int(Dbusmenu.MENUITEM_PROP_TOGGLE_STATE);
-        if (state === Dbusmenu.MENUITEM_TOGGLE_STATE_UNKNOWN) {
+        const state = dbusmenuItem.property_get_int(DBusMenu.MENUITEM_PROP_TOGGLE_STATE);
+        if (state === DBusMenu.MENUITEM_TOGGLE_STATE_UNKNOWN) {
             // PopupMenu doesn't natively support an "unknown" ornament, but we
             // can hack one in:
             item.setOrnament(ornament);
@@ -170,10 +163,10 @@ function makePopupMenuItem(dbusmenuItem, deep) {
             item.actor.remove_style_pseudo_class('checked');
         } else {
             item.actor.remove_accessible_state(Atk.StateType.INDETERMINATE);
-            if (state === Dbusmenu.MENUITEM_TOGGLE_STATE_CHECKED) {
-                if (toggleType === Dbusmenu.MENUITEM_TOGGLE_CHECK)
+            if (state === DBusMenu.MENUITEM_TOGGLE_STATE_CHECKED) {
+                if (toggleType === DBusMenu.MENUITEM_TOGGLE_CHECK)
                     ornament = PopupMenu.Ornament.CHECK;
-                else if (toggleType === Dbusmenu.MENUITEM_TOGGLE_RADIO)
+                else if (toggleType === DBusMenu.MENUITEM_TOGGLE_RADIO)
                     ornament = PopupMenu.Ornament.DOT;
 
                 item.actor.add_style_pseudo_class('checked');
@@ -188,30 +181,30 @@ function makePopupMenuItem(dbusmenuItem, deep) {
         // `value` is null when a property is cleared, so handle those cases
         // with sensible defaults.
         switch (name) {
-        case Dbusmenu.MENUITEM_PROP_TYPE:
+        case DBusMenu.MENUITEM_PROP_TYPE:
             recreateItem();
             break;
-        case Dbusmenu.MENUITEM_PROP_ENABLED:
+        case DBusMenu.MENUITEM_PROP_ENABLED:
             item.setSensitive(value ? value.unpack() : false);
             break;
-        case Dbusmenu.MENUITEM_PROP_LABEL:
+        case DBusMenu.MENUITEM_PROP_LABEL:
             item.label.text = value ? value.unpack() : '';
             break;
-        case Dbusmenu.MENUITEM_PROP_VISIBLE:
+        case DBusMenu.MENUITEM_PROP_VISIBLE:
             item.actor.visible = value ? value.unpack() : false;
             break;
-        case Dbusmenu.MENUITEM_PROP_DISPOSITION:
+        case DBusMenu.MENUITEM_PROP_DISPOSITION:
             updateDisposition();
             break;
-        case Dbusmenu.MENUITEM_PROP_ACCESSIBLE_DESC:
+        case DBusMenu.MENUITEM_PROP_ACCESSIBLE_DESC:
             item.actor.get_accessible().accessible_description = value && value.unpack() || '';
             break;
-        case Dbusmenu.MENUITEM_PROP_ICON_DATA:
-        case Dbusmenu.MENUITEM_PROP_ICON_NAME:
+        case DBusMenu.MENUITEM_PROP_ICON_DATA:
+        case DBusMenu.MENUITEM_PROP_ICON_NAME:
             updateIcon();
             break;
-        case Dbusmenu.MENUITEM_PROP_TOGGLE_TYPE:
-        case Dbusmenu.MENUITEM_PROP_TOGGLE_STATE:
+        case DBusMenu.MENUITEM_PROP_TOGGLE_TYPE:
+        case DBusMenu.MENUITEM_PROP_TOGGLE_STATE:
             updateOrnament();
             break;
         }
@@ -236,20 +229,20 @@ function makePopupMenuItem(dbusmenuItem, deep) {
         };
         updateChildren();
         signalsHandler.add(
-            [dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_CHILD_ADDED, updateChildren],
-            [dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_CHILD_MOVED, updateChildren],
-            [dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_CHILD_REMOVED, updateChildren]);
+            [dbusmenuItem, DBusMenu.MENUITEM_SIGNAL_CHILD_ADDED, updateChildren],
+            [dbusmenuItem, DBusMenu.MENUITEM_SIGNAL_CHILD_MOVED, updateChildren],
+            [dbusmenuItem, DBusMenu.MENUITEM_SIGNAL_CHILD_REMOVED, updateChildren]);
     } else {
         // Don't make a submenu.
         if (!deep) {
             // We only have the potential to get a submenu if we aren't deep.
             signalsHandler.add(
-                [dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_CHILD_ADDED, recreateItem],
-                [dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_CHILD_MOVED, recreateItem],
-                [dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_CHILD_REMOVED, recreateItem]);
+                [dbusmenuItem, DBusMenu.MENUITEM_SIGNAL_CHILD_ADDED, recreateItem],
+                [dbusmenuItem, DBusMenu.MENUITEM_SIGNAL_CHILD_MOVED, recreateItem],
+                [dbusmenuItem, DBusMenu.MENUITEM_SIGNAL_CHILD_REMOVED, recreateItem]);
         }
 
-        if (itemType === Dbusmenu.CLIENT_TYPES_SEPARATOR) {
+        if (itemType === DBusMenu.CLIENT_TYPES_SEPARATOR) {
             item = new PopupMenu.PopupSeparatorMenuItem();
         } else if (wantIcon) {
             item = new PopupMenu.PopupImageMenuItem(label, null);
@@ -274,12 +267,12 @@ function makePopupMenuItem(dbusmenuItem, deep) {
         item.icon.icon_size = 16;
 
 
-    signalsHandler.add(dbusmenuItem, Dbusmenu.MENUITEM_SIGNAL_PROPERTY_CHANGED, onPropertyChanged);
+    signalsHandler.add(dbusmenuItem, DBusMenu.MENUITEM_SIGNAL_PROPERTY_CHANGED, onPropertyChanged);
 
     // Connections on item will be lost when item is disposed; there's no need
     // to add them to signalsHandler.
     item.connect('activate', () =>
-        dbusmenuItem.handle_event(Dbusmenu.MENUITEM_EVENT_ACTIVATED,
+        dbusmenuItem.handle_event(DBusMenu.MENUITEM_EVENT_ACTIVATED,
             new GLib.Variant('i', 0), Math.floor(Date.now() / 1000)));
     item.connect('destroy', () => signalsHandler.destroy());
 

--- a/dependencies/gi.js
+++ b/dependencies/gi.js
@@ -1,0 +1,27 @@
+import Atk from 'gi://Atk';
+import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import Gdk from 'gi://Gdk?version=4.0';
+import GdkPixbuf from 'gi://GdkPixbuf';
+import Gio from 'gi://Gio';
+import Gtk from 'gi://Gtk?version=4.0';
+import Meta from 'gi://Meta';
+import Pango from 'gi://Pango';
+import Shell from 'gi://Shell';
+import St from 'gi://St';
+
+export {
+    Atk,
+    Clutter,
+    GLib,
+    GObject,
+    Gdk,
+    GdkPixbuf,
+    Gio,
+    Gtk,
+    Meta,
+    Pango,
+    Shell,
+    St
+};

--- a/dependencies/shell/extensions/extension.js
+++ b/dependencies/shell/extensions/extension.js
@@ -1,0 +1,1 @@
+export * as Extension from 'resource:///org/gnome/shell/extensions/extension.js';

--- a/dependencies/shell/misc.js
+++ b/dependencies/shell/misc.js
@@ -1,0 +1,5 @@
+export * as AnimationUtils from 'resource:///org/gnome/shell/misc/animationUtils.js';
+export * as Config from 'resource:///org/gnome/shell/misc/config.js';
+export * as ExtensionUtils from 'resource:///org/gnome/shell/misc/extensionUtils.js';
+export * as ParentalControlsManager from 'resource:///org/gnome/shell/misc/parentalControlsManager.js';
+export * as Util from 'resource:///org/gnome/shell/misc/util.js';

--- a/dependencies/shell/ui.js
+++ b/dependencies/shell/ui.js
@@ -1,0 +1,17 @@
+export * as AppDisplay from 'resource:///org/gnome/shell/ui/appDisplay.js';
+export * as AppFavorites from 'resource:///org/gnome/shell/ui/appFavorites.js';
+export * as BoxPointer from 'resource:///org/gnome/shell/ui/boxpointer.js';
+export * as DND from 'resource:///org/gnome/shell/ui/dnd.js';
+export * as Dash from 'resource:///org/gnome/shell/ui/dash.js';
+export * as Layout from 'resource:///org/gnome/shell/ui/layout.js';
+export * as Main from 'resource:///org/gnome/shell/ui/main.js';
+export * as Overview from 'resource:///org/gnome/shell/ui/overview.js';
+export * as OverviewControls from 'resource:///org/gnome/shell/ui/overviewControls.js';
+export * as PointerWatcher from 'resource:///org/gnome/shell/ui/pointerWatcher.js';
+export * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+export * as SearchController from 'resource:///org/gnome/shell/ui/searchController.js';
+export * as ShellMountOperation from 'resource:///org/gnome/shell/ui/shellMountOperation.js';
+export * as Workspace from 'resource:///org/gnome/shell/ui/workspace.js';
+export * as WorkspaceSwitcherPopup from 'resource:///org/gnome/shell/ui/workspaceSwitcherPopup.js';
+export * as WorkspaceThumbnail from 'resource:///org/gnome/shell/ui/workspaceThumbnail.js';
+export * as WorkspacesView from 'resource:///org/gnome/shell/ui/workspacesView.js';

--- a/desktopIconsIntegration.js
+++ b/desktopIconsIntegration.js
@@ -55,11 +55,11 @@
  *
  *******************************************************************************/
 
-import { GLib } from './dependencies/gi.js';
-import { Main } from './dependencies/shell/ui.js';
-import { ExtensionUtils } from './dependencies/shell/misc.js';
+import {GLib} from './dependencies/gi.js';
+import {Main} from './dependencies/shell/ui.js';
+import {ExtensionUtils} from './dependencies/shell/misc.js';
 
-import { DockManager } from './docking.js';
+import {DockManager} from './docking.js';
 
 const IDENTIFIER_UUID = '130cbc66-235c-4bd6-8571-98d2d8bba5e2';
 

--- a/desktopIconsIntegration.js
+++ b/desktopIconsIntegration.js
@@ -55,17 +55,15 @@
  *
  *******************************************************************************/
 
-/* exported DesktopIconsUsableAreaClass */
+import { GLib } from './dependencies/gi.js';
+import { Main } from './dependencies/shell/ui.js';
+import { ExtensionUtils } from './dependencies/shell/misc.js';
 
-const { GLib } = imports.gi;
-const { main: Main } = imports.ui;
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import { DockManager } from './docking.js';
 
 const IDENTIFIER_UUID = '130cbc66-235c-4bd6-8571-98d2d8bba5e2';
 
-var DesktopIconsUsableAreaClass = class {
+export class DesktopIconsUsableAreaClass {
     constructor() {
         this._extensionManager = Main.extensionManager;
         this._timedMarginsID = 0;
@@ -158,7 +156,9 @@ var DesktopIconsUsableAreaClass = class {
             return;
 
         const usableArea = extension?.stateObj?.DesktopIconsUsableArea;
-        if (usableArea?.uuid === IDENTIFIER_UUID)
-            usableArea.setMarginsForExtension(Me.uuid, this._margins);
+        if (usableArea?.uuid === IDENTIFIER_UUID) {
+            usableArea.setMarginsForExtension(
+                DockManager.extension.uuid, this._margins);
+        }
     }
-};
+}

--- a/docking.js
+++ b/docking.js
@@ -39,7 +39,7 @@ import {
     Utils
 } from './imports.js';
 
-const { signals: Signals } = imports;
+const {signals: Signals} = imports;
 
 const DOCK_DWELL_CHECK_INTERVAL = 100;
 const ICON_ANIMATOR_DURATION = 3000;
@@ -232,7 +232,7 @@ const DockedDash = GObject.registerClass({
         this._rtl = Clutter.get_default_text_direction() === Clutter.TextDirection.RTL;
 
         // Load settings
-        const { settings } = DockManager;
+        const {settings} = DockManager;
         this._isHorizontal = (this._position === St.Side.TOP) || (this._position === St.Side.BOTTOM);
 
         // Temporary ignore hover events linked to autohide for whatever reason
@@ -511,7 +511,7 @@ const DockedDash = GObject.registerClass({
     }
 
     _bindSettingsChanges() {
-        const { settings } = DockManager;
+        const {settings} = DockManager;
         this._signalsHandler.add([
             settings,
             'changed::scroll-action',
@@ -666,7 +666,7 @@ const DockedDash = GObject.registerClass({
      * This is call when visibility settings change
      */
     _updateVisibilityMode() {
-        const { settings } = DockManager;
+        const {settings} = DockManager;
         if (DockManager.settings.dockFixed || DockManager.settings.manualhide) {
             this._autohideIsEnabled = false;
             this._intellihideIsEnabled = false;
@@ -707,7 +707,7 @@ const DockedDash = GObject.registerClass({
         if (Main.overview.visibleTarget)
             return;
 
-        const { settings } = DockManager;
+        const {settings} = DockManager;
 
         if (DockManager.settings.dockFixed) {
             this._removeAnimations();
@@ -797,7 +797,7 @@ const DockedDash = GObject.registerClass({
     _hide() {
         // If no hiding animation is running or queued
         if ((this._dockState === State.SHOWN) || (this._dockState === State.SHOWING)) {
-            const { settings } = DockManager;
+            const {settings} = DockManager;
             const delay = settings.hideDelay;
 
             if (this._dockState === State.SHOWING) {
@@ -953,9 +953,9 @@ const DockedDash = GObject.registerClass({
     }
 
     _updatePressureBarrier() {
-        const { settings } = DockManager;
+        const {settings} = DockManager;
         this._canUsePressure = global.display.supports_extended_barriers();
-        const { pressureThreshold } = settings;
+        const {pressureThreshold} = settings;
 
         // Remove existing pressure barrier
         if (this._pressureBarrier) {
@@ -1135,7 +1135,7 @@ const DockedDash = GObject.registerClass({
         // Ensure variables linked to settings are updated.
         this._updateVisibilityMode();
 
-        const { dockFixed: fixedIsEnabled, dockExtended: extendHeight } = DockManager.settings;
+        const {dockFixed: fixedIsEnabled, dockExtended: extendHeight} = DockManager.settings;
 
         if (fixedIsEnabled)
             this.add_style_class_name('fixed');
@@ -1194,7 +1194,7 @@ const DockedDash = GObject.registerClass({
         if (!this._intellihideIsEnabled)
             return;
 
-        const { desktopIconsUsableArea } = DockManager.getDefault();
+        const {desktopIconsUsableArea} = DockManager.getDefault();
         if (this._position === St.Side.BOTTOM)
             desktopIconsUsableArea.setMargins(this.monitorIndex, 0, this._box.height, 0, 0);
         else if (this._position === St.Side.TOP)
@@ -1247,7 +1247,7 @@ const DockedDash = GObject.registerClass({
         // Restore dash accessibility
         Main.ctrlAltTabManager.addGroup(
             this.dash, _('Dash'), 'user-bookmarks-symbolic',
-            { focusCallback: this._onAccessibilityFocus.bind(this) });
+            {focusCallback: this._onAccessibilityFocus.bind(this)});
     }
 
     /**
@@ -1437,7 +1437,7 @@ const KeyboardShortcuts = class DashToDockKeyboardShortcuts {
 
         // Setup keyboard bindings for dash elements
         const keys = ['app-hotkey-', 'app-shift-hotkey-', 'app-ctrl-hotkey-'];
-        const { mainDock } = DockManager.getDefault();
+        const {mainDock} = DockManager.getDefault();
         keys.forEach(function (key) {
             for (let i = 0; i < NUM_HOTKEYS; i++) {
                 const appNum = i;
@@ -1468,7 +1468,7 @@ const KeyboardShortcuts = class DashToDockKeyboardShortcuts {
     }
 
     _optionalNumberOverlay() {
-        const { settings } = DockManager;
+        const {settings} = DockManager;
         this._shortcutIsSet = false;
         // Enable extra shortcut if either 'overlay' or 'show-dock' are true
         if (settings.hotKeys &&
@@ -1491,7 +1491,7 @@ const KeyboardShortcuts = class DashToDockKeyboardShortcuts {
     }
 
     _checkHotkeysOptions() {
-        const { settings } = DockManager;
+        const {settings} = DockManager;
 
         if (settings.hotKeys &&
            (settings.hotkeysOverlay || settings.hotkeysShowDock))
@@ -1556,7 +1556,7 @@ const KeyboardShortcuts = class DashToDockKeyboardShortcuts {
  */
 const WorkspaceIsolation = class DashToDockWorkspaceIsolation {
     constructor() {
-        const { settings } = DockManager;
+        const {settings} = DockManager;
 
         this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._injectionsHandler = new Utils.InjectionsHandler();
@@ -1650,7 +1650,7 @@ export class DockManager {
         this._propertyInjections = new Utils.PropertyInjectionsHandler(this);
         this._settings = this._extension.getSettings(
             'org.gnome.shell.extensions.dash-to-dock');
-        this._appSwitcherSettings = new Gio.Settings({ schema_id: 'org.gnome.shell.app-switcher' });
+        this._appSwitcherSettings = new Gio.Settings({schema_id: 'org.gnome.shell.app-switcher'});
         this._mapSettingsValues();
 
         this._iconTheme = new Utils.IconTheme();
@@ -1784,7 +1784,7 @@ export class DockManager {
     }
 
     _ensureLocations() {
-        const { showMounts, showTrash } = this.settings;
+        const {showMounts, showTrash} = this.settings;
 
         if (showTrash || showMounts) {
             if (!this._fm1Client)
@@ -1854,7 +1854,7 @@ export class DockManager {
                     },
                 ]);
 
-                const { get: defaultFocusAppGetter } = Object.getOwnPropertyDescriptor(
+                const {get: defaultFocusAppGetter} = Object.getOwnPropertyDescriptor(
                     Shell.WindowTracker.prototype, 'focus_app');
                 this._propertyInjections.addWithLabel(Labels.LOCATIONS,
                     Shell.WindowTracker.prototype, 'focus_app', {
@@ -1920,11 +1920,11 @@ export class DockManager {
                 `changed::${key}`, updateSetting);
             if (key !== camelKey) {
                 Object.defineProperty(this.settings, key,
-                    { get: () => this.settings[camelKey] });
+                    {get: () => this.settings[camelKey]});
             }
         });
         Object.defineProperties(this.settings, {
-            dockExtended: { get: () => this.settings.extendHeight },
+            dockExtended: {get: () => this.settings.extendHeight},
         });
     }
 
@@ -2048,7 +2048,7 @@ export class DockManager {
             for (let iMon = 0; iMon < nMon; iMon++) {
                 if (iMon === this._preferredMonitorIndex)
                     continue;
-                dock = new DockedDash({ monitorIndex: iMon });
+                dock = new DockedDash({monitorIndex: iMon});
                 this._allDocks.push(dock);
                 // connect app icon into the view selector
                 dock.dash.showAppsButton.connect('notify::checked',
@@ -2066,7 +2066,7 @@ export class DockManager {
 
     _prepareStartupAnimation(callback) {
         DockManager.allDocks.forEach(dock => {
-            const { dash } = dock;
+            const {dash} = dock;
 
             dock.opacity = 255;
             dash.set({
@@ -2103,10 +2103,10 @@ export class DockManager {
     }
 
     _runStartupAnimation(callback) {
-        const { STARTUP_ANIMATION_TIME } = Layout;
+        const {STARTUP_ANIMATION_TIME} = Layout;
 
         DockManager.allDocks.forEach(dock => {
-            const { dash } = dock;
+            const {dash} = dock;
 
             switch (dock.position) {
             case St.Side.LEFT:
@@ -2199,7 +2199,7 @@ export class DockManager {
                 return [0, 0];
             });
 
-        const { ControlsManager } = OverviewControls;
+        const {ControlsManager} = OverviewControls;
         // FIXME: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2890
         // const { ControlsManagerLayout } = OverviewControls;
         const ControlsManagerLayout = this.overviewControls.layout_manager.constructor;
@@ -2264,7 +2264,7 @@ export class DockManager {
 
                     dockManager._signalsHandler.addWithLabel(Labels.STARTUP_ANIMATION,
                         Utils.getMonitorManager(), 'monitors-changed', () => {
-                            const { x, y, width, height } = this.primaryMonitor;
+                            const {x, y, width, height} = this.primaryMonitor;
                             global.window_group.set_clip(x, y, width, height);
                             this._coverPane?.set({
                                 width: global.screen_width,
@@ -2308,7 +2308,7 @@ export class DockManager {
         const maybeAdjustBoxSize = (state, box, spacing) => {
             if (state === OverviewControls.ControlsState.WINDOW_PICKER) {
                 const searchBox = this.overviewControls._searchEntry.get_allocation_box();
-                const { shouldShow: wsThumbnails } = this.overviewControls._thumbnailsBox;
+                const {shouldShow: wsThumbnails} = this.overviewControls._thumbnailsBox;
 
                 if (!wsThumbnails) {
                     box.y1 += spacing;
@@ -2357,7 +2357,7 @@ export class DockManager {
                 const oldStartY = workAreaBox.y1;
 
                 const propertyInjections = new Utils.PropertyInjectionsHandler();
-                propertyInjections.add(Main.layoutManager.panelBox, 'height', { value: startY });
+                propertyInjections.add(Main.layoutManager.panelBox, 'height', {value: startY});
 
                 if (Main.layoutManager.panelBox.y === Main.layoutManager.primaryMonitor.y)
                     workAreaBox.y1 -= oldStartY;
@@ -2506,7 +2506,7 @@ export class DockManager {
                     const monitor = Main.layoutManager.primaryMonitor;
                     const x = monitor.x + monitor.width / 2.0;
                     const y = monitor.y + monitor.height / 2.0;
-                    const { STARTUP_ANIMATION_TIME } = Layout;
+                    const {STARTUP_ANIMATION_TIME} = Layout;
 
                     this._prepareStartupAnimation(callback);
                     Main.uiGroup.set_pivot_point(
@@ -2574,8 +2574,8 @@ export class DockManager {
     }
 
     _onShowAppsButtonToggled(button) {
-        const { checked } = button;
-        const { overviewControls } = this;
+        const {checked} = button;
+        const {overviewControls} = this;
 
         if (!Main.overview.visible) {
             this.mainDock.dash.showAppsButton._fromDesktop = true;
@@ -2757,7 +2757,7 @@ export class IconAnimator {
     addAnimation(target, name) {
         const targetDestroyId = target.connect('destroy',
             () => this.removeAnimation(target, name));
-        this._animations[name].push({ target, targetDestroyId });
+        this._animations[name].push({target, targetDestroyId});
         if (this._started && this._count === 0)
             this._timeline.start();
 

--- a/extension.js
+++ b/extension.js
@@ -1,32 +1,18 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-/* exported init, enable, disable */
+import { DockManager } from './docking.js';
+import { Extension } from './dependencies/shell/extensions/extension.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { docking: Docking } = Me.imports;
+// We export this so it can be accessed by other extensions
+export let dockManager;
 
-// We declare this with var so it can be accessed by other extensions in
-// GNOME Shell 3.26+ (mozjs52+).
-var dockManager;
+export default class DashToDockExtension extends Extension.Extension {
+    enable() {
+        dockManager = new DockManager(this);
+    }
 
-/**
- *
- */
-function init() {
-    ExtensionUtils.initTranslations('dashtodock');
-}
-
-/**
- *
- */
-function enable() {
-    new Docking.DockManager();
-}
-
-/**
- *
- */
-function disable() {
-    dockManager.destroy();
+    disable() {
+        dockManager?.destroy();
+        dockManager = null;
+    }
 }

--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,7 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-import { DockManager } from './docking.js';
-import { Extension } from './dependencies/shell/extensions/extension.js';
+import {DockManager} from './docking.js';
+import {Extension} from './dependencies/shell/extensions/extension.js';
 
 // We export this so it can be accessed by other extensions
 export let dockManager;

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -1,10 +1,9 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-const { GLib, Gio } = imports.gi;
+import { GLib, Gio } from './dependencies/gi.js';
 const { signals: Signals } = imports;
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const { utils: Utils } = Me.imports;
+import { Utils } from './imports.js';
 
 const FileManager1Iface = '<node><interface name="org.freedesktop.FileManager1">\
                                <property name="OpenWindowsWithLocations" type="a{sas}" access="read"/>\
@@ -24,7 +23,7 @@ const Labels = Object.freeze({
  * The property is a map from window identifiers to a list of locations open in
  * the window.
  */
-var FileManager1Client = class DashToDockFileManager1Client {
+export class FileManager1Client {
     constructor() {
         this._signalsHandler = new Utils.GlobalSignalsHandler();
         this._cancellable = new Gio.Cancellable();
@@ -198,5 +197,5 @@ var FileManager1Client = class DashToDockFileManager1Client {
             this.emit('windows-changed');
         }
     }
-};
+}
 Signals.addSignalMethods(FileManager1Client.prototype);

--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -1,9 +1,9 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-import { GLib, Gio } from './dependencies/gi.js';
-const { signals: Signals } = imports;
+import {GLib, Gio} from './dependencies/gi.js';
+const {signals: Signals} = imports;
 
-import { Utils } from './imports.js';
+import {Utils} from './imports.js';
 
 const FileManager1Iface = '<node><interface name="org.freedesktop.FileManager1">\
                                <property name="OpenWindowsWithLocations" type="a{sas}" access="read"/>\

--- a/imports.js
+++ b/imports.js
@@ -1,0 +1,35 @@
+import * as AppIconIndicators from './appIconIndicators.js';
+import * as AppIcons from './appIcons.js';
+import * as AppSpread from './appSpread.js';
+import * as DockDash from './dash.js';
+import * as DBusMenuUtils from './dbusmenuUtils.js';
+import * as DesktopIconsIntegration from './desktopIconsIntegration.js';
+import * as Docking from './docking.js';
+import * as Extension from './extension.js';
+import * as FileManager1API from './fileManager1API.js';
+import * as Intellihide from './intellihide.js';
+import * as LauncherAPI from './launcherAPI.js';
+import * as Locations from './locations.js';
+import * as NotificationsMonitor from './notificationsMonitor.js';
+import * as Theming from './theming.js';
+import * as Utils from './utils.js';
+import * as WindowPreview from './windowPreview.js';
+
+export {
+    AppIconIndicators,
+    AppIcons,
+    AppSpread,
+    DockDash,
+    DBusMenuUtils,
+    DesktopIconsIntegration,
+    Docking,
+    Extension,
+    FileManager1API,
+    Intellihide,
+    LauncherAPI,
+    Locations,
+    NotificationsMonitor,
+    Theming,
+    Utils,
+    WindowPreview
+};

--- a/intellihide.js
+++ b/intellihide.js
@@ -1,18 +1,17 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-const {
+import {
     GLib,
     Meta,
-    Shell,
-} = imports.gi;
+    Shell
+} from './dependencies/gi.js';
+
+import {
+    Docking,
+    Utils
+} from './imports.js';
 
 const { signals: Signals } = imports;
-
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const {
-    docking: Docking,
-    utils: Utils,
-} = Me.imports;
 
 // A good compromise between reactivity and efficiency; to be tuned.
 const INTELLIHIDE_CHECK_INTERVAL = 100;
@@ -52,7 +51,7 @@ const ignoreApps = ['com.rastersoft.ding', 'com.desktop.ding'];
  * Intallihide object: emit 'status-changed' signal when the overlap of windows
  * with the provided targetBoxClutter.ActorBox changes;
  */
-var Intellihide = class DashToDockIntellihide {
+export class Intellihide {
     constructor(monitorIndex) {
         // Load settings
         this._monitorIndex = monitorIndex;
@@ -325,7 +324,7 @@ var Intellihide = class DashToDockIntellihide {
 
         const wtype = metaWindow.get_window_type();
         for (let i = 0; i < handledWindowTypes.length; i++) {
-            var hwtype = handledWindowTypes[i];
+            const hwtype = handledWindowTypes[i];
             if (hwtype === wtype)
                 return true;
             else if (hwtype > wtype)
@@ -333,6 +332,6 @@ var Intellihide = class DashToDockIntellihide {
         }
         return false;
     }
-};
+}
 
 Signals.addSignalMethods(Intellihide.prototype);

--- a/intellihide.js
+++ b/intellihide.js
@@ -11,7 +11,7 @@ import {
     Utils
 } from './imports.js';
 
-const { signals: Signals } = imports;
+const {signals: Signals} = imports;
 
 // A good compromise between reactivity and efficiency; to be tuned.
 const INTELLIHIDE_CHECK_INTERVAL = 100;
@@ -290,7 +290,7 @@ export class Intellihide {
         case IntellihideMode.ALWAYS_ON_TOP:
             // Always on top, except for fullscreen windows
             if (this._focusApp) {
-                const { focusWindow } = global.display;
+                const {focusWindow} = global.display;
                 if (!focusWindow?.fullscreen)
                     return false;
             }

--- a/launcherAPI.js
+++ b/launcherAPI.js
@@ -1,15 +1,11 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-/* exported LauncherEntryRemoteModel */
+import { Gio } from './dependencies/gi.js';
+import { DBusMenuUtils } from './imports.js';
 
-const { Gio } = imports.gi;
+const DBusMenu = await DBusMenuUtils.haveDBusMenu();
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const { dbusmenuUtils: DbusmenuUtils } = Me.imports;
-
-const Dbusmenu = DbusmenuUtils.haveDBusMenu();
-
-var LauncherEntryRemoteModel = class DashToDockLauncherEntryRemoteModel {
+export class LauncherEntryRemoteModel {
     constructor() {
         this._entrySourceStacks = new Map();
         this._remoteMaps = new Map();
@@ -119,7 +115,7 @@ var LauncherEntryRemoteModel = class DashToDockLauncherEntryRemoteModel {
             remoteMap.set(appId, remote = Object.assign({}, launcherEntryDefaults));
 
         for (const name in properties) {
-            if (name === 'quicklist' && Dbusmenu) {
+            if (name === 'quicklist' && DBusMenu) {
                 const quicklistPath = properties[name].unpack();
                 if (quicklistPath &&
                     (!remote._quicklistMenuClient ||
@@ -132,7 +128,7 @@ var LauncherEntryRemoteModel = class DashToDockLauncherEntryRemoteModel {
                         // This property should not be enumerable
                         Object.defineProperty(remote, '_quicklistMenuClient', {
                             writable: true,
-                            value: menuClient = new Dbusmenu.Client({
+                            value: menuClient = new DBusMenu.Client({
                                 dbus_name: senderName,
                                 dbus_object: quicklistPath,
                             }),
@@ -148,7 +144,7 @@ var LauncherEntryRemoteModel = class DashToDockLauncherEntryRemoteModel {
                             }
                         }
                     };
-                    menuClient.connect(Dbusmenu.CLIENT_SIGNAL_ROOT_CHANGED, handler);
+                    menuClient.connect(DBusMenu.CLIENT_SIGNAL_ROOT_CHANGED, handler);
                 }
             } else {
                 remote[name] = properties[name].unpack();
@@ -158,7 +154,7 @@ var LauncherEntryRemoteModel = class DashToDockLauncherEntryRemoteModel {
         const sourceStack = this._lookupStackById(appId);
         sourceStack.target._emitChangedEvents(sourceStack.update(remote));
     }
-};
+}
 
 const launcherEntryDefaults = Object.freeze({
     count: 0,

--- a/launcherAPI.js
+++ b/launcherAPI.js
@@ -1,7 +1,7 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-import { Gio } from './dependencies/gi.js';
-import { DBusMenuUtils } from './imports.js';
+import {Gio} from './dependencies/gi.js';
+import {DBusMenuUtils} from './imports.js';
 
 const DBusMenu = await DBusMenuUtils.haveDBusMenu();
 
@@ -178,7 +178,7 @@ const LauncherEntry = class DashToDockLauncherEntry {
 
         callback(this, this);
         const id = this._nextId++;
-        const handler = { id, callback };
+        const handler = {id, callback};
         eventNames.forEach(name => {
             let handlerList = this._handlers.get(name);
             if (!handlerList)

--- a/lint/eslintrc-gjs.yml
+++ b/lint/eslintrc-gjs.yml
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
 # SPDX-FileCopyrightText: 2018 Claudio André <claudioandre.br@gmail.com>
 env:
-  es6: true
-  es2020: true
+  es2021: true
 extends: 'eslint:recommended'
 rules:
   array-bracket-newline:
@@ -241,4 +240,4 @@ globals:
   printerr: readonly
   window: readonly
 parserOptions:
-  ecmaVersion: 2020
+  ecmaVersion: 2022

--- a/lint/eslintrc-gjs.yml
+++ b/lint/eslintrc-gjs.yml
@@ -72,7 +72,10 @@ rules:
   linebreak-style:
     - error
     - unix
-  lines-between-class-members: error
+  lines-between-class-members:
+    - error
+    - always
+    - exceptAfterSingleLine: true
   max-nested-callbacks: error
   max-statements-per-line: error
   new-parens: error
@@ -111,12 +114,6 @@ rules:
   no-restricted-globals: [error, window]
   no-restricted-properties:
     - error
-    - object: imports
-      property: format
-      message: Use template strings
-    - object: pkg
-      property: initFormat
-      message: Use template strings
     - object: Lang
       property: copyProperties
       message: Use Object.assign()
@@ -175,6 +172,7 @@ rules:
   object-curly-newline:
     - error
     - consistent: true
+      multiline: true
   object-curly-spacing: error
   object-shorthand: error
   operator-assignment: error
@@ -239,5 +237,12 @@ globals:
   print: readonly
   printerr: readonly
   window: readonly
+  TextEncoder: readonly
+  TextDecoder: readonly
+  console: readonly
+  setTimeout: readonly
+  setInterval: readonly
+  clearTimeout: readonly
+  clearInterval: readonly
 parserOptions:
   ecmaVersion: 2022

--- a/lint/eslintrc-shell.yml
+++ b/lint/eslintrc-shell.yml
@@ -4,20 +4,23 @@ rules:
     - properties: never
       allow: [^vfunc_, ^on_]
   consistent-return: error
+  eqeqeq:
+    - error
+    - smart
   key-spacing:
     - error
     - mode: minimum
       beforeColon: false
       afterColon: true
-  object-curly-spacing:
-    - error
-    - always
   prefer-arrow-callback: error
 
 overrides:
-  - files: js/**
+  - files:
+      - js/**
+      - tests/shell/**
     excludedFiles:
       - js/portalHelper/*
+      - js/extensions/*
     globals:
       global: readonly
       _: readonly

--- a/locations.js
+++ b/locations.js
@@ -8,20 +8,20 @@ import {
     St
 } from './dependencies/gi.js';
 
-import { ShellMountOperation } from './dependencies/shell/ui.js';
+import {ShellMountOperation} from './dependencies/shell/ui.js';
 
 import {
     Docking,
     Utils
 } from './imports.js';
 
-import { Extension } from './dependencies/shell/extensions/extension.js';
+import {Extension} from './dependencies/shell/extensions/extension.js';
 
 // Use __ () and N__() for the extension gettext domain, and reuse
 // the shell domain with the default _() and N_()
-const { gettext: __ } = Extension;
+const {gettext: __} = Extension;
 
-const { signals: Signals } = imports;
+const {signals: Signals} = imports;
 
 const FALLBACK_REMOVABLE_MEDIA_ICON = 'drive-removable-media';
 const FALLBACK_TRASH_ICON = 'user-trash';
@@ -75,7 +75,7 @@ function makeNautilusFileOperationsProxy() {
             timestamp: global.get_current_time(),
             windowPosition: 'center',
         };
-        const { parentHandle, timestamp, windowPosition } = {
+        const {parentHandle, timestamp, windowPosition} = {
             ...defaultParams,
             ...params,
         };
@@ -249,7 +249,7 @@ export const LocationAppInfo = GObject.registerClass({
     }
 
     async _queryLocationIcons(params) {
-        const icons = { standard: null, custom: null };
+        const icons = {standard: null, custom: null};
         if (!this.location)
             return icons;
 
@@ -298,14 +298,14 @@ export const LocationAppInfo = GObject.registerClass({
         return icons;
     }
 
-    async _updateLocationIcon(params = { standard: true, custom: true }) {
+    async _updateLocationIcon(params = {standard: true, custom: true}) {
         const cancellable = new Utils.CancellableChild(this.cancellable);
 
         try {
             this._updateIconCancellable?.cancel();
             this._updateIconCancellable = cancellable;
 
-            const icons = await this._queryLocationIcons({ cancellable, ...params });
+            const icons = await this._queryLocationIcons({cancellable, ...params});
             const icon = icons.custom ?? icons.standard;
 
             if (icon && !icon.equal(this.icon))
@@ -503,7 +503,7 @@ class MountableVolumeAppInfo extends LocationAppInfo {
 
     list_actions() {
         const actions = [];
-        const { mount } = this;
+        const {mount} = this;
 
         if (mount) {
             if (this.mount.can_unmount())
@@ -553,7 +553,7 @@ class MountableVolumeAppInfo extends LocationAppInfo {
         this.location = this.mount?.get_default_location() ??
             this.volume.get_activation_root();
 
-        this._updateLocationIcon({ custom: true });
+        this._updateLocationIcon({custom: true});
     }
 
     _monitorChanges() {
@@ -804,7 +804,7 @@ class TrashAppInfo extends LocationAppInfo {
         const nautilus = makeNautilusFileOperationsProxy();
         const askConfirmation = true;
         nautilus.EmptyTrashRemote(askConfirmation,
-            nautilus.platformData({ timestamp }), (_p, error) => {
+            nautilus.platformData({timestamp}), (_p, error) => {
                 if (error)
                     logError(error, 'Empty trash failed');
             }, this.cancellable);
@@ -838,7 +838,7 @@ function wrapWindowsBackedApp(shellApp) {
                     set: v => (this[p] = v),
                     configurable: true,
                     enumerable: !!o.enumerable,
-                }, o.readOnly ? { set: undefined } : {}));
+                }, o.readOnly ? {set: undefined} : {}));
                 if (o.value)
                     this[p] = o.value;
                 this.proxyProperties.push(publicProp);
@@ -859,9 +859,9 @@ function wrapWindowsBackedApp(shellApp) {
         windows: {},
         state: {},
         startingWorkspace: {},
-        isFocused: { public: true },
-        signalConnections: { readOnly: true },
-        sources: { readOnly: true },
+        isFocused: {public: true},
+        signalConnections: {readOnly: true},
+        sources: {readOnly: true},
         checkFocused: {},
         setDtdData: {},
     });
@@ -870,9 +870,9 @@ function wrapWindowsBackedApp(shellApp) {
         for (const [name, value] of Object.entries(data)) {
             if (params.readOnly && name in this._dtdData)
                 throw new Error('Property %s is already defined'.format(name));
-            const defaultParams = { public: true, readOnly: true };
+            const defaultParams = {public: true, readOnly: true};
             this._dtdData.addProxyProperties(this, {
-                [name]: { ...defaultParams, ...params, value },
+                [name]: {...defaultParams, ...params, value},
             });
         }
     };
@@ -881,10 +881,10 @@ function wrapWindowsBackedApp(shellApp) {
     const p = (...args) => shellApp._dtdData.propertyInjections.add(shellApp, ...args);
 
     // mi is Method injector, pi is Property injector
-    shellApp._setDtdData({ mi: m, pi: p }, { public: false });
+    shellApp._setDtdData({mi: m, pi: p}, {public: false});
 
     m('get_state', () => shellApp._state ?? shellApp._getStateByWindows());
-    p('state', { get: () => shellApp.get_state() });
+    p('state', {get: () => shellApp.get_state()});
 
     m('get_windows', () => shellApp._windows);
     m('get_n_windows', () => shellApp._windows.length);
@@ -925,7 +925,7 @@ function wrapWindowsBackedApp(shellApp) {
         _setWindows(windows) {
             const oldState = this.state;
             const oldWindows = this._windows.slice();
-            const result = { windowsChanged: false, stateChanged: false };
+            const result = {windowsChanged: false, stateChanged: false};
             this._state = undefined;
 
             if (windows.length !== oldWindows.length ||
@@ -943,7 +943,7 @@ function wrapWindowsBackedApp(shellApp) {
 
             return result;
         },
-    }, { readOnly: false });
+    }, {readOnly: false});
 
     shellApp._sources.add(GLib.idle_add(GLib.DEFAULT_PRIORITY, () => {
         shellApp._updateWindows();
@@ -1017,7 +1017,7 @@ function wrapWindowsBackedApp(shellApp) {
 
     m('compare', (_om, other) => Utils.shellAppCompare(shellApp, other));
 
-    const { destroy: defaultDestroy } = shellApp;
+    const {destroy: defaultDestroy} = shellApp;
     shellApp.destroy = function () {
         /* eslint-disable no-invalid-this */
         this._dtdData.proxyProperties.forEach(prop => delete this[prop]);
@@ -1041,7 +1041,7 @@ function makeLocationApp(params) {
     if (!(params?.appInfo instanceof LocationAppInfo))
         throw new TypeError('Invalid location');
 
-    const { fallbackIconName } = params;
+    const {fallbackIconName} = params;
     delete params.fallbackIconName;
 
     const shellApp = new Shell.App(params);
@@ -1050,7 +1050,7 @@ function makeLocationApp(params) {
     shellApp._setDtdData({
         location: () => shellApp.appInfo.location,
         isTrash: shellApp.appInfo instanceof TrashAppInfo,
-    }, { getter: true, enumerable: true });
+    }, {getter: true, enumerable: true});
 
     shellApp._mi('toString', defaultToString =>
         '[LocationApp "%s" - %s]'.format(shellApp.get_id(),
@@ -1120,7 +1120,7 @@ function makeLocationApp(params) {
             return parentGetBusy.call(this);
             /* eslint-enable no-invalid-this */
         });
-        shellApp._pi('busy', { get: () => shellApp.get_busy() });
+        shellApp._pi('busy', {get: () => shellApp.get_busy()});
         shellApp._signalConnections.add(shellApp.appInfo, 'notify::busy', _ =>
             shellApp.notify('busy'));
     }
@@ -1133,7 +1133,7 @@ function makeLocationApp(params) {
         /* eslint-enable no-invalid-this */
     });
 
-    const { fm1Client } = Docking.DockManager.getDefault();
+    const {fm1Client} = Docking.DockManager.getDefault();
     shellApp._setDtdData({
         _needsResort: true,
 
@@ -1150,7 +1150,7 @@ function makeLocationApp(params) {
         _updateWindows() {
             const windows = fm1Client.getWindows(this.location?.get_uri()).sort(
                 Utils.shellWindowsCompare);
-            const { windowsChanged } = this._setWindows(windows);
+            const {windowsChanged} = this._setWindows(windows);
 
             if (!windowsChanged)
                 return;
@@ -1163,7 +1163,7 @@ function makeLocationApp(params) {
                             this._windowsOrderChanged();
                     }));
         },
-    }, { readOnly: false });
+    }, {readOnly: false});
 
     shellApp._signalConnections.add(fm1Client, 'windows-changed', () =>
         shellApp._updateWindows());
@@ -1196,7 +1196,7 @@ export function wrapFileManagerApp() {
     const originalGetWindows = fileManagerApp.get_windows;
     wrapWindowsBackedApp(fileManagerApp);
 
-    const { removables, trash } = Docking.DockManager.getDefault();
+    const {removables, trash} = Docking.DockManager.getDefault();
     fileManagerApp._signalConnections.addWithLabel(Labels.WINDOWS_CHANGED,
         fileManagerApp, 'windows-changed', () => {
             fileManagerApp.stop_emission_by_name('windows-changed');
@@ -1402,7 +1402,7 @@ export class Removables {
     }
 
     _onVolumeRemoved(volume) {
-        const volumeIndex = this._volumeApps.findIndex(({ appInfo }) =>
+        const volumeIndex = this._volumeApps.findIndex(({appInfo}) =>
             appInfo.volume === volume);
         if (volumeIndex !== -1) {
             const [volumeApp] = this._volumeApps.splice(volumeIndex, 1);
@@ -1417,7 +1417,7 @@ export class Removables {
         if (!Docking.DockManager.settings.showMountsOnlyMounted)
             return;
 
-        if (!this._volumeApps.find(({ appInfo }) => appInfo.mount === mount)) {
+        if (!this._volumeApps.find(({appInfo}) => appInfo.mount === mount)) {
             // In some Gio.Mount implementations the volume may be set after
             // mount is emitted, so we could just ignore it as we'll get it
             // later via volume-added

--- a/locationsWorker.js
+++ b/locationsWorker.js
@@ -1,9 +1,7 @@
 #!/usr/bin/env gjs
 
-const { GLib, Gio } = imports.gi;
-
-const currentPath = GLib.path_get_dirname(new Error().fileName);
-imports.searchPath.unshift(currentPath);
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
 
 const GJS_SUPPORTS_FILE_IFACE_PROMISES = imports.system.version >= 17101;
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,6 @@
 {
 "shell-version": [
-    "40",
-    "41",
-    "42",
-    "43",
-    "44"
+    "45"
 ],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",

--- a/notificationsMonitor.js
+++ b/notificationsMonitor.js
@@ -1,29 +1,20 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-/* exported NotificationsMonitor */
+import { Gio } from './dependencies/gi.js';
+import { Main } from './dependencies/shell/ui.js';
+
+import {
+    Docking,
+    Utils
+} from './imports.js';
 
 const { signals: Signals } = imports;
 
-const {
-    Gio,
-} = imports.gi;
-
-const {
-    main: Main,
-} = imports.ui;
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
-const {
-    docking: Docking,
-    utils: Utils,
-} = Me.imports;
 const Labels = Object.freeze({
     SOURCES: Symbol('sources'),
     NOTIFICATIONS: Symbol('notifications'),
 });
-var NotificationsMonitor = class NotificationsManagerImpl {
+export class NotificationsMonitor {
     constructor() {
         this._settings = new Gio.Settings({
             schema_id: 'org.gnome.desktop.notifications',
@@ -124,6 +115,6 @@ var NotificationsMonitor = class NotificationsManagerImpl {
 
         this.emit('changed');
     }
-};
+}
 
 Signals.addSignalMethods(NotificationsMonitor.prototype);

--- a/notificationsMonitor.js
+++ b/notificationsMonitor.js
@@ -1,14 +1,14 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-import { Gio } from './dependencies/gi.js';
-import { Main } from './dependencies/shell/ui.js';
+import {Gio} from './dependencies/gi.js';
+import {Main} from './dependencies/shell/ui.js';
 
 import {
     Docking,
     Utils
 } from './imports.js';
 
-const { signals: Signals } = imports;
+const {signals: Signals} = imports;
 
 const Labels = Object.freeze({
     SOURCES: Symbol('sources'),

--- a/prefs.js
+++ b/prefs.js
@@ -131,9 +131,9 @@ class MonitorsConfig {
         // for monitors, it can be removed when we don't care about breaking
         // old user configurations or external apps configuring this extension
         // such as ubuntu's gnome-control-center.
-        const { index: primaryMonitorIndex } = this._primaryMonitor;
+        const {index: primaryMonitorIndex} = this._primaryMonitor;
         for (const monitor of this._monitors) {
-            let { index } = monitor;
+            let {index} = monitor;
             // The The dock uses the Gdk index for monitors, where the primary monitor
             // always has index 0, so let's follow what dash-to-dock does in docking.js
             // (as part of _createDocks), but using inverted math
@@ -180,7 +180,7 @@ const DockSettings = GObject.registerClass({
         this._extensionPreferences = extensionPreferences;
         this._settings = extensionPreferences.getSettings(
             'org.gnome.shell.extensions.dash-to-dock');
-        this._appSwitcherSettings = new Gio.Settings({ schema_id: 'org.gnome.shell.app-switcher' });
+        this._appSwitcherSettings = new Gio.Settings({schema_id: 'org.gnome.shell.app-switcher'});
         this._rtl = Gtk.Widget.get_default_direction() === Gtk.TextDirection.RTL;
 
         this._builder = new Gtk.Builder();
@@ -1164,7 +1164,7 @@ const DockSettings = GObject.registerClass({
 export default class DockPreferences extends ExtensionPreferences {
     getPreferencesWidget() {
         const settings = new DockSettings(this);
-        const { widget } = settings;
+        const {widget} = settings;
         return widget;
     }
 }

--- a/theming.js
+++ b/theming.js
@@ -6,14 +6,14 @@ import {
     St
 } from './dependencies/gi.js';
 
-import { Main } from './dependencies/shell/ui.js';
+import {Main} from './dependencies/shell/ui.js';
 
 import {
     Docking,
     Utils
 } from './imports.js';
 
-const { signals: Signals } = imports;
+const {signals: Signals} = imports;
 
 /*
  * DEFAULT:  transparency given by theme
@@ -48,8 +48,8 @@ export class ThemeManager {
         this._dash = dock.dash;
 
         // initialize colors with generic values
-        this._customizedBackground = { red: 0, green: 0, blue: 0, alpha: 0 };
-        this._customizedBorder = { red: 0, green: 0, blue: 0, alpha: 0 };
+        this._customizedBackground = {red: 0, green: 0, blue: 0, alpha: 0};
+        this._customizedBorder = {red: 0, green: 0, blue: 0, alpha: 0};
         this._transparency = new Transparency(dock);
 
         this._signalsHandler.add([
@@ -156,7 +156,7 @@ export class ThemeManager {
         if (!backgroundColor)
             return;
 
-        const { settings } = Docking.DockManager;
+        const {settings} = Docking.DockManager;
 
         if (settings.customBackgroundColor) {
             // When applying a custom color, we need to check the alpha value,
@@ -165,7 +165,7 @@ export class ThemeManager {
             // the opacity will be set by the opaque/transparent styles anyway.
             let newAlpha = Math.round(backgroundColor.alpha / 2.55) / 100;
 
-            ({ backgroundColor } = settings);
+            ({backgroundColor} = settings);
             // backgroundColor is a string like rgb(0,0,0)
             const [ret, color] = Clutter.Color.from_string(backgroundColor);
             if (!ret) {
@@ -192,7 +192,7 @@ export class ThemeManager {
     }
 
     _updateCustomStyleClasses() {
-        const { settings } = Docking.DockManager;
+        const {settings} = Docking.DockManager;
 
         if (settings.applyCustomTheme)
             this._actor.add_style_class_name('dashtodock');
@@ -239,7 +239,7 @@ export class ThemeManager {
         if (!this._dash._background.get_stage())
             return;
 
-        const { settings } = Docking.DockManager;
+        const {settings} = Docking.DockManager;
 
         // Remove prior style edits
         this._dash._background.set_style(null);
@@ -547,7 +547,7 @@ class Transparency {
 
         Main.uiGroup.remove_child(dummyObject);
 
-        const { settings } = Docking.DockManager;
+        const {settings} = Docking.DockManager;
 
         if (settings.customizeAlphas) {
             this._opaqueAlpha = settings.maxAlpha;

--- a/theming.js
+++ b/theming.js
@@ -1,22 +1,19 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-/* exported PositionStyleClass */
-
-const { signals: Signals } = imports;
-
-const {
+import {
     Clutter,
     Meta,
-    St,
-} = imports.gi;
+    St
+} from './dependencies/gi.js';
 
-const { main: Main } = imports.ui;
+import { Main } from './dependencies/shell/ui.js';
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const {
-    docking: Docking,
-    utils: Utils,
-} = Me.imports;
+import {
+    Docking,
+    Utils
+} from './imports.js';
+
+const { signals: Signals } = imports;
 
 /*
  * DEFAULT:  transparency given by theme
@@ -33,7 +30,7 @@ const Labels = Object.freeze({
     TRANSPARENCY: Symbol('transparency'),
 });
 
-var PositionStyleClass = Object.freeze([
+export const PositionStyleClass = Object.freeze([
     'top',
     'right',
     'bottom',
@@ -43,7 +40,7 @@ var PositionStyleClass = Object.freeze([
 /**
  * Manage theme customization and custom theme support
  */
-var ThemeManager = class DashToDockThemeManager {
+export class ThemeManager {
     constructor(dock) {
         this._signalsHandler = new Utils.GlobalSignalsHandler(this);
         this._bindSettingsChanges();
@@ -313,7 +310,7 @@ var ThemeManager = class DashToDockThemeManager {
             () => this.updateCustomTheme(),
         ]));
     }
-};
+}
 Signals.addSignalMethods(ThemeManager.prototype);
 
 /**
@@ -321,7 +318,7 @@ Signals.addSignalMethods(ThemeManager.prototype);
  * https://git.gnome.org/browse/gnome-shell/commit/?id=447bf55e45b00426ed908b1b1035f472c2466956
  * Transparency when free-floating
  */
-var Transparency = class DashToDockTransparency {
+class Transparency {
     constructor(dock) {
         this._dash = dock.dash;
         this._actor = this._dash._container;
@@ -559,5 +556,5 @@ var Transparency = class DashToDockTransparency {
             this._transparentAlphaBorder = this._transparentAlpha / 2;
         }
     }
-};
+}
 Signals.addSignalMethods(Transparency.prototype);

--- a/utils.js
+++ b/utils.js
@@ -13,7 +13,7 @@ import {
     Docking
 } from './imports.js';
 
-const { _gi: Gi } = imports;
+const {_gi: Gi} = imports;
 
 export const SignalsHandlerFlags = Object.freeze({
     NONE: 0,
@@ -232,7 +232,7 @@ export class ColorUtils {
     // Return {r:r, g:g, b:b} object.
     static HSVtoRGB(h, s, v) {
         if (arguments.length === 1)
-            ({ s, v, h } = h);
+            ({s, v, h} = h);
 
         let r, g, b;
         const c = v * s;
@@ -280,7 +280,7 @@ export class ColorUtils {
     // Return {h:h, s:s, v:v} object.
     static RGBtoHSV(r, g, b) {
         if (arguments.length === 1)
-            ({ r, g, b } = r);
+            ({r, g, b} = r);
 
         let h, s;
 
@@ -385,14 +385,14 @@ export class PropertyInjectionsHandler extends BasicHandler {
         if (!(name in instance))
             throw new Error(`Object ${instance} has no '${name}' property`);
 
-        const { prototype } = instance.constructor;
+        const {prototype} = instance.constructor;
         const originalPropertyDescriptor = Object.getOwnPropertyDescriptor(prototype, name) ??
             Object.getOwnPropertyDescriptor(instance, name);
 
         Object.defineProperty(instance, name, {
             ...originalPropertyDescriptor,
             ...injectedPropertyDescriptor,
-            ...{ configurable: true },
+            ...{configurable: true},
         });
         return [instance, name, originalPropertyDescriptor];
     }
@@ -478,7 +478,7 @@ export function splitHandler(handler) {
 
     const count = handler.length - 1;
     let missingValueBits = (1 << count) - 1;
-    const values = Array.from({ length: count });
+    const values = Array.from({length: count});
     return values.map((_ignored, i) => {
         const mask = ~(1 << i);
         return (obj, value) => {
@@ -522,7 +522,7 @@ export class IconTheme {
  */
 export function getWindowsByObjectPath() {
     const windowsByObjectPath = new Map();
-    const { workspaceManager } = global;
+    const {workspaceManager} = global;
     const workspaces = [...new Array(workspaceManager.nWorkspaces)].map(
         (_c, i) => workspaceManager.get_workspace_by_index(i));
 
@@ -615,7 +615,7 @@ class CancellableChild extends Gio.Cancellable {
         if (parent && !(parent instanceof Gio.Cancellable))
             throw TypeError('Not a valid cancellable');
 
-        super._init({ parent });
+        super._init({parent});
 
         if (parent?.is_cancelled()) {
             this.cancel();

--- a/utils.js
+++ b/utils.js
@@ -1,10 +1,4 @@
-/* exported GlobalSignalsHandler, InjectionsHandler, VFuncInjectionsHandler,
-            PropertyInjectionsHandler, SignalHandlersFlags, IconTheme,
-            CancellableChild, getPosition, drawRoundedLine,
-            getWindowsByObjectPath, shellAppCompare, shellWindowsCompare,
-            splitHandler, getMonitorManager, laterAdd, laterRemove */
-
-const {
+import {
     Clutter,
     GLib,
     Gio,
@@ -12,15 +6,16 @@ const {
     Gtk,
     Meta,
     Shell,
-    St,
-} = imports.gi;
+    St
+} from './dependencies/gi.js';
+
+import {
+    Docking
+} from './imports.js';
 
 const { _gi: Gi } = imports;
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const { docking: Docking } = Me.imports;
-
-var SignalsHandlerFlags = Object.freeze({
+export const SignalsHandlerFlags = Object.freeze({
     NONE: 0,
     CONNECT_AFTER: 1,
 });
@@ -160,7 +155,7 @@ const BasicHandler = class DashToDockBasicHandler {
 /**
  * Manage global signals
  */
-var GlobalSignalsHandler = class DashToDockGlobalSignalHandler extends BasicHandler {
+export class GlobalSignalsHandler extends BasicHandler {
     _create(object, event, callback, flags = SignalsHandlerFlags.NONE) {
         if (!object)
             throw new Error('Impossible to connect to an invalid object');
@@ -203,12 +198,12 @@ var GlobalSignalsHandler = class DashToDockGlobalSignalHandler extends BasicHand
         if (object instanceof GObject.Object)
             GObject.Object.prototype.unblock_signal_handler.call(object, id);
     }
-};
+}
 
 /**
  * Color manipulation utilities
  */
-var ColorUtils = class DashToDockColorUtils {
+export class ColorUtils {
     // Darken or brigthen color by a fraction dlum
     // Each rgb value is modified by the same fraction.
     // Return "#rrggbb" string
@@ -315,13 +310,13 @@ var ColorUtils = class DashToDockColorUtils {
             v,
         };
     }
-};
+}
 
 /**
  * Manage function injection: both instances and prototype can be overridden
  * and restored
  */
-var InjectionsHandler = class DashToDockInjectionsHandler extends BasicHandler {
+export class InjectionsHandler extends BasicHandler {
     _create(object, name, injectedFunction) {
         const original = object[name];
 
@@ -338,13 +333,13 @@ var InjectionsHandler = class DashToDockInjectionsHandler extends BasicHandler {
         const [object, name, original] = item;
         object[name] = original;
     }
-};
+}
 
 /**
  * Manage vfunction injection: both instances and prototype can be overridden
  * and restored
  */
-var VFuncInjectionsHandler = class DashToDockVFuncInjectionsHandler extends BasicHandler {
+export class VFuncInjectionsHandler extends BasicHandler {
     _create(prototype, name, injectedFunction) {
         const original = prototype[`vfunc_${name}`];
         if (!(original instanceof Function))
@@ -379,13 +374,13 @@ var VFuncInjectionsHandler = class DashToDockVFuncInjectionsHandler extends Basi
 
         return prototype[Gi.hook_up_vfunc_symbol](name, func);
     }
-};
+}
 
 /**
  * Manage properties injection: both instances and prototype can be overridden
  * and restored
  */
-var PropertyInjectionsHandler = class DashToDockPropertyInjectionsHandler extends BasicHandler {
+export class PropertyInjectionsHandler extends BasicHandler {
     _create(instance, name, injectedPropertyDescriptor) {
         if (!(name in instance))
             throw new Error(`Object ${instance} has no '${name}' property`);
@@ -409,12 +404,12 @@ var PropertyInjectionsHandler = class DashToDockPropertyInjectionsHandler extend
         else
             delete instance[name];
     }
-};
+}
 
 /**
  * Return the actual position reverseing left and right in rtl
  */
-function getPosition() {
+export function getPosition() {
     const position = Docking.DockManager.settings.dockPosition;
     if (Clutter.get_default_text_direction() === Clutter.TextDirection.RTL) {
         if (position === St.Side.LEFT)
@@ -436,7 +431,7 @@ function getPosition() {
  * @param stroke
  * @param fill
  */
-function drawRoundedLine(cr, x, y, width, height, isRoundLeft, isRoundRight, stroke, fill) {
+export function drawRoundedLine(cr, x, y, width, height, isRoundLeft, isRoundRight, stroke, fill) {
     if (height > width) {
         y += Math.floor((height - width) / 2.0);
         height = width;
@@ -444,8 +439,8 @@ function drawRoundedLine(cr, x, y, width, height, isRoundLeft, isRoundRight, str
 
     height = 2.0 * Math.floor(height / 2.0);
 
-    var leftRadius = isRoundLeft ? height / 2.0 : 0.0;
-    var rightRadius = isRoundRight ? height / 2.0 : 0.0;
+    const leftRadius = isRoundLeft ? height / 2.0 : 0.0;
+    const rightRadius = isRoundRight ? height / 2.0 : 0.0;
 
     cr.moveTo(x + width - rightRadius, y);
     cr.lineTo(x + leftRadius, y);
@@ -477,7 +472,7 @@ function drawRoundedLine(cr, x, y, width, height, isRoundLeft, isRoundRight, str
  *
  * @param handler
  */
-function splitHandler(handler) {
+export function splitHandler(handler) {
     if (handler.length > 30)
         throw new Error('too many parameters');
 
@@ -495,7 +490,7 @@ function splitHandler(handler) {
     });
 }
 
-var IconTheme = class DashToDockIconTheme {
+export class IconTheme {
     constructor() {
         if (St.IconTheme) {
             this._iconTheme = new St.IconTheme();
@@ -520,12 +515,12 @@ var IconTheme = class DashToDockIconTheme {
 
         this._iconTheme = null;
     }
-};
+}
 
 /**
  * Construct a map of gtk application window object paths to MetaWindows.
  */
-function getWindowsByObjectPath() {
+export function getWindowsByObjectPath() {
     const windowsByObjectPath = new Map();
     const { workspaceManager } = global;
     const workspaces = [...new Array(workspaceManager.nWorkspaces)].map(
@@ -548,7 +543,7 @@ function getWindowsByObjectPath() {
  * @param appA
  * @param appB
  */
-function shellAppCompare(appA, appB) {
+export function shellAppCompare(appA, appB) {
     if (appA.state !== appB.state) {
         if (appA.state === Shell.AppState.RUNNING)
             return -1;
@@ -586,7 +581,7 @@ function shellAppCompare(appA, appB) {
  * @param winA
  * @param winB
  */
-function shellWindowsCompare(winA, winB) {
+export function shellWindowsCompare(winA, winB) {
     const activeWorkspace = global.workspaceManager.get_active_workspace();
     const wsA = winA.get_workspace() === activeWorkspace;
     const wsB = winB.get_workspace() === activeWorkspace;
@@ -607,7 +602,7 @@ function shellWindowsCompare(winA, winB) {
     return winB.get_user_time() - winA.get_user_time();
 }
 
-var CancellableChild = GObject.registerClass({
+export const CancellableChild = GObject.registerClass({
     Properties: {
         'parent': GObject.ParamSpec.object(
             'parent', 'parent', 'parent',
@@ -665,7 +660,7 @@ class CancellableChild extends Gio.Cancellable {
 /**
  *
  */
-function getMonitorManager() {
+export function getMonitorManager() {
     return global.backend.get_monitor_manager?.() ?? Meta.MonitorManager.get();
 }
 
@@ -673,7 +668,7 @@ function getMonitorManager() {
  * @param laterType
  * @param callback
  */
-function laterAdd(laterType, callback) {
+export function laterAdd(laterType, callback) {
     return global.compositor?.get_laters?.().add(laterType, callback) ??
         Meta.later_add(laterType, callback);
 }
@@ -681,7 +676,7 @@ function laterAdd(laterType, callback) {
 /**
  * @param id
  */
-function laterRemove(id) {
+export function laterRemove(id) {
     if (global.compositor?.get_laters)
         global.compositor?.get_laters().remove(id);
     else

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -45,7 +45,7 @@ export class WindowPreviewMenu extends PopupMenu.PopupMenu {
         this._app = this._source.app;
         const workArea = Main.layoutManager.getWorkAreaForMonitor(
             this._source.monitorIndex);
-        const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
+        const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
 
         this.actor.add_style_class_name('app-menu');
         this.actor.set_style(
@@ -359,7 +359,7 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
                 ? Clutter.ActorAlign.START : Clutter.ActorAlign.END,
             y_align: Clutter.ActorAlign.START,
         });
-        this.closeButton.add_actor(new St.Icon({ icon_name: 'window-close-symbolic' }));
+        this.closeButton.add_actor(new St.Icon({icon_name: 'window-close-symbolic'}));
         this.closeButton.connect('clicked', () => this._closeWindow());
 
         const overlayGroup = new Clutter.Actor({
@@ -370,18 +370,22 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
         overlayGroup.add_actor(this._cloneBin);
         overlayGroup.add_actor(this.closeButton);
 
-        const label = new St.Label({ text: window.get_title() });
+        const label = new St.Label({text: window.get_title()});
         label.set_style(`max-width: ${PREVIEW_MAX_WIDTH}px`);
-        const labelBin = new St.Bin({ child: label,
-            x_align: Clutter.ActorAlign.CENTER });
+        const labelBin = new St.Bin({
+            child: label,
+            x_align: Clutter.ActorAlign.CENTER,
+        });
 
         this._windowTitleId = this._window.connect('notify::title', () => {
             label.set_text(this._window.get_title());
         });
 
-        const box = new St.BoxLayout({ vertical: true,
+        const box = new St.BoxLayout({
+            vertical: true,
             reactive: true,
-            x_expand: true });
+            x_expand: true,
+        });
         box.add(overlayGroup);
         box.add(labelBin);
         this._box = box;
@@ -403,7 +407,7 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
         let [minHeight, naturalHeight] = this._box.get_preferred_height(naturalWidth);
         [minWidth, naturalWidth] = themeNode.adjust_preferred_width(minWidth, naturalWidth);
         [minHeight, naturalHeight] = themeNode.adjust_preferred_height(minHeight, naturalHeight);
-        this.set({ minWidth, naturalWidth, minHeight, naturalHeight });
+        this.set({minWidth, naturalWidth, minHeight, naturalHeight});
     }
 
     _getWindowPreviewSize() {
@@ -417,7 +421,7 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
         if (!width || !height)
             return emptySize;
 
-        let { previewSizeScale: scale } = Docking.DockManager.settings;
+        let {previewSizeScale: scale} = Docking.DockManager.settings;
         if (!scale) {
             // a simple example with 1680x1050:
             // * 250/1680 = 0,1488
@@ -461,10 +465,12 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
         }
 
         const mutterWindow = metaWin.get_compositor_private();
-        const clone = new Clutter.Clone({ source: mutterWindow,
+        const clone = new Clutter.Clone({
+            source: mutterWindow,
             reactive: true,
             width: this._width * this._scale,
-            height: this._height * this._scale });
+            height: this._height * this._scale,
+        });
 
         // when the source actor is destroyed, i.e. the window closed, first destroy the clone
         // and then destroy the menu item (do this animating out)

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -5,29 +5,26 @@
  * Some code was also adapted from the upstream Gnome Shell source code.
  */
 
-/* exported WindowPreviewMenu */
-
-const {
+import {
     Clutter,
     GLib,
     GObject,
     Meta,
-    St,
-} = imports.gi;
+    St
+} from './dependencies/gi.js';
 
-const {
-    boxpointer: BoxPointer,
-    main: Main,
-    popupMenu: PopupMenu,
-    workspace: Workspace,
-} = imports.ui;
+import {
+    BoxPointer,
+    Main,
+    PopupMenu,
+    Workspace
+} from './dependencies/shell/ui.js';
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const {
-    docking: Docking,
-    theming: Theming,
-    utils: Utils,
-} = Me.imports;
+import {
+    Docking,
+    Theming,
+    Utils
+} from './imports.js';
 
 const PREVIEW_MAX_WIDTH = 250;
 const PREVIEW_MAX_HEIGHT = 150;
@@ -37,7 +34,7 @@ const MAX_PREVIEW_GENERATION_ATTEMPTS = 15;
 
 const MENU_MARGINS = 10;
 
-var WindowPreviewMenu = class DashToDockWindowPreviewMenu extends PopupMenu.PopupMenu {
+export class WindowPreviewMenu extends PopupMenu.PopupMenu {
     constructor(source) {
         super(source, 0.5, Utils.getPosition());
 
@@ -93,9 +90,9 @@ var WindowPreviewMenu = class DashToDockWindowPreviewMenu extends PopupMenu.Popu
         if (this._destroyId)
             this._source.disconnect(this._destroyId);
     }
-};
+}
 
-var WindowPreviewList = class DashToDockWindowPreviewList extends PopupMenu.PopupMenuSection {
+class WindowPreviewList extends PopupMenu.PopupMenuSection {
     constructor(source) {
         super();
         this.actor = new St.ScrollView({
@@ -323,9 +320,9 @@ var WindowPreviewList = class DashToDockWindowPreviewList extends PopupMenu.Popu
             return result || actor.animatingOut;
         }, false);
     }
-};
+}
 
-var WindowPreviewMenuItem = GObject.registerClass(
+export const WindowPreviewMenuItem = GObject.registerClass(
 class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
     _init(window, position, params) {
         super._init(params);
@@ -335,7 +332,7 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
         this._windowAddedId = 0;
 
         // We don't want this: it adds spacing on the left of the item.
-        this.remove_child(this._ornamentLabel);
+        this.remove_child(this._ornamentIcon);
         this.add_style_class_name('dashtodock-app-well-preview-menu-item');
         this.add_style_class_name(Theming.PositionStyleClass[position]);
         if (Docking.DockManager.settings.customThemeShrink)


### PR DESCRIPTION
Use ESM imports as gnome-45 requires, so drop compatibility with all the
old versions so that we could modernize things a bit in future.

Closes: #2066