### PR TITLE
utils: Override async functions with async functions

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -322,9 +322,16 @@ export class InjectionsHandler extends BasicHandler {
         if (!(original instanceof Function))
             throw new Error(`Virtual function ${name}() is not available for ${object}`);
 
-        object[name] = function (...args) {
-            return injectedFunction.call(this, original, ...args);
-        };
+        if (original.constructor.name === 'AsyncFunction') {
+            // eslint-disable-next-line require-await
+            object[name] = async function (...args) {
+                return injectedFunction.call(this, original, ...args);
+            };
+        } else {
+            object[name] = function (...args) {
+                return injectedFunction.call(this, original, ...args);
+            };
+        }
         return [object, name, original];
     }
 


### PR DESCRIPTION
Otherwise gnome-shell (`LayoutManager._loadBackground`) can't find the override when it was expecting an async function.

Closes: https://github.com/micheleg/dash-to-dock/issues/2110