### PR TITLE
Draft: Restore the missing login animation

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2269,7 +2269,6 @@ export class DockManager {
                     injections.destroy();
 
                     const onComplete = () => callback(...callbackArgs);
-                    dockManager._prepareStartupAnimation();
                     dockManager._runStartupAnimation(onComplete);
                     return ret;
                 } catch (e) {

--- a/docking.js
+++ b/docking.js
@@ -2475,6 +2475,7 @@ export class DockManager {
 
         if (Main.layoutManager._startingUp && Main.sessionMode.hasOverview &&
             this._settings.disableOverviewOnStartup) {
+            this._prepareStartupAnimation();
             this._methodInjections.addWithLabel(Labels.STARTUP_ANIMATION,
                 Overview.Overview.prototype,
                 'runStartupAnimation', (_originalFunction, callback) => {
@@ -2482,7 +2483,6 @@ export class DockManager {
                     const x = monitor.x + monitor.width / 2.0;
                     const y = monitor.y + monitor.height / 2.0;
 
-                    this._prepareStartupAnimation();
                     Main.uiGroup.set_pivot_point(
                         x / global.screen_width,
                         y / global.screen_height);

--- a/docking.js
+++ b/docking.js
@@ -2065,7 +2065,7 @@ export class DockManager {
         this.emit('docks-ready');
     }
 
-    _prepareStartupAnimation(callback) {
+    _prepareStartupAnimation() {
         DockManager.allDocks.forEach(dock => {
             const {dash} = dock;
 
@@ -2076,31 +2076,6 @@ export class DockManager {
                 translation_y: 0,
             });
         });
-
-        // We need to ensure that if docks are destroyed before animation is
-        // completed, then we still ensure the animation runs anyways.
-        const label = Labels.STARTUP_ANIMATION;
-        this._signalsHandler.removeWithLabel(label);
-
-        // This shouldn't really ever happen, but in theory the manager
-        // could be destroyed at any time, in such case complete the animation
-        this._signalsHandler.addWithLabel(label, this, 'destroy', () =>
-            Main.overview.runStartupAnimation(callback));
-
-        const waitForDocksReady = () => {
-            global.window_group.remove_clip();
-            this._signalsHandler.addWithLabel(label, this, 'docks-ready', () => {
-                this._signalsHandler.removeWithLabel(label);
-                Main.overview.runStartupAnimation(callback);
-            });
-        };
-
-        if (this._allDocks.length) {
-            this._signalsHandler.addWithLabel(label, this, 'docks-destroyed',
-                () => waitForDocksReady());
-        } else {
-            waitForDocksReady();
-        }
     }
 
     _runStartupAnimation(callback) {
@@ -2286,7 +2261,7 @@ export class DockManager {
                 try {
                     const injections = new Utils.InjectionsHandler();
                     const dockManager = DockManager.getDefault();
-                    dockManager._prepareStartupAnimation(callback);
+                    dockManager._prepareStartupAnimation();
                     injections.add(dockManager.mainDock.dash, 'ease', () => {});
                     let callbackArgs = [];
                     const ret = await originalMethod.call(this,
@@ -2294,7 +2269,7 @@ export class DockManager {
                     injections.destroy();
 
                     const onComplete = () => callback(...callbackArgs);
-                    dockManager._prepareStartupAnimation(onComplete);
+                    dockManager._prepareStartupAnimation();
                     dockManager._runStartupAnimation(onComplete);
                     return ret;
                 } catch (e) {
@@ -2508,7 +2483,7 @@ export class DockManager {
                     const x = monitor.x + monitor.width / 2.0;
                     const y = monitor.y + monitor.height / 2.0;
 
-                    this._prepareStartupAnimation(callback);
+                    this._prepareStartupAnimation();
                     Main.uiGroup.set_pivot_point(
                         x / global.screen_width,
                         y / global.screen_height);

--- a/docking.js
+++ b/docking.js
@@ -43,6 +43,7 @@ const {signals: Signals} = imports;
 
 const DOCK_DWELL_CHECK_INTERVAL = 100;
 const ICON_ANIMATOR_DURATION = 3000;
+const STARTUP_ANIMATION_TIME = 500;
 
 export const State = Object.freeze({
     HIDDEN:  0,
@@ -2103,8 +2104,6 @@ export class DockManager {
     }
 
     _runStartupAnimation(callback) {
-        const {STARTUP_ANIMATION_TIME} = Layout;
-
         DockManager.allDocks.forEach(dock => {
             const {dash} = dock;
 
@@ -2508,7 +2507,6 @@ export class DockManager {
                     const monitor = Main.layoutManager.primaryMonitor;
                     const x = monitor.x + monitor.width / 2.0;
                     const y = monitor.y + monitor.height / 2.0;
-                    const {STARTUP_ANIMATION_TIME} = Layout;
 
                     this._prepareStartupAnimation(callback);
                     Main.uiGroup.set_pivot_point(


### PR DESCRIPTION
Restore the missing login animation, primarily for Ubuntu Dock which has disable-overview-on-startup.

https://bugs.launchpad.net/bugs/2058468

- [x] Use non-zero/undefined animation time.
- [x] Stop showing the dock before the animation starts.
- [ ] Prevent the panel from showing before the animation starts (or don't animate the panel at all).
- [ ] Disabling disable-overview-on-startup to re-enable the overview on startup has a broken animation.