### PR TITLE
Fix window preview in Gnome 45

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -197,10 +197,7 @@ export const DockDash = GObject.registerClass({
         });
         this._box._delegate = this;
         this._boxContainer.add_child(this._box);
-        if (this._scrollView.add_actor)
-            this._scrollView.add_actor(this._boxContainer);
-        else
-            this._scrollView.add_child(this._boxContainer);
+        Utils.addActor(this._scrollView, this._boxContainer);
         this._dashContainer.add_child(this._scrollView);
 
         this._showAppsIcon = new AppIcons.DockShowAppsIcon(this._position);

--- a/utils.js
+++ b/utils.js
@@ -686,3 +686,10 @@ export function supportsExtendedBarriers() {
         return global.display.supports_extended_barriers();
     return !!(global.backend.capabilities & Meta.BackendCapabilities.BARRIERS);
 }
+
+export function addActor(element, actor) {
+    if (element.add_actor)
+        element.add_actor(actor);
+    else
+        element.add_child(actor);
+}

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -60,7 +60,10 @@ export class WindowPreviewMenu extends PopupMenu.PopupMenu {
         });
         this._destroyId = this._source.connect('destroy', this.destroy.bind(this));
 
-        Main.uiGroup.add_child(this.actor);
+        if (Main.uiGroup.add_actor)
+            Main.uiGroup.add_actor(this.actor);
+        else
+            Main.uiGroup.add_child(this.actor);
 
         this.connect('destroy', this._onDestroy.bind(this));
     }
@@ -109,7 +112,10 @@ class WindowPreviewList extends PopupMenu.PopupMenuSection {
         this.isHorizontal = position === St.Side.BOTTOM || position === St.Side.TOP;
         this.box.set_vertical(!this.isHorizontal);
         this.box.set_name('dashtodockWindowList');
-        this.actor.add_child(this.box);
+        if (this.actor.add_actor)
+            this.actor.add_actor(this.box);
+        else
+            this.actor.add_child(this.box);
         this.actor._delegate = this;
 
         this._shownInitially = false;
@@ -359,7 +365,10 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
                 ? Clutter.ActorAlign.START : Clutter.ActorAlign.END,
             y_align: Clutter.ActorAlign.START,
         });
-        this.closeButton.set_child(new St.Icon({icon_name: 'window-close-symbolic'}));
+        if (this.closeButton.add_actor)
+            this.closeButton.add_actor(new St.Icon({icon_name: 'window-close-symbolic'}));
+        else
+            this.closeButton.add_child(new St.Icon({icon_name: 'window-close-symbolic'}));
         this.closeButton.connect('clicked', () => this._closeWindow());
 
         const overlayGroup = new Clutter.Actor({
@@ -387,8 +396,13 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
             x_expand: true,
         });
 
-        box.add_child(overlayGroup);
-        box.add_child(labelBin);
+        if (box.add) {
+            box.add(overlayGroup);
+            box.add(labelBin);
+        } else {
+            box.add_child(overlayGroup);
+            box.add_child(labelBin);
+        }
         this._box = box;
         this.add_child(box);
 

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -60,10 +60,7 @@ export class WindowPreviewMenu extends PopupMenu.PopupMenu {
         });
         this._destroyId = this._source.connect('destroy', this.destroy.bind(this));
 
-        if (Main.uiGroup.add_actor)
-            Main.uiGroup.add_actor(this.actor);
-        else
-            Main.uiGroup.add_child(this.actor);
+        Utils.addActor(Main.uiGroup, this.actor);
 
         this.connect('destroy', this._onDestroy.bind(this));
     }
@@ -112,10 +109,7 @@ class WindowPreviewList extends PopupMenu.PopupMenuSection {
         this.isHorizontal = position === St.Side.BOTTOM || position === St.Side.TOP;
         this.box.set_vertical(!this.isHorizontal);
         this.box.set_name('dashtodockWindowList');
-        if (this.actor.add_actor)
-            this.actor.add_actor(this.box);
-        else
-            this.actor.add_child(this.box);
+        Utils.addActor(this.actor, this.box);
         this.actor._delegate = this;
 
         this._shownInitially = false;
@@ -365,10 +359,7 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
                 ? Clutter.ActorAlign.START : Clutter.ActorAlign.END,
             y_align: Clutter.ActorAlign.START,
         });
-        if (this.closeButton.add_actor)
-            this.closeButton.add_actor(new St.Icon({icon_name: 'window-close-symbolic'}));
-        else
-            this.closeButton.add_child(new St.Icon({icon_name: 'window-close-symbolic'}));
+        Utils.addActor(this.closeButton, new St.Icon({icon_name: 'window-close-symbolic'}));
         this.closeButton.connect('clicked', () => this._closeWindow());
 
         const overlayGroup = new Clutter.Actor({


### PR DESCRIPTION
When setting the middle button click as "show window preview", the previews aren't shown. Instead, an empty rectangle appears and a lot of errors are shown in the log.

This patch fixes this.

Fix #2202