### PR TITLE
Fix dashtodock.pot generation (avoid missing strings for translations)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,9 @@ mergepo: potfile
 
 ./po/dashtodock.pot: $(TOLOCALIZE) Settings.ui
 	mkdir -p po
-	xgettext -k --keyword=__ --keyword=N__ --add-comments='Translators:' -o po/dashtodock.pot --package-name "Dash to Dock" --from-code=utf-8 $(TOLOCALIZE)
+	xgettext --keyword=__ --keyword=N__ --add-comments='Translators:' -o po/dashtodock.pot --package-name "Dash to Dock" --from-code=utf-8 $(TOLOCALIZE)
 	intltool-extract --type=gettext/glade Settings.ui
-	xgettext -k --keyword=_ --keyword=N_ --join-existing -o po/dashtodock.pot Settings.ui.h
+	xgettext --keyword=_ --keyword=N_ --join-existing -o po/dashtodock.pot Settings.ui.h
 
 ./po/%.mo: ./po/%.po
 	msgfmt -c $< -o $@


### PR DESCRIPTION
Some strings are not generated due to redundant option "-k" (leftover from commit 51db80abc3ec5c6c0621a0ba74f04919cb3f0b12)

In result most translations lack:
msgid "Show Details"
msgid "Launch using Integrated Graphics Card"
msgid "Launch using Discrete Graphics Card"
msgid "Failed to launch “%s”"