### PR TITLE
Update for Gnome Shell 46

### DIFF
--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -13,6 +13,8 @@ $_dark_base_color: darken(desaturate(#241f31, 100%), 2%);
 $base_color: if($variant =='light', #fff, $_dark_base_color);
 $system_bg_color: $base_color;
 
+$remark_color: rgba(238, 238, 236, 0.2);
+
 // From https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/43.0/data/theme/gnome-shell-sass/widgets/_dash.scss
 $dash_background_color: lighten($system_bg_color, 5%);
 $dash_placeholder_size: 32px;
@@ -215,7 +217,7 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
                         background-image: none;
                     }
                     &.focused .overview-icon {
-                        background-color: rgba(238, 238, 236, 0.2);
+                        background-color: $remark_color;
                     }
 
                     .app-well-app-running-dot {

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -203,7 +203,8 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
                     0, $dock_icons_distance / 2);
 
                 .app-well-app,
-                .show-apps {
+                .show-apps,
+                .overview-tile {
                     @include set-internal-children-property($side, padding, $spacing);
                     padding-#{$side}: $padding + $side_margin;
                     padding-#{opposite($side)}: $padding;

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -250,12 +250,6 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
     }
 }
 
-.overview-tile {
-    margin: 0px;
-    padding: 0px;
-    border: 0px;
-}
-
 .overview-tile .overview-icon, .show-apps .overview-icon {
     background-color: rgba(255,255,255,0);
 }

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -256,11 +256,11 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
     border: 0px;
 }
 
-.overview-icon {
+.overview-tile .overview-icon, .show-apps .overview-icon {
     background-color: rgba(255,255,255,0);
 }
 
-.overview-tile:hover .overview-icon, .show-apps:hover .overview-icon {
+.overview-tile:hover .overview-icon, .overview-tile.focused .overview-icon, .show-apps:hover .overview-icon {
     background-color: $remark_color;
 }
 

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -247,6 +247,20 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
     }
 }
 
+.overview-tile {
+    margin: 0px;
+    padding: 0px;
+    border: 0px;
+}
+
+.overview-tile .overview-icon {
+    background-color: rgba(255,255,255,0);
+}
+
+.overview-tile:hover .overview-icon, .overview-tile.focused .overview-icon, .show-apps:hover .overview-icon {
+    background-color: $remark_color;
+}
+
 @each $side in $dock_sides {
     @each $style_mode in $dock_style_modes {
         $is_shrink: str-index(#{$style_mode}, shrink) !=null;

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -256,11 +256,11 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
     border: 0px;
 }
 
-.overview-tile .overview-icon {
+.overview-icon {
     background-color: rgba(255,255,255,0);
 }
 
-.overview-tile:hover .overview-icon, .overview-tile.focused .overview-icon, .show-apps:hover .overview-icon {
+.overview-tile:hover .overview-icon, .show-apps:hover .overview-icon {
     background-color: $remark_color;
 }
 

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -13,7 +13,7 @@ $_dark_base_color: darken(desaturate(#241f31, 100%), 2%);
 $base_color: if($variant =='light', #fff, $_dark_base_color);
 $system_bg_color: $base_color;
 
-$remark_color: rgba(238, 238, 236, 0.2);
+$remark_color: rgba(238, 238, 238, 0.2);
 
 // From https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/43.0/data/theme/gnome-shell-sass/widgets/_dash.scss
 $dash_background_color: lighten($system_bg_color, 5%);
@@ -250,11 +250,14 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
     }
 }
 
-.overview-tile .overview-icon, .show-apps .overview-icon {
+.dash-item-container .overview-tile .overview-icon,
+.dash-item-container .show-apps .overview-icon {
     background-color: rgba(255,255,255,0);
 }
 
-.overview-tile:hover .overview-icon, .overview-tile.focused .overview-icon, .show-apps:hover .overview-icon {
+.dash-item-container .overview-tile:hover .overview-icon,
+.dash-item-container .overview-tile.focused .overview-icon,
+.dash-item-container .show-apps:hover .overview-icon {
     background-color: $remark_color;
 }
 

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -7,6 +7,12 @@ import {
     St,
 } from './dependencies/gi.js';
 
+if (!Clutter.cairo_set_source_color) {
+    Clutter.cairo_set_source_color = function (cr, sourceColor) {
+        cr.setSourceColor(sourceColor);
+    };
+}
+
 import {Main} from './dependencies/shell/ui.js';
 
 import {

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -7,12 +7,6 @@ import {
     St,
 } from './dependencies/gi.js';
 
-if (!Clutter.cairo_set_source_color) {
-    Clutter.cairo_set_source_color = function (cr, sourceColor) {
-        cr.setSourceColor(sourceColor);
-    };
-}
-
 import {Main} from './dependencies/shell/ui.js';
 
 import {
@@ -413,7 +407,7 @@ class RunningIndicatorDots extends RunningIndicatorBase {
         const n = this._number;
 
         cr.setLineWidth(this._borderWidth);
-        Clutter.cairo_set_source_color(cr, this._borderColor);
+        Utils.cairoSetSourceColor(cr, this._borderColor);
 
         // draw for the bottom case:
         cr.translate(
@@ -428,7 +422,7 @@ class RunningIndicatorDots extends RunningIndicatorBase {
         }
 
         cr.strokePreserve();
-        Clutter.cairo_set_source_color(cr, this._bodyColor);
+        Utils.cairoSetSourceColor(cr, this._bodyColor);
         cr.fill();
     }
 
@@ -454,7 +448,7 @@ class RunningIndicatorCiliora extends RunningIndicatorDots {
             const yOffset = this._height - padding - size;
 
             cr.setLineWidth(this._borderWidth);
-            Clutter.cairo_set_source_color(cr, this._borderColor);
+            Utils.cairoSetSourceColor(cr, this._borderColor);
 
             cr.translate(0, yOffset);
             cr.newSubPath();
@@ -465,7 +459,7 @@ class RunningIndicatorCiliora extends RunningIndicatorDots {
             }
 
             cr.strokePreserve();
-            Clutter.cairo_set_source_color(cr, this._bodyColor);
+            Utils.cairoSetSourceColor(cr, this._bodyColor);
             cr.fill();
         }
     }
@@ -487,7 +481,7 @@ class RunningIndicatorSegmented extends RunningIndicatorDots {
             const yOffset = this._height - padding - size;
 
             cr.setLineWidth(this._borderWidth);
-            Clutter.cairo_set_source_color(cr, this._borderColor);
+            Utils.cairoSetSourceColor(cr, this._borderColor);
 
             cr.translate(0, yOffset);
             for (let i = 0; i < this._number; i++) {
@@ -496,7 +490,7 @@ class RunningIndicatorSegmented extends RunningIndicatorDots {
             }
 
             cr.strokePreserve();
-            Clutter.cairo_set_source_color(cr, this._bodyColor);
+            Utils.cairoSetSourceColor(cr, this._bodyColor);
             cr.fill();
         }
     }
@@ -516,14 +510,14 @@ class RunningIndicatorSolid extends RunningIndicatorDots {
             const yOffset = this._height - padding - size;
 
             cr.setLineWidth(this._borderWidth);
-            Clutter.cairo_set_source_color(cr, this._borderColor);
+            Utils.cairoSetSourceColor(cr, this._borderColor);
 
             cr.translate(0, yOffset);
             cr.newSubPath();
             cr.rectangle(0, 0, this._width, size);
 
             cr.strokePreserve();
-            Clutter.cairo_set_source_color(cr, this._bodyColor);
+            Utils.cairoSetSourceColor(cr, this._bodyColor);
             cr.fill();
         }
     }
@@ -540,7 +534,7 @@ class RunningIndicatorSquares extends RunningIndicatorDots {
             const yOffset = this._height - padding - size;
 
             cr.setLineWidth(this._borderWidth);
-            Clutter.cairo_set_source_color(cr, this._borderColor);
+            Utils.cairoSetSourceColor(cr, this._borderColor);
 
             cr.translate(
                 Math.floor((this._width - this._number * size - (this._number - 1) * spacing) / 2),
@@ -551,7 +545,7 @@ class RunningIndicatorSquares extends RunningIndicatorDots {
                 cr.rectangle(i * size + i * spacing, 0, size, size);
             }
             cr.strokePreserve();
-            Clutter.cairo_set_source_color(cr, this._bodyColor);
+            Utils.cairoSetSourceColor(cr, this._bodyColor);
             cr.fill();
         }
     }
@@ -569,7 +563,7 @@ class RunningIndicatorDashes extends RunningIndicatorDots {
             const yOffset = this._height - padding - size;
 
             cr.setLineWidth(this._borderWidth);
-            Clutter.cairo_set_source_color(cr, this._borderColor);
+            Utils.cairoSetSourceColor(cr, this._borderColor);
 
             cr.translate(
                 Math.floor((this._width - this._number * dashLength - (this._number - 1) * spacing) / 2),
@@ -581,7 +575,7 @@ class RunningIndicatorDashes extends RunningIndicatorDots {
             }
 
             cr.strokePreserve();
-            Clutter.cairo_set_source_color(cr, this._bodyColor);
+            Utils.cairoSetSourceColor(cr, this._bodyColor);
             cr.fill();
         }
     }
@@ -613,7 +607,7 @@ class RunningIndicatorMetro extends RunningIndicatorDots {
             const n = this._number;
             if (n <= 1) {
                 cr.translate(0, yOffset);
-                Clutter.cairo_set_source_color(cr, this._bodyColor);
+                Utils.cairoSetSourceColor(cr, this._bodyColor);
                 cr.newSubPath();
                 cr.rectangle(0, 0, this._width, size);
                 cr.fill();
@@ -627,15 +621,15 @@ class RunningIndicatorMetro extends RunningIndicatorDots {
 
                 cr.translate(0, yOffset);
 
-                Clutter.cairo_set_source_color(cr, this._bodyColor);
+                Utils.cairoSetSourceColor(cr, this._bodyColor);
                 cr.newSubPath();
                 cr.rectangle(0, 0, this._width - darkenedLength - blackenedLength, size);
                 cr.fill();
-                Clutter.cairo_set_source_color(cr, blackenedColor);
+                Utils.cairoSetSourceColor(cr, blackenedColor);
                 cr.newSubPath();
                 cr.rectangle(this._width - darkenedLength - blackenedLength, 0, 1, size);
                 cr.fill();
-                Clutter.cairo_set_source_color(cr, darkenedColor);
+                Utils.cairoSetSourceColor(cr, darkenedColor);
                 cr.newSubPath();
                 cr.rectangle(this._width - darkenedLength, 0, darkenedLength, size);
                 cr.fill();
@@ -656,7 +650,7 @@ class RunningIndicatorBinary extends RunningIndicatorDots {
             const binaryValue = String(`0000${(n >>> 0).toString(2)}`).slice(-4);
 
             cr.setLineWidth(this._borderWidth);
-            Clutter.cairo_set_source_color(cr, this._borderColor);
+            Utils.cairoSetSourceColor(cr, this._borderColor);
 
             cr.translate(Math.floor((this._width - 4 * size - (4 - 1) * spacing) / 2), yOffset);
             for (let i = 0; i < binaryValue.length; i++) {
@@ -673,7 +667,7 @@ class RunningIndicatorBinary extends RunningIndicatorDots {
                 }
             }
             cr.strokePreserve();
-            Clutter.cairo_set_source_color(cr, this._bodyColor);
+            Utils.cairoSetSourceColor(cr, this._bodyColor);
             cr.fill();
         }
     }

--- a/appIcons.js
+++ b/appIcons.js
@@ -997,7 +997,7 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
         });
         source.connect('destroy', () => this.destroy());
 
-        Utils.addActor(Main.uiGroup, this.actor);
+        Main.uiGroup.add_child(this.actor);
 
         const {remoteModel} = Docking.DockManager.getDefault();
         const remoteModelApp = remoteModel?.lookupById(this._source?.app?.id);

--- a/appIcons.js
+++ b/appIcons.js
@@ -377,7 +377,7 @@ const DockAbstractAppIcon = GObject.registerClass({
     }
 
     /**
-     * Update taraget for minimization animation
+     * Update target for minimization animation
      */
     updateIconGeometry() {
         // If (for unknown reason) the actor is not on the stage the reported size

--- a/appIcons.js
+++ b/appIcons.js
@@ -997,7 +997,7 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
         });
         source.connect('destroy', () => this.destroy());
 
-        Main.uiGroup.add_actor(this.actor);
+        Utils.addActor(Main.uiGroup, this.actor);
 
         const {remoteModel} = Docking.DockManager.getDefault();
         const remoteModelApp = remoteModel?.lookupById(this._source?.app?.id);

--- a/dash.js
+++ b/dash.js
@@ -194,9 +194,12 @@ export const DockDash = GObject.registerClass({
             x_expand: this._isHorizontal,
         });
         this._box._delegate = this;
-        Utils.addActor(this._dashContainer, this._scrollView);
-        Utils.addActor(this._boxContainer, this._box);
-        Utils.addActor(this._scrollView, this._boxContainer);
+        this._boxContainer.add_child(this._box);
+        if (this._scrollView.add_actor)
+            this._scrollView.add_actor(this._boxContainer);
+        else
+            this._scrollView.add_child(this._boxContainer);
+        this._dashContainer.add_child(this._scrollView);
 
         this._showAppsIcon = new AppIcons.DockShowAppsIcon(this._position);
         this._showAppsIcon.show(false);

--- a/dash.js
+++ b/dash.js
@@ -178,10 +178,12 @@ export const DockDash = GObject.registerClass({
         this._scrollView.connect('scroll-event', this._onScrollEvent.bind(this));
 
         this._boxContainer = new St.BoxLayout({
+            name: 'dashtodockBoxContainer',
             x_align: Clutter.ActorAlign.FILL,
             y_align: Clutter.ActorAlign.FILL,
             vertical: !this._isHorizontal,
         });
+        this._boxContainer.add_style_class_name(Theming.PositionStyleClass[this._position]);
 
         const rtl = Clutter.get_default_text_direction() === Clutter.TextDirection.RTL;
         this._box = new St.BoxLayout({

--- a/dash.js
+++ b/dash.js
@@ -194,9 +194,9 @@ export const DockDash = GObject.registerClass({
             x_expand: this._isHorizontal,
         });
         this._box._delegate = this;
-        this._dashContainer.add_actor(this._scrollView);
-        this._boxContainer.add_actor(this._box);
-        this._scrollView.add_actor(this._boxContainer);
+        Utils.addActor(this._dashContainer, this._scrollView);
+        Utils.addActor(this._boxContainer, this._box);
+        Utils.addActor(this._scrollView, this._boxContainer);
 
         this._showAppsIcon = new AppIcons.DockShowAppsIcon(this._position);
         this._showAppsIcon.show(false);

--- a/docking.js
+++ b/docking.js
@@ -2325,8 +2325,7 @@ export class DockManager {
                     box.y2 -= spacing;
                 }
 
-                box.y2 -= searchBox.get_height() + spacing;
-                box.y2 -= spacing;
+                box.y2 -= searchBox.get_height() + 2 * spacing;
             }
 
             return box;

--- a/docking.js
+++ b/docking.js
@@ -2313,6 +2313,9 @@ export class DockManager {
             });
 
         const maybeAdjustBoxSize = (state, box, spacing) => {
+            // ensure that an undefined value will be converted into a valid one
+            if (!spacing)
+                spacing = 0;
             if (state === OverviewControls.ControlsState.WINDOW_PICKER) {
                 const searchBox = this.overviewControls._searchEntry.get_allocation_box();
                 const {shouldShow: wsThumbnails} = this.overviewControls._thumbnailsBox;

--- a/docking.js
+++ b/docking.js
@@ -51,13 +51,6 @@ export const State = Object.freeze({
     HIDING:  3,
 });
 
-function _supportsExtendedBarriers() {
-    if (global.display.supports_extended_barriers)
-        return global.display.supports_extended_barriers();
-    const {capabilities} = global.backend;
-    return (capabilities & Meta.BackendCapabilities.BARRIERS) !== 0;
-}
-
 const scrollAction = Object.freeze({
     DO_NOTHING: 0,
     CYCLE_WINDOWS: 1,
@@ -873,7 +866,7 @@ const DockedDash = GObject.registerClass({
         // If we don't have extended barrier features, then we need
         // to support the old tray dwelling mechanism.
         if (this._autohideIsEnabled &&
-            (!_supportsExtendedBarriers() ||
+            (!Utils.supportsExtendedBarriers() ||
              !DockManager.settings.requirePressureToShow)) {
             const pointerWatcher = PointerWatcher.getPointerWatcher();
             this._dockWatch = pointerWatcher.addWatch(
@@ -961,7 +954,7 @@ const DockedDash = GObject.registerClass({
 
     _updatePressureBarrier() {
         const {settings} = DockManager;
-        this._canUsePressure = _supportsExtendedBarriers();
+        this._canUsePressure = Utils.supportsExtendedBarriers();
         const {pressureThreshold} = settings;
 
         // Remove existing pressure barrier
@@ -2314,8 +2307,8 @@ export class DockManager {
 
         const maybeAdjustBoxSize = (state, box, spacing) => {
             // ensure that an undefined value will be converted into a valid one
-            if (!spacing)
-                spacing = 0;
+            spacing = spacing ?? 0;
+
             if (state === OverviewControls.ControlsState.WINDOW_PICKER) {
                 const searchBox = this.overviewControls._searchEntry.get_allocation_box();
                 const {shouldShow: wsThumbnails} = this.overviewControls._thumbnailsBox;

--- a/docking.js
+++ b/docking.js
@@ -403,7 +403,7 @@ const DockedDash = GObject.registerClass({
         // Add dash container actor and the container to the Chrome.
         this.set_child(this._slider);
         this._slider.set_child(this._box);
-        Utils.addActor(this._box, this.dash);
+        this._box.add_child(this.dash);
 
         // Add aligning container without tracking it for input region
         this._trackDock();

--- a/docking.js
+++ b/docking.js
@@ -51,6 +51,12 @@ export const State = Object.freeze({
     HIDING:  3,
 });
 
+if (!global.display.supports_extended_barriers) {
+    global.display.supports_extended_barriers = function () {
+        return true;
+    };
+}
+
 const scrollAction = Object.freeze({
     DO_NOTHING: 0,
     CYCLE_WINDOWS: 1,
@@ -397,7 +403,7 @@ const DockedDash = GObject.registerClass({
         // Add dash container actor and the container to the Chrome.
         this.set_child(this._slider);
         this._slider.set_child(this._box);
-        this._box.add_actor(this.dash);
+        Utils.addActor(this._box, this.dash);
 
         // Add aligning container without tracking it for input region
         this._trackDock();
@@ -1115,7 +1121,7 @@ const DockedDash = GObject.registerClass({
 
             if (this._pressureBarrier && this._dockState === State.HIDDEN) {
                 this._barrier = new Meta.Barrier({
-                    display: global.display,
+                    backend: global.backend,
                     x1,
                     x2,
                     y1,

--- a/docking.js
+++ b/docking.js
@@ -51,10 +51,11 @@ export const State = Object.freeze({
     HIDING:  3,
 });
 
-if (!global.display.supports_extended_barriers) {
-    global.display.supports_extended_barriers = function () {
-        return true;
-    };
+function _supportsExtendedBarriers() {
+    if (global.display.supports_extended_barriers)
+        return global.display.supports_extended_barriers();
+    const {capabilities} = global.backend;
+    return (capabilities & Meta.BackendCapabilities.BARRIERS) !== 0;
 }
 
 const scrollAction = Object.freeze({
@@ -872,7 +873,7 @@ const DockedDash = GObject.registerClass({
         // If we don't have extended barrier features, then we need
         // to support the old tray dwelling mechanism.
         if (this._autohideIsEnabled &&
-            (!global.display.supports_extended_barriers() ||
+            (!_supportsExtendedBarriers() ||
              !DockManager.settings.requirePressureToShow)) {
             const pointerWatcher = PointerWatcher.getPointerWatcher();
             this._dockWatch = pointerWatcher.addWatch(
@@ -960,7 +961,7 @@ const DockedDash = GObject.registerClass({
 
     _updatePressureBarrier() {
         const {settings} = DockManager;
-        this._canUsePressure = global.display.supports_extended_barriers();
+        this._canUsePressure = _supportsExtendedBarriers();
         const {pressureThreshold} = settings;
 
         // Remove existing pressure barrier

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,7 @@
 {
 "shell-version": [
-    "45"
+    "45",
+    "46"
 ],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",

--- a/theming.js
+++ b/theming.js
@@ -354,15 +354,15 @@ class Transparency {
             this._base_actor_style = '';
 
 
-        let addedSignal;
-        let removedSignal;
-        if (GObject.signal_lookup('actor-added', global.window_group) === 0) {
-            addedSignal = 'child-added';
-            removedSignal = 'child-removed';
-        } else {
+        let addedSignal = 'child-added';
+        let removedSignal = 'child-removed';
+
+        // for compatibility with Gnome Shell 45
+        if (GObject.signal_lookup('actor-added', global.window_group)) {
             addedSignal = 'actor-added';
             removedSignal = 'actor-removed';
         }
+
         this._signalsHandler.addWithLabel(Labels.TRANSPARENCY, [
             global.window_group,
             addedSignal,

--- a/theming.js
+++ b/theming.js
@@ -2,6 +2,7 @@
 
 import {
     Clutter,
+    GObject,
     Meta,
     St,
 } from './dependencies/gi.js';
@@ -353,13 +354,22 @@ class Transparency {
             this._base_actor_style = '';
 
 
+        let addedSignal;
+        let removedSignal;
+        if (GObject.signal_lookup('actor-added', global.window_group) === 0) {
+            addedSignal = 'child-added';
+            removedSignal = 'child-removed';
+        } else {
+            addedSignal = 'actor-added';
+            removedSignal = 'actor-removed';
+        }
         this._signalsHandler.addWithLabel(Labels.TRANSPARENCY, [
             global.window_group,
-            'actor-added',
+            addedSignal,
             this._onWindowActorAdded.bind(this),
         ], [
             global.window_group,
-            'actor-removed',
+            removedSignal,
             this._onWindowActorRemoved.bind(this),
         ], [
             global.window_manager,

--- a/utils.js
+++ b/utils.js
@@ -654,10 +654,3 @@ export function laterRemove(id) {
     else
         Meta.later_remove(id);
 }
-
-export function addActor(obj, actor) {
-    if (obj.add_actor)
-        obj.add_actor(actor);
-    else
-        obj.add_child(actor);
-}

--- a/utils.js
+++ b/utils.js
@@ -654,3 +654,35 @@ export function laterRemove(id) {
     else
         Meta.later_remove(id);
 }
+
+/**
+ * Up to Gnome Shell 45, the Cairo Context object didn't export the
+ * `setSourceColor()` method, so Clutter included a function call for
+ * that, written in C. In Gnome Shell 46, the method was finally exported,
+ * so that function was removed.
+ *
+ * This function is, thus, required for Gnome Shell 45 compatibility.
+ *
+ * @param {*} cr A cairo context
+ * @param {*} sourceColor The new color for source
+ */
+export function cairoSetSourceColor(cr, sourceColor) {
+    if (Clutter.cairo_set_source_color)
+        Clutter.cairo_set_source_color(cr, sourceColor);
+    else
+        cr.setSourceColor(sourceColor);
+}
+
+/**
+ * Specifies if the system supports extended barriers. This function
+ * is required for Gnome Shell 45 compatibility, which used
+ * `global.display.supports_extended_barriers`. Gnome Shell 46 moved
+ * that into global.backend.capabilities.
+ *
+ * @returns True if the system supports extended barriers.
+ */
+export function supportsExtendedBarriers() {
+    if (global.display.supports_extended_barriers)
+        return global.display.supports_extended_barriers();
+    return !!(global.backend.capabilities & Meta.BackendCapabilities.BARRIERS);
+}

--- a/utils.js
+++ b/utils.js
@@ -655,3 +655,9 @@ export function laterRemove(id) {
         Meta.later_remove(id);
 }
 
+export function addActor(obj, actor) {
+    if (obj.add_actor)
+        obj.add_actor(actor);
+    else
+        obj.add_child(actor);
+}

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -60,7 +60,7 @@ export class WindowPreviewMenu extends PopupMenu.PopupMenu {
         });
         this._destroyId = this._source.connect('destroy', this.destroy.bind(this));
 
-        Utils.addActor(Main.uiGroup, this.actor);
+        Main.uiGroup.add_child(this.actor);
 
         this.connect('destroy', this._onDestroy.bind(this));
     }
@@ -109,7 +109,7 @@ class WindowPreviewList extends PopupMenu.PopupMenuSection {
         this.isHorizontal = position === St.Side.BOTTOM || position === St.Side.TOP;
         this.box.set_vertical(!this.isHorizontal);
         this.box.set_name('dashtodockWindowList');
-        Utils.addActor(this.actor, this.box);
+        this.actor.add_child(this.box);
         this.actor._delegate = this;
 
         this._shownInitially = false;
@@ -359,7 +359,7 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
                 ? Clutter.ActorAlign.START : Clutter.ActorAlign.END,
             y_align: Clutter.ActorAlign.START,
         });
-        Utils.addActor(this.closeButton, new St.Icon({icon_name: 'window-close-symbolic'}));
+        this.closeButton.add_child(new St.Icon({icon_name: 'window-close-symbolic'}));
         this.closeButton.connect('clicked', () => this._closeWindow());
 
         const overlayGroup = new Clutter.Actor({
@@ -367,8 +367,8 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
             y_expand: true,
         });
 
-        Utils.addActor(overlayGroup, this._cloneBin);
-        Utils.addActor(overlayGroup, this.closeButton);
+        overlayGroup.add_child(this._cloneBin);
+        overlayGroup.add_child(this.closeButton);
 
         const label = new St.Label({text: window.get_title()});
         label.set_style(`max-width: ${PREVIEW_MAX_WIDTH}px`);
@@ -394,7 +394,7 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
             box.add_child(labelBin);
         }
         this._box = box;
-        Utils.addActor(this, box);
+        this.add_child(box);
 
         this._cloneTexture(window);
 

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -359,7 +359,7 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
                 ? Clutter.ActorAlign.START : Clutter.ActorAlign.END,
             y_align: Clutter.ActorAlign.START,
         });
-        this.closeButton.add_child(new St.Icon({icon_name: 'window-close-symbolic'}));
+        this.closeButton.set_child(new St.Icon({icon_name: 'window-close-symbolic'}));
         this.closeButton.connect('clicked', () => this._closeWindow());
 
         const overlayGroup = new Clutter.Actor({

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -60,7 +60,7 @@ export class WindowPreviewMenu extends PopupMenu.PopupMenu {
         });
         this._destroyId = this._source.connect('destroy', this.destroy.bind(this));
 
-        Main.uiGroup.add_actor(this.actor);
+        Utils.addActor(Main.uiGroup, this.actor);
 
         this.connect('destroy', this._onDestroy.bind(this));
     }
@@ -109,7 +109,7 @@ class WindowPreviewList extends PopupMenu.PopupMenuSection {
         this.isHorizontal = position === St.Side.BOTTOM || position === St.Side.TOP;
         this.box.set_vertical(!this.isHorizontal);
         this.box.set_name('dashtodockWindowList');
-        this.actor.add_actor(this.box);
+        Utils.addActor(this.actor, this.box);
         this.actor._delegate = this;
 
         this._shownInitially = false;
@@ -359,7 +359,7 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
                 ? Clutter.ActorAlign.START : Clutter.ActorAlign.END,
             y_align: Clutter.ActorAlign.START,
         });
-        this.closeButton.add_actor(new St.Icon({icon_name: 'window-close-symbolic'}));
+        Utils.addActor(this.closeButton, new St.Icon({icon_name: 'window-close-symbolic'}));
         this.closeButton.connect('clicked', () => this._closeWindow());
 
         const overlayGroup = new Clutter.Actor({
@@ -367,8 +367,8 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
             y_expand: true,
         });
 
-        overlayGroup.add_actor(this._cloneBin);
-        overlayGroup.add_actor(this.closeButton);
+        Utils.addActor(overlayGroup, this._cloneBin);
+        Utils.addActor(overlayGroup, this.closeButton);
 
         const label = new St.Label({text: window.get_title()});
         label.set_style(`max-width: ${PREVIEW_MAX_WIDTH}px`);
@@ -386,10 +386,15 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
             reactive: true,
             x_expand: true,
         });
-        box.add(overlayGroup);
-        box.add(labelBin);
+        if (box.add) {
+            box.add(overlayGroup);
+            box.add(labelBin);
+        } else {
+            box.add_child(overlayGroup);
+            box.add_child(labelBin);
+        }
         this._box = box;
-        this.add_actor(box);
+        Utils.addActor(this, box);
 
         this._cloneTexture(window);
 

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -386,13 +386,9 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
             reactive: true,
             x_expand: true,
         });
-        if (box.add) {
-            box.add(overlayGroup);
-            box.add(labelBin);
-        } else {
-            box.add_child(overlayGroup);
-            box.add_child(labelBin);
-        }
+
+        box.add_child(overlayGroup);
+        box.add_child(labelBin);
         this._box = box;
         this.add_child(box);
 


### PR DESCRIPTION
add_actor() has been removed after being deprecated, and it must be replaced with add_child(). Also, there are two add methods that also have to be changed.

Tested in Gnome 46 alpha, in a Fedora RawHide system. I also tested it in Gnome 45, but doesn't work, so it must be only 46.