### PR TITLE
Fix progress bar colors

### DIFF
--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -355,6 +355,10 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
 
 #dashtodockContainer.dashtodock .progress-bar {
     /* Customization of the progress bar style, e.g.:
+      // base colors (the "background")
+      -progress-bar-base-background: rgba(0.25, 0.25, 0.25, 0,75);
+      -progress-bar-base-border: rgba(0.75, 0.75, 0.75, 0,25);
+      // progress bar colors
       -progress-bar-background: rgba(0.8, 0.8, 0.8, 1);
       -progress-bar-border: rgba(0.9, 0.9, 0.9, 1);
     */

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -354,14 +354,55 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
 }
 
 #dashtodockContainer.dashtodock .progress-bar {
-    /* Customization of the progress bar style, e.g.:
-      // track colors (the "background")
-      -progress-bar-track-filling: rgba(0.25, 0.25, 0.25, 0,75);
-      -progress-bar-track-border: rgba(0.75, 0.75, 0.75, 0,25);
-      // progress bar colors
-      -progress-bar-background: rgba(0.8, 0.8, 0.8, 1);
-      -progress-bar-border: rgba(0.9, 0.9, 0.9, 1);
-    */
+    /* Customization of the progress bar style. The possible elements
+     * are:
+     *
+     * -XXXXXX-YYYYYY: plain color
+     * -XXXXXX-YYYYYY-color-start: start color for gradient
+     * -XXXXXX-YYYYYY-color-end: end color for gradient
+     * -XXXXXX-YYYYYY-offset-start: offset for start color in gradient (0-1)
+     * -XXXXXX-YYYYYY-offset-end: offset for end color in gradient (0-1)
+     * -XXXXXX-line-width: width value for the line used for the border
+     *
+     * XXXXXX can be either
+     *
+     *    progress-bar-track: the "track" over which the progress bar is shown
+     *    progress-bar: the progress bar itself
+     *
+     * YYYYYY can be either
+     *
+     *    background: for the background color
+     *    border: for the border color
+     *
+     * plain color entries have priority over gradients, so if both are set for
+     * an element, the plain color will be used.
+     *
+     * Examples:
+     *
+     *  -progress-bar-track-background: rgba(128, 128, 0, 0.75);
+     *  -progress-bar-track-border: rgba(0, 0, 255, 0.25);
+     *
+     *  -progress-bar-background: rgba(0, 204, 204, 1);
+     *  -progress-bar-border: rgba(230, 230, 230, 1);
+     *
+     * Default values when these entries aren't set are equivalent to:
+     *   -progress-bar-track-background-color-start: 64, 64, 64, 1.0
+     *   -progress-bar-track-background-color-end: 89, 89, 89, 1.0
+     *   -progress-bar-track-background-start-offset: 0.4
+     *   -progress-bar-track-background-end-offset: 0.9
+     *   -progress-bar-track-border-color-start: 128, 128, 128, 0.1
+     *   -progress-bar-track-border-color-end: 89, 89, 89, 0.4
+     *   -progress-bar-track-border-start-offset: 0.5
+     *   -progress-bar-track-border-end-offset: 0.9
+     *   -progress-bar-track-line-width: 1
+     *   -progress-bar-background: 204, 204, 204, 1.0
+     *   -progress-bar-border: 230, 230, 230, 1.0
+     *   -progress-bar-line-width: 1
+     */
+    -progress-bar-track-background: rgba(0, 0, 0, 0.45);
+    -progress-bar-track-border: rgba(0, 0, 0, 0.7);
+    -progress-bar-background: rgba(255, 255, 255, 1.0);
+    -progress-bar-border: rgba(255, 255, 255, 1.0);
 }
 
 #dashtodockContainer.top #dash .placeholder,

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -355,9 +355,9 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
 
 #dashtodockContainer.dashtodock .progress-bar {
     /* Customization of the progress bar style, e.g.:
-      // base colors (the "background")
-      -progress-bar-base-background: rgba(0.25, 0.25, 0.25, 0,75);
-      -progress-bar-base-border: rgba(0.75, 0.75, 0.75, 0,25);
+      // track colors (the "background")
+      -progress-bar-track-filling: rgba(0.25, 0.25, 0.25, 0,75);
+      -progress-bar-track-border: rgba(0.75, 0.75, 0.75, 0,25);
       // progress bar colors
       -progress-bar-background: rgba(0.8, 0.8, 0.8, 1);
       -progress-bar-border: rgba(0.9, 0.9, 0.9, 1);

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -868,11 +868,11 @@ class UnityIndicator extends IndicatorBase {
         let hasColor, bg, bd, fg;
         const node = this._progressOverlayArea.get_theme_node();
 
-        [hasColor, bg] = node.lookup_color('-progress-bar-base-background', false);
+        [hasColor, bg] = node.lookup_color('-progress-bar-track-filling', false);
         if (!hasColor)
             bg = new Clutter.Color({red: 64, green: 64, blue: 64, alpha: 192});
 
-        [hasColor, fg] = node.lookup_color('-progress-bar-base-border', false);
+        [hasColor, fg] = node.lookup_color('-progress-bar-track-border', false);
         if (!hasColor)
             fg = new Clutter.Color({red: 192, green: 192, blue: 192, alpha: 64});
 

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -859,24 +859,26 @@ class UnityIndicator extends IndicatorBase {
 
         cr.setLineWidth(lineWidth);
 
-        // Draw the outer stroke
-        let stroke = new Cairo.LinearGradient(0, y, 0, y + height);
-        let fill = null;
-        stroke.addColorStopRGBA(0.5, 0.5, 0.5, 0.5, 0.1);
-        stroke.addColorStopRGBA(0.9, 0.8, 0.8, 0.8, 0.4);
-        Utils.drawRoundedLine(cr, x + lineWidth / 2.0,
-            y + lineWidth / 2.0, width, height, true, true, stroke, fill);
-
         // Draw the background
         x += lineWidth;
         y += lineWidth;
         width -= 2.0 * lineWidth;
         height -= 2.0 * lineWidth;
 
-        stroke = Cairo.SolidPattern.createRGBA(0.20, 0.20, 0.20, 0.9);
-        fill = new Cairo.LinearGradient(0, y, 0, y + height);
-        fill.addColorStopRGBA(0.4, 0.25, 0.25, 0.25, 1.0);
-        fill.addColorStopRGBA(0.9, 0.35, 0.35, 0.35, 1.0);
+        let hasColor, bg, bd, fg;
+        const node = this._progressOverlayArea.get_theme_node();
+
+        [hasColor, bg] = node.lookup_color('-progress-bar-base-background', false);
+        if (!hasColor)
+            bg = new Clutter.Color({red: 64, green: 64, blue: 64, alpha: 192});
+
+        [hasColor, fg] = node.lookup_color('-progress-bar-base-border', false);
+        if (!hasColor)
+            fg = new Clutter.Color({red: 192, green: 192, blue: 192, alpha: 64});
+
+        let fill = Cairo.SolidPattern.createRGBA(bg.red / 255, bg.green / 255, bg.blue / 255, bg.alpha / 255);
+        let stroke = Cairo.SolidPattern.createRGBA(
+            fg.red / 255, fg.green / 255, fg.blue / 255, fg.alpha / 255);
         Utils.drawRoundedLine(cr, x + lineWidth / 2.0,
             y + lineWidth / 2.0, width, height, true, true, stroke, fill);
 
@@ -887,9 +889,6 @@ class UnityIndicator extends IndicatorBase {
         height -= 2.0 * lineWidth;
 
         const finishedWidth = Math.ceil(this._progress * width);
-
-        let hasColor, bg, bd;
-        const node = this._progressOverlayArea.get_theme_node();
 
         [hasColor, bg] = node.lookup_color('-progress-bar-background', false);
         if (!hasColor)


### PR DESCRIPTION
As commented in https://github.com/ubuntu/yaru/issues/4016, the progress bar, with its 3D gradient track, doesn't fit very well in the current Gnome/Yaru theme.

This patch changes this, allowing to set all the colors in the bars using CSS: the background color and outline width and color both for the track and the progress bar itself, and also use either plain colors or gradients in each of the four elements, allowing to also specify the start and stop points.

![imagen](https://github.com/micheleg/dash-to-dock/assets/105285003/91ce9fcb-4e9f-4031-b34e-79a56f52b6e1)

