### PR TITLE
Remove any dependency on dockmanager in desktopIconsIntegration.js

### DIFF
--- a/desktopIconsIntegration.js
+++ b/desktopIconsIntegration.js
@@ -55,16 +55,17 @@
  *
  *******************************************************************************/
 
-import {GLib} from './dependencies/gi.js';
-import {Main} from './dependencies/shell/ui.js';
-import {ExtensionUtils} from './dependencies/shell/misc.js';
-
-import {DockManager} from './docking.js';
+import GLib from 'gi://GLib';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as ExtensionUtils from 'resource:///org/gnome/shell/misc/extensionUtils.js';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 const IDENTIFIER_UUID = '130cbc66-235c-4bd6-8571-98d2d8bba5e2';
 
 export class DesktopIconsUsableAreaClass {
     constructor() {
+        const Me = Extension.lookupByURL(import.meta.url);
+        this._UUID = Me.uuid;
         this._extensionManager = Main.extensionManager;
         this._timedMarginsID = 0;
         this._margins = {};
@@ -158,7 +159,7 @@ export class DesktopIconsUsableAreaClass {
         const usableArea = extension?.stateObj?.DesktopIconsUsableArea;
         if (usableArea?.uuid === IDENTIFIER_UUID) {
             usableArea.setMarginsForExtension(
-                DockManager.extension.uuid, this._margins);
+                this._UUID, this._margins);
         }
     }
 }


### PR DESCRIPTION
Dockmanager can be null, and this spams the log if desktopIconsIntegration class is initialized and used.

desktopIconsIntegration class is initialized and called from the extension and really should not have any other dependencies other than the shell, it is meant to be used and can be used as is by any extension if called as is independently without modifications.

Fix resource path for Extension