### PR TITLE
docking: adapt ControlsManagerLayout spacing for GNOME 46

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2355,7 +2355,10 @@ export class DockManager {
                 workAreaBox.set_origin(startX, startY);
                 workAreaBox.set_size(workArea.width, workArea.height);
 
-                maybeAdjustBoxToDock(undefined, workAreaBox, this.spacing);
+                // GNOME 46 changes "spacing" to "_spacing".
+                const spacing = this.spacing ?? this._spacing;
+
+                maybeAdjustBoxToDock(undefined, workAreaBox, spacing);
                 const oldStartY = workAreaBox.y1;
 
                 const propertyInjections = new Utils.PropertyInjectionsHandler();
@@ -2412,7 +2415,9 @@ export class DockManager {
                     return originalFunction.call(this, state, ...args);
 
                 const box = workspaceBoxOriginFixer.call(this, originalFunction, state, ...args);
-                return maybeAdjustBoxSize(state, box, this.spacing);
+                // GNOME 46 changes "spacing" to "_spacing".
+                const spacing = this.spacing ?? this._spacing;
+                return maybeAdjustBoxSize(state, box, spacing);
                 /* eslint-enable no-invalid-this */
             },
         ], [


### PR DESCRIPTION
In https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3104, the base class of `ControlsManagerLayout` is changed from `Clutter.BoxLayout` to `Clutter.LayoutManager`, and `spacing` is replaced by `_spacing`. This makes the fix in https://github.com/micheleg/dash-to-dock/issues/1608 no longer works in GNOME 46.