### PR TITLE
intellihide: treat fullscreen windows as maximized

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -283,7 +283,7 @@ export class Intellihide {
 
         case IntellihideMode.MAXIMIZED_WINDOWS:
             // Skip unmaximized windows
-            if (!metaWin.maximized_vertically && !metaWin.maximized_horizontally)
+            if (!metaWin.maximized_vertically && !metaWin.maximized_horizontally && !metaWin.fullscreen)
                 return false;
             break;
 


### PR DESCRIPTION
I can't think of any reason to NOT hide the dock when the window is in fullscreen mode. In my opinion that defeats the purpose of "dodge maximized windows".