### PR TITLE
Fix for blurry background when opening a new application

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -66,12 +66,11 @@ class DockDashItemContainer extends Dash.DashItemContainer {
         if (this.child == null)
             return;
 
-        let time = animate ? DASH_ANIMATION_TIME : 0;
         this.ease({
             scale_x: 1,
             scale_y: 1,
             opacity: 255,
-            duration: time,
+            duration: animate ? DASH_ANIMATION_TIME : 0,
             mode: Clutter.AnimationMode.EASE_OUT_QUAD,
             onComplete: () => {
                 // when the animation is ended, we simulate

--- a/dash.js
+++ b/dash.js
@@ -27,7 +27,10 @@ import {
     Utils,
 } from './imports.js';
 
-const {DASH_ANIMATION_TIME} = Dash;
+// module "Dash" does not export DASH_ANIMATION_TIME
+// so we just define it like it is defined in Dash;
+// taken from https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dash.js
+const DASH_ANIMATION_TIME = 200;
 const DASH_VISIBILITY_TIMEOUT = 3;
 
 const Labels = Object.freeze({
@@ -53,6 +56,30 @@ class DockDashItemContainer extends Dash.DashItemContainer {
 
     showLabel() {
         return AppIcons.itemShowLabel.call(this);
+    }
+
+    // we override the method show taken from:
+    // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dash.js
+    // in order to apply a little modification at the end of the animation
+    // which makes sure that the icon background is not blurry
+    show(animate) {
+        if (this.child == null)
+            return;
+
+        let time = animate ? DASH_ANIMATION_TIME : 0;
+        this.ease({
+            scale_x: 1,
+            scale_y: 1,
+            opacity: 255,
+            duration: time,
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+            onComplete: () => {
+                // when the animation is ended, we simulate
+                // a hover to gain back focus and unblur the
+                // background
+                this.set_hover(true);
+            },
+        });
     }
 });
 


### PR DESCRIPTION
When a new application is opened, the background usually results in being blurry, unless the mouse cursor hovers over the dash, just like in the following screenshots:
![image](https://github.com/micheleg/dash-to-dock/assets/45568396/8a6f15c5-e8d8-452e-8675-012b9dfecb38)
![image](https://github.com/micheleg/dash-to-dock/assets/45568396/6a2f82de-6a11-491c-9a30-c4c6258b732c)

Such a problem was already well documented in the issue #1722.

This pull request fixes this issue by overriding the show() method from DashItemContainer in DockDashItemContainer and simulating a hover over the item once the animation is finished.