### PR TITLE
Change "Show Details" to GNOME's "App Details"

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -24,7 +24,7 @@ import {
     ParentalControlsManager,
 } from './dependencies/shell/misc.js';
 
-import { Config } from './dependencies/shell/misc.js';
+import {Config} from './dependencies/shell/misc.js';
 
 import {
     AppIconIndicators,
@@ -36,7 +36,7 @@ import {
     WindowPreview,
 } from './imports.js';
 
-import { Extension } from './dependencies/shell/extensions/extension.js';
+import {Extension} from './dependencies/shell/extensions/extension.js';
 
 // Use __ () and N__() for the extension gettext domain, and reuse
 // the shell domain with the default _() and N_()

--- a/appIcons.js
+++ b/appIcons.js
@@ -24,7 +24,7 @@ import {
     ParentalControlsManager,
 } from './dependencies/shell/misc.js';
 
-import {Config} from './dependencies/shell/misc.js';
+import { Config } from './dependencies/shell/misc.js';
 
 import {
     AppIconIndicators,
@@ -36,7 +36,7 @@ import {
     WindowPreview,
 } from './imports.js';
 
-import {Extension} from './dependencies/shell/extensions/extension.js';
+import { Extension } from './dependencies/shell/extensions/extension.js';
 
 // Use __ () and N__() for the extension gettext domain, and reuse
 // the shell domain with the default _() and N_()
@@ -1148,7 +1148,7 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
             if (Shell.AppSystem.get_default().lookup_app('org.gnome.Software.desktop') &&
                 (this._source instanceof DockAppIcon)) {
                 this._appendSeparator();
-                const item = this._appendMenuItem(_('Show Details'));
+                const item = this._appendMenuItem(_('App Details'));
                 item.connect('activate', () => {
                     const id = this._source.app.get_id();
                     const args = GLib.Variant.new('(ss)', [id, '']);


### PR DESCRIPTION
Close #2104

`Show Details` menu label uses the default translation of the Gnome Shell. But the text of the Gnome Shell menu item is `App Details`, therefore this label is always displayed in English.

With the old label:

![image](https://github.com/micheleg/dash-to-dock/assets/7840559/d1e6fb77-bfb8-4f4b-8387-757df3477b37)

With the new label it's correct displays Gnome Shell localized string:

![image](https://github.com/micheleg/dash-to-dock/assets/7840559/c75af421-a973-4dc5-9afa-a249a77111d0)
