### PR TITLE
Releasing v87

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
 "original-author": "micxgx@gmail.com",
 "url": "https://micheleg.github.io/dash-to-dock/",
 "gettext-domain": "dashtodock",
-"version": 85
+"version": 87
 }


### PR DESCRIPTION
86 is skipped because e.g.o 500 error tricked me and rejected that.