### PR TITLE
Skip conflicting injections if V-Shell extension is enabled

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,11 +2,11 @@
 "shell-version": [
     "45"
 ],
-"uuid": "dash-to-dock@micxgx.gmail.com",
+"uuid": "dash-to-dock-vshell@G-dH@GitHub.com",
 "name": "Dash to Dock",
-"description": "A dock for the Gnome Shell. This extension moves the dash out of the overview transforming it in a dock for an easier launching of applications and a faster switching between windows and desktops. Side and bottom placement options are available.",
+"description": "A Dash to Dock fork compatible with the V-Shell extension. This extension moves the dash out of the overview transforming it in a dock for an easier launching of applications and a faster switching between windows and desktops. Side and bottom placement options are available.",
 "original-author": "micxgx@gmail.com",
 "url": "https://micheleg.github.io/dash-to-dock/",
 "gettext-domain": "dashtodock",
-"version": 89
+"version-name": "45.1"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
 "original-author": "micxgx@gmail.com",
 "url": "https://micheleg.github.io/dash-to-dock/",
 "gettext-domain": "dashtodock",
-"version-name": "45.1"
+"version-name": "89.1 (V-Shell)"
 }


### PR DESCRIPTION
Injections of startup and overview allocate methods are problem for the V-Shell extension. This patch includes a detection mechanism to identify if V-Shell is enabled and, in such cases, skips the problematic injections to prevent issues.