### PR TITLE
i18n: Add Korean translation

### DIFF
--- a/po/ko.po
+++ b/po/ko.po
@@ -1,0 +1,715 @@
+# Dash to Dock master ko.po
+# Copyright (C) 2024 Dash to Dock COPYRIGHT HOLDER
+# This file is distributed under the same license as the Dash to Dock package.
+# Byoungchan Lee <byoungchan.lee@gmx.com>, 2024.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Dash to Dock\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-21 15:19+0900\n"
+"PO-Revision-Date: 2024-04-22 07:15+0900\n"
+"Last-Translator: Byoungchan Lee <byoungchan.lee@gmx.com>\n"
+"Language-Team: \n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. Translators: This will be followed by Display Name - Connector.
+#: prefs.js:382
+msgid "Primary monitor: "
+msgstr "주 모니터: "
+
+#. Translators: Followed by monitor index, Display Name - Connector.
+#: prefs.js:388
+msgid "Secondary monitor "
+msgstr "보조 모니터 "
+
+#: prefs.js:434 Settings.ui.h:32
+msgid "Right"
+msgstr "오른쪽"
+
+#: prefs.js:435 Settings.ui.h:29
+msgid "Left"
+msgstr "왼쪽"
+
+#: prefs.js:490
+msgid "Intelligent autohide customization"
+msgstr "지능적인 자동 숨김 사용자 정의"
+
+#: prefs.js:498 prefs.js:820 prefs.js:879
+msgid "Reset to defaults"
+msgstr "기본값으로 재설정"
+
+#: prefs.js:649
+msgid "Managed by GNOME Multitasking's Application Switching setting."
+msgstr "GNOME 멀티태스킹의 응용프로그램 전환 설정에 의해 관리됩니다."
+
+#: prefs.js:812
+msgid "Show dock and application numbers"
+msgstr "Dock 및 응용프로그램 번호 표시"
+
+#: prefs.js:871
+msgid "Customize middle-click behavior"
+msgstr "가운데 클릭 동작 사용자 정의"
+
+#: prefs.js:968
+msgid "Customize running indicators"
+msgstr "실행 표시기 사용자 정의"
+
+#: prefs.js:1083 Settings.ui.h:95
+msgid "Customize opacity"
+msgstr "불투명도 사용자 정의"
+
+#: appIcons.js:1050
+msgid "All Windows"
+msgstr "모든 창"
+
+#. Translators: This is the heading of a list of open windows
+#: appIcons.js:1062
+msgid "Open Windows"
+msgstr "열린 창"
+
+#: appIcons.js:1082
+msgid "New Window"
+msgstr "새 창"
+
+#: appIcons.js:1100
+msgid "Launch using Integrated Graphics Card"
+msgstr "내장 그래픽 카드를 사용해 시작"
+
+#: appIcons.js:1101
+msgid "Launch using Discrete Graphics Card"
+msgstr "외장 그래픽 카드를 사용해 시작"
+
+#: appIcons.js:1130
+msgid "Unpin"
+msgstr "고정 해제"
+
+#: appIcons.js:1131
+msgid "Remove from Favorites"
+msgstr "즐겨찾기에서 제거"
+
+#: appIcons.js:1138
+msgid "Pin to Dash"
+msgstr "Dash에 고정"
+
+#: appIcons.js:1139
+msgid "Add to Favorites"
+msgstr "즐겨찾기에 추가"
+
+#: appIcons.js:1151
+msgid "App Details"
+msgstr "앱 세부정보"
+
+#: appIcons.js:1188 appIcons.js:1200 Settings.ui.h:14
+msgid "Quit"
+msgstr "종료"
+
+#: appIcons.js:1203
+#, javascript-format
+msgid "Quit %d Window"
+msgid_plural "Quit %d Windows"
+msgstr[0] "%d 창 종료"
+
+#. Translators: %s is "Settings", which is automatically translated. You
+#. can also translate the full message if this fits better your language.
+#: appIcons.js:1450
+#, javascript-format
+msgid "Dash to Dock %s"
+msgstr "Dash to Dock %s"
+
+#: appIcons.js:1450
+msgid "Settings"
+msgstr "설정"
+
+#: locations.js:533
+msgid "Mount"
+msgstr "마운트"
+
+#: locations.js:535
+msgid "Unmount"
+msgstr "언마운트"
+
+#: locations.js:537
+msgid "Eject"
+msgstr "꺼내기"
+
+#: locations.js:596
+#, javascript-format
+msgid "Failed to mount “%s”"
+msgstr "%s을(를) 마운트하지 못했습니다"
+
+#: locations.js:599
+#, javascript-format
+msgid "Failed to umount “%s”"
+msgstr "%s을(를) 언마운트하지 못했습니다"
+
+#: locations.js:602
+#, javascript-format
+msgid "Failed to eject “%s”"
+msgstr "%s을(를) 꺼내지 못했습니다"
+
+#: locations.js:614
+msgid "Mount operation already in progress"
+msgstr "마운트 작업이 이미 진행 중입니다"
+
+#: locations.js:617
+msgid "Umount operation already in progress"
+msgstr "언마운트 작업이 이미 진행 중입니다"
+
+#: locations.js:620
+msgid "Eject operation already in progress"
+msgstr "꺼내기 작업이 이미 진행 중입니다"
+
+#: locations.js:699
+msgid "Trash"
+msgstr "휴지통"
+
+#: locations.js:740
+msgid "Empty Trash"
+msgstr "휴지통 비우기"
+
+#: locations.js:1010
+#, javascript-format
+msgid "Failed to launch “%s”"
+msgstr "%s을(를) 시작하지 못했습니다"
+
+#: Settings.ui.h:1
+msgid ""
+"When set to minimize, double clicking minimizes all the windows of the "
+"application."
+msgstr "최소화로 설정하면, 더블 클릭으로 응용프로그램의 모든 창을 최소화합니다."
+
+#: Settings.ui.h:2
+msgid "Shift+Click action"
+msgstr "Shift+클릭 동작"
+
+#: Settings.ui.h:3
+msgid "Raise window"
+msgstr "창 맨 위로 이동"
+
+#: Settings.ui.h:4
+msgid "Minimize window"
+msgstr "창 최소화"
+
+#: Settings.ui.h:5
+msgid "Launch new instance"
+msgstr "새 인스턴스 시작"
+
+#: Settings.ui.h:6
+msgid "Cycle through windows"
+msgstr "창 순환"
+
+#: Settings.ui.h:7
+msgid "Minimize or overview"
+msgstr "창 최소화 또는 개요"
+
+#: Settings.ui.h:8
+msgid "Show window previews"
+msgstr "창 미리보기 표시"
+
+#: Settings.ui.h:9
+msgid "Minimize or show previews"
+msgstr "창 최소화 또는 미리보기 표시"
+
+#: Settings.ui.h:10
+msgid "Focus or show previews"
+msgstr "창 포커스 또는 미리보기 표시"
+
+#: Settings.ui.h:11
+msgid "Focus or app spread"
+msgstr "창 포커스 또는 앱 스프레드"
+
+#: Settings.ui.h:12
+msgid "Focus, minimize or show previews"
+msgstr "창 포커스, 최소화 또는 미리보기 표시"
+
+#: Settings.ui.h:13
+msgid "Focus, minimize or app spread"
+msgstr "창 포커스, 최소화 또는 앱 스프레드"
+
+#: Settings.ui.h:15
+msgid "Behavior for Middle-Click."
+msgstr "가운데 클릭 시의 동작."
+
+#: Settings.ui.h:16
+msgid "Middle-Click action"
+msgstr "가운데 클릭 행동"
+
+#: Settings.ui.h:17
+msgid "Behavior for Shift+Middle-Click."
+msgstr "Shift+가운데 클릭 시의 동작."
+
+#: Settings.ui.h:18
+msgid "Shift+Middle-Click action"
+msgstr "Shift+가운데 클릭 행동"
+
+#: Settings.ui.h:19
+msgid "Enable Unity7 like glossy backlit items"
+msgstr "Unity7과 유사한 글로시 백라이트 항목 사용"
+
+#: Settings.ui.h:20
+msgid "Apply glossy effect."
+msgstr "광택 효과 적용."
+
+#: Settings.ui.h:21
+msgid "Use dominant color"
+msgstr "주도되는 색 사용"
+
+#: Settings.ui.h:22
+msgid "Customize indicator style"
+msgstr "인디케이터 스타일 사용자 정의"
+
+#: Settings.ui.h:23
+msgid "Color"
+msgstr "색상"
+
+#: Settings.ui.h:24
+msgid "Border color"
+msgstr "테두리 색상"
+
+#: Settings.ui.h:25
+msgid "Border width"
+msgstr "테두리 너비"
+
+#: Settings.ui.h:26
+msgid "Show the dock on"
+msgstr "Dock 을 다음에 표시"
+
+#: Settings.ui.h:27
+msgid "Show on all monitors"
+msgstr "모든 모니터에 표시"
+
+#: Settings.ui.h:28
+msgid "Position on screen"
+msgstr "화면상의 위치"
+
+#: Settings.ui.h:30
+msgid "Bottom"
+msgstr "하단"
+
+#: Settings.ui.h:31
+msgid "Top"
+msgstr "상단"
+
+#: Settings.ui.h:33
+msgid ""
+"Hide the dock when it obstructs a window of the current application. More "
+"refined settings are available."
+msgstr ""
+"현재 응용프로그램의 창을 가리는 경우 Dock을 숨깁니다. 세부 설정이 가능합니다."
+
+#: Settings.ui.h:34
+msgid "Intelligent autohide"
+msgstr "지능적 자동 숨김"
+
+#: Settings.ui.h:35
+msgid "Dock size limit"
+msgstr "Dock 크기 제한"
+
+#: Settings.ui.h:36
+msgid "Panel mode: extend to the screen edge"
+msgstr "패널 모드: 화면 가장자리까지 확장"
+
+#: Settings.ui.h:37
+msgid "Place icons to the center"
+msgstr "아이콘을 중앙에 배치"
+
+#: Settings.ui.h:38
+msgid "Icon size limit"
+msgstr "아이콘 크기 제한"
+
+#: Settings.ui.h:39
+msgid "Fixed icon size: scroll to reveal other icons"
+msgstr "고정된 아이콘 크기: 스크롤하여 다른 아이콘 표시"
+
+#: Settings.ui.h:40
+msgid "Preview size scale"
+msgstr "미리보기 크기 스케일"
+
+#: Settings.ui.h:41
+msgid "Position and size"
+msgstr "위치 및 크기"
+
+#: Settings.ui.h:42
+msgid "Show pinned applications"
+msgstr "고정된 응용프로그램 표시"
+
+#: Settings.ui.h:43
+msgid "Show running applications"
+msgstr "실행 중인 응용프로그램 표시"
+
+#: Settings.ui.h:44
+msgid "Isolate workspaces"
+msgstr "워크스페이스를 고립"
+
+#: Settings.ui.h:45
+msgid "Show urgent windows despite current workspace"
+msgstr "현재 워크스페이스에 관계없이 긴급한 창 표시"
+
+#: Settings.ui.h:46
+msgid "Isolate monitors"
+msgstr "모니터를 고립"
+
+#: Settings.ui.h:47
+msgid "Show open windows' previews"
+msgstr "열린 창의 미리보기 표시"
+
+#: Settings.ui.h:48
+msgid "Keep the focused application always visible in the dash"
+msgstr "Dash에서 항상 포커스된 응용프로그램을 보이게 유지"
+
+#: Settings.ui.h:49
+msgid ""
+"If disabled, these settings are accessible from gnome-tweak-tool or the "
+"extension website."
+msgstr ""
+"비활성화된 경우, 이러한 설정은 gnome-tweak-tool 또는 확장 프로그램 웹 사이트에"
+"서 접근할 수 있습니다."
+
+#: Settings.ui.h:50
+# Translators note: Original string is "Show <i>Applications</i> icon",
+# but it should be "<i>Show Applications</i> icon",
+# because it is a name of the application.
+# Other labels italize <i>Show Applications</i> as well, so it should be consistent.
+msgid "Show <i>Applications</i> icon"
+msgstr "<i>앱 표시</i> 아이콘"
+
+#: Settings.ui.h:51
+msgid "Move at beginning of the dock"
+msgstr "Dock의 시작 부분으로 이동"
+
+#: Settings.ui.h:52
+msgid "Animate <i>Show Applications</i>"
+msgstr "<i>앱 표시</i> 애니매이션 사용"
+
+#: Settings.ui.h:53
+msgid "Put <i>Show Applications</i> in a dock edge when using Panel mode"
+msgstr "패널 모드 사용 시 <i>앱 표시</i>를 Dock 가장자리에 놓기"
+
+#: Settings.ui.h:54
+msgid "Show trash can"
+msgstr "휴지통 표시"
+
+#: Settings.ui.h:55
+msgid "Show volumes and devices"
+msgstr "볼륨 및 장치 표시"
+
+#: Settings.ui.h:56
+msgid "Only if mounted"
+msgstr "마운트된 경우에만"
+
+#: Settings.ui.h:57
+msgid "Include network volumes"
+msgstr "네트워크 볼륨 포함"
+
+#: Settings.ui.h:58
+msgid "Isolate volumes, devices and trash windows from file manager"
+msgstr "파일 관리자에서 볼륨, 장치 및 휴지통 창을 고립"
+
+#: Settings.ui.h:59
+msgid "Wiggle urgent applications"
+msgstr "긴급 응용 프로그램 흔들림"
+
+#: Settings.ui.h:60
+msgid "Hide application tooltip"
+msgstr "응용 프로그램 툴팁 숨김"
+
+#: Settings.ui.h:61
+msgid "Show icons emblems"
+msgstr "아이콘 엠블럼 표시"
+
+#: Settings.ui.h:62
+msgid ""
+"When enabled application icons will show notification counters and progress-"
+"bars (if Unity API is used)."
+msgstr ""
+"활성화되면 응용프로그램 아이콘에 알림 카운터 및 진행률 표시(Unity API를 사용하"
+"는 경우)."
+
+#: Settings.ui.h:63
+msgid "Show the number of unread notifications"
+msgstr "읽지 않은 알림의 숫자 표시"
+
+#: Settings.ui.h:64
+msgid "Application-provided counter overrides the notifications counter"
+msgstr "응용 프로그램에서 제공하는 카운터가 알림 카툰터를 덮어씁니다"
+
+#: Settings.ui.h:65
+msgid "Launchers"
+msgstr "런처"
+
+#: Settings.ui.h:66
+msgid ""
+"Enable Super+(0-9) as shortcuts to activate apps. It can also be used "
+"together with Shift and Ctrl."
+msgstr ""
+"Super+(0-9)를 단축키로 사용하여 응용 프로그램을 활성화합니다. Shift 및 Ctrl과 "
+"함께 사용할 수도 있습니다."
+
+#: Settings.ui.h:67
+msgid "Use keyboard shortcuts to activate apps"
+msgstr "키보드 단축키를 사용하여 응용 프로그램 활성화"
+
+#: Settings.ui.h:68
+msgid "Behaviour when clicking on the icon of a running application."
+msgstr "실행 중인 응용 프로그램 아이콘을 클릭할 때의 동작."
+
+#: Settings.ui.h:69
+msgid "Click action"
+msgstr "클릭 행동"
+
+#: Settings.ui.h:70
+msgid "Minimize"
+msgstr "줄이기"
+
+#: Settings.ui.h:71
+msgid "Behaviour when scrolling on the icon of an application."
+msgstr "응용 프로그램 아이콘을 스크롤 할 때의 동작."
+
+#: Settings.ui.h:72
+msgid "Scroll action"
+msgstr "스크롤 행동"
+
+#: Settings.ui.h:73
+msgid "Do nothing"
+msgstr "아무것도 하지 않음"
+
+#: Settings.ui.h:74
+msgid "Switch workspace"
+msgstr "워크스페이스 전환"
+
+#: Settings.ui.h:75
+msgid "Behavior"
+msgstr "동작"
+
+#: Settings.ui.h:76
+msgid "Save space reducing padding and border radius."
+msgstr "패딩과 테두리 반지름을 줄여 공간을 절약합니다."
+
+#: Settings.ui.h:77
+msgid "Shrink the dash"
+msgstr "Dash 축소"
+
+#: Settings.ui.h:78
+msgid "Force straight corner"
+msgstr "직사각형 모서리 강제"
+
+#: Settings.ui.h:79
+msgid "Show overview on startup"
+msgstr "시작할 때 개요 표시"
+
+#: Settings.ui.h:80
+msgid ""
+"Few customizations meant to integrate the dock with the default GNOME theme. "
+"Alternatively, specific options can be enabled below."
+msgstr ""
+"기본 GNOME 테마와 통합하기 위한 몇 가지 사용자 정의. 또는 아래에서 특정 옵션"
+"을 활성화할 수 있습니다."
+
+#: Settings.ui.h:81
+msgid "Use built-in theme"
+msgstr "내부 테마 사용"
+
+#: Settings.ui.h:82
+msgid "Customize windows counter indicators"
+msgstr "창 카운터 표시기 사용자 정의"
+
+#: Settings.ui.h:83
+msgid "Default"
+msgstr "기본"
+
+#: Settings.ui.h:84
+msgid "Dots"
+msgstr "점"
+
+#: Settings.ui.h:85
+msgid "Squares"
+msgstr "정사각형"
+
+#: Settings.ui.h:86
+msgid "Dashes"
+msgstr "대시"
+
+#: Settings.ui.h:87
+msgid "Segmented"
+msgstr "분할된"
+
+#: Settings.ui.h:88
+msgid "Solid"
+msgstr "Solid"
+
+#: Settings.ui.h:89
+msgid "Ciliora"
+msgstr "Ciliora"
+
+#: Settings.ui.h:90
+msgid "Metro"
+msgstr "메트로"
+
+#: Settings.ui.h:91
+msgid "Binary"
+msgstr "이진"
+
+#: Settings.ui.h:92
+msgid "Set the background color for the dash."
+msgstr "Dash의 배경 색상을 설정합니다."
+
+#: Settings.ui.h:93
+msgid "Customize the dash color"
+msgstr "Dash의 색상 사용자 정의"
+
+#: Settings.ui.h:94
+msgid "Tune the dash background opacity."
+msgstr "Dash의 배경 투명도를 조정합니다."
+
+#: Settings.ui.h:96
+msgid "Fixed"
+msgstr "고정된"
+
+#: Settings.ui.h:97
+msgid "Dynamic"
+msgstr "동적"
+
+#: Settings.ui.h:98
+msgid "Opacity"
+msgstr "투명도"
+
+#: Settings.ui.h:99
+msgid "Appearance"
+msgstr "외형"
+
+#: Settings.ui.h:100
+msgid "version:"
+msgstr "버전:"
+
+#: Settings.ui.h:101
+msgid "Moves the dash out of the overview transforming it in a dock"
+msgstr "Dash를 개요에서 이동하여 Dock으로 변환"
+
+#: Settings.ui.h:102
+msgid "Created by"
+msgstr "만든 사람"
+
+#: Settings.ui.h:103
+msgid "Webpage"
+msgstr "웹 페이지"
+
+#: Settings.ui.h:104
+msgid ""
+"<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
+"See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0."
+"html\">GNU General Public License, version 2 or later</a> for details.</span>"
+msgstr ""
+"<span size=\"small\">이 프로그램은 어떠한 형태의 보증도 제공되지 않습니다.\n"
+"자세한 내용은 <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0."
+"html\">GNU 일반 공중 사용 허가서, 버전 2 또는 이후</a>를 참조하십시오.</span>"
+
+#: Settings.ui.h:106
+msgid "About"
+msgstr "정보"
+
+#: Settings.ui.h:107
+msgid "Customize minimum and maximum opacity values"
+msgstr "투명도 최소/최대 값의 조정"
+
+#: Settings.ui.h:108
+msgid "Minimum opacity"
+msgstr "최소 투명도"
+
+#: Settings.ui.h:109
+msgid "Maximum opacity"
+msgstr "최대 투명도"
+
+#: Settings.ui.h:110
+msgid "Number overlay"
+msgstr "번호 오버레이"
+
+#: Settings.ui.h:111
+msgid ""
+"Temporarily show the application numbers over the icons, corresponding to the "
+"shortcut."
+msgstr ""
+"일시적으로 단축키에 해당하는 아이콘 위에 응용프로그램 번호를 표시합니다."
+
+#: Settings.ui.h:112
+msgid "Show the dock if it is hidden"
+msgstr "Dock이 숨겨져 있으면 표시"
+
+#: Settings.ui.h:113
+msgid ""
+"If using autohide, the dock will appear for a short time when triggering the "
+"shortcut."
+msgstr "자동 숨김을 사용하는 경우, 단축키를 트리거할 때 Dock이 잠시 나타납니다."
+
+#: Settings.ui.h:114
+msgid "Shortcut for the options above"
+msgstr "위 옵션의 단축키"
+
+#: Settings.ui.h:115
+msgid "Syntax: <Shift>, <Ctrl>, <Alt>, <Super>"
+msgstr "문법: <Shift>, <Ctrl>, <Alt>, <Super>"
+
+#: Settings.ui.h:116
+msgid "Hide timeout (s)"
+msgstr "숨김 타임아웃 (초)"
+
+#: Settings.ui.h:117
+msgid "Show the dock by mouse hover on the screen edge."
+msgstr "화면 가장자리에 마우스를 올려 Dock을 표시합니다."
+
+#: Settings.ui.h:118
+msgid "Autohide"
+msgstr "자동 숨김"
+
+#: Settings.ui.h:119
+msgid "Push to show: require pressure to show the dock"
+msgstr "눌러서 표시: Dock을 표시하려면 압력이 필요합니다"
+
+#: Settings.ui.h:120
+msgid "Enable in fullscreen mode"
+msgstr "전체화면 모드에서 허용"
+
+#: Settings.ui.h:121
+msgid "Show dock for urgent notifications"
+msgstr "긴급 알림을 위해 Dock 표시"
+
+#: Settings.ui.h:122
+msgid "Show the dock when it doesn't obstruct application windows."
+msgstr "응용 프로그램 창이 가려지지 않을 때 Dock을 표시합니다."
+
+#: Settings.ui.h:123
+msgid "Dodge windows"
+msgstr "창을 피합니다"
+
+#: Settings.ui.h:124
+msgid "All windows"
+msgstr "모든 창"
+
+#: Settings.ui.h:125
+msgid "Only focused application's windows"
+msgstr "주된 응용 프로그램 창만"
+
+#: Settings.ui.h:126
+msgid "Only maximized windows"
+msgstr "최대화된 창만"
+
+#: Settings.ui.h:127
+msgid "Always on top"
+msgstr "항상 위로 표시"
+
+#: Settings.ui.h:128
+msgid "Animation duration (s)"
+msgstr "애니메이션 지속 시간 (초)"
+
+#: Settings.ui.h:129
+msgid "Show timeout (s)"
+msgstr "타임아웃 표시 (초)"
+
+#: Settings.ui.h:130
+msgid "Pressure threshold"
+msgstr "압력 임계값"


### PR DESCRIPTION
Settings app with Korean translation is as follows:
(Please note, as I'm currently using Fedora 39 with Dash to Dock 89, some settings may be different)
![스크린샷 2024-04-22 07-47-59](https://github.com/micheleg/dash-to-dock/assets/7533290/5b3f4f41-300a-4615-96f5-64577e9b53d2)
