### PR TITLE
locations: Do not cancel operations after a volume has been umounted / removed

### DIFF
--- a/locations.js
+++ b/locations.js
@@ -274,7 +274,8 @@ export const LocationAppInfo = GObject.registerClass({
                 iconsQuery.join(','),
                 Gio.FileQueryInfoFlags.NONE,
                 GLib.PRIORITY_LOW, cancellable);
-            icons.standard = info.get_icon();
+            if (info.has_attribute(Gio.FILE_ATTRIBUTE_STANDARD_ICON))
+                icons.standard = info.get_icon();
         } catch (e) {
             if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND) ||
                 e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_MOUNTED))

--- a/locations.js
+++ b/locations.js
@@ -107,7 +107,7 @@ export const LocationAppInfo = GObject.registerClass({
             Gio.Icon.$gtype),
         'cancellable': GObject.ParamSpec.object(
             'cancellable', 'cancellable', 'cancellable',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             Gio.Cancellable.$gtype),
     },
 }, class LocationAppInfo extends Gio.DesktopAppInfo {
@@ -1410,6 +1410,8 @@ export class Removables {
             appInfo.volume === volume);
         if (volumeIndex !== -1) {
             const [volumeApp] = this._volumeApps.splice(volumeIndex, 1);
+            // We don't care about cancelling the ongoing operations from now on.
+            volumeApp.appInfo.cancellable = null;
             volumeApp.destroy();
             this.emit('changed');
         }


### PR DESCRIPTION
In case we're unmounting a volume we were optionally removing its icon
but this was also leading cancelling the operation that in the Gio queue
caused the action not to be fully performed.

So once, we've removed a volume or umounted a mount, we don't really
care about cancelling the ongoing operations since they should be done
already.

[LP: #1993054](https://bugs.launchpad.net/ubuntu/+source/gnome-shell-extension-ubuntu-dock/+bug/1993054)