### PR TITLE
docking: Use the signal handler to disconnect on startup-completed signal

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -65,6 +65,7 @@ const Labels = Object.freeze({
     MAIN_DASH: Symbol('main-dash'),
     OLD_DASH_CHANGES: Symbol('old-dash-changes'),
     SETTINGS: Symbol('settings'),
+    STARTUP_ANIMATION: Symbol('startup-animation'),
     WORKSPACE_SWITCH_SCROLL: Symbol('workspace-switch-scroll'),
 });
 
@@ -466,7 +467,6 @@ const DockedDash = GObject.registerClass({
         // for instance on unlocking the screen if it was locked with the overview open.
         if (Main.overview.visibleTarget)
             this._onOverviewShowing();
-
 
         this._updateAutoHideBarriers();
     }
@@ -2421,11 +2421,12 @@ export class DockManager {
             if (this._settings.disableOverviewOnStartup)
                 Main.sessionMode.hasOverview = false;
 
-            const id = Main.layoutManager.connect('startup-complete', () => {
-                Main.sessionMode.hasOverview = hadOverview;
-                Main.layoutManager.disconnect(id);
-                this._runStartupAnimation();
-            });
+            this._signalsHandler.addWithLabel(Labels.STARTUP_ANIMATION,
+                Main.layoutManager, 'startup-complete', () => {
+                    this._signalsHandler.removeWithLabel(Labels.STARTUP_ANIMATION);
+                    Main.sessionMode.hasOverview = hadOverview;
+                    this._runStartupAnimation();
+                });
         }
     }
 


### PR DESCRIPTION
As requested by the g.e.o review, it's not really a big deal though since this signal is going to really last few frames and the extension is not really unloaded by that time.

/cc @vanvugt 