### PR TITLE
Fix Polish translation of "Empty Trash"

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -78,7 +78,7 @@ msgstr "Kosz"
 
 #: locations.js:74
 msgid "Empty Trash"
-msgstr "Pusty kosz"
+msgstr "Opróźnij kosz"
 
 #: locations.js:182
 msgid "Mount"


### PR DESCRIPTION
My understanding is that "Empty" here is a verb in imperative, not an adjective. The previous translation was correct only if "Empty" was as adjective.