### PR TITLE
appIcons: Use Mtk.Rectangle instead of Meta.Rectangle

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -6,6 +6,7 @@ import {
     GLib,
     GObject,
     Meta,
+    Mtk,
     Shell,
     St,
 } from './dependencies/gi.js';
@@ -386,7 +387,7 @@ const DockAbstractAppIcon = GObject.registerClass({
         if (!this.get_stage())
             return;
 
-        const rect = new Meta.Rectangle();
+        const rect = new Mtk.Rectangle();
 
         [rect.x, rect.y] = this.get_transformed_position();
         [rect.width, rect.height] = this.get_transformed_size();

--- a/dependencies/gi.js
+++ b/dependencies/gi.js
@@ -7,6 +7,7 @@ export {default as GdkPixbuf} from 'gi://GdkPixbuf';
 export {default as Gio} from 'gi://Gio';
 export {default as Gtk} from 'gi://Gtk';
 export {default as Meta} from 'gi://Meta';
+export {default as Mtk} from 'gi://Mtk';
 export {default as Pango} from 'gi://Pango';
 export {default as Shell} from 'gi://Shell';
 export {default as St} from 'gi://St';


### PR DESCRIPTION
Meta.Rectangle has been deprecated, fixes logs being flooded with:
`Meta.Rectangle is deprecated, use Mtk.Rectangle instead`