### PR TITLE
Fix wl-clipboard messing with the dock

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -824,7 +824,7 @@ export const DockDash = GObject.registerClass({
 
             // Second: add the new apps
             running.forEach(app => {
-                if (!showFavorites || !(app.get_id() in favorites))
+                if ((!showFavorites || !(app.get_id() in favorites)) && !(app.get_windows()[0].get_title() === 'wl-clipboard'))
                     newApps.push(app);
             });
         }

--- a/intellihide.js
+++ b/intellihide.js
@@ -317,6 +317,9 @@ export class Intellihide {
         if (ignoreApps.includes(wmApp) && metaWindow.is_skip_taskbar())
             return false;
 
+		if (metaWindow.get_title() === 'wl-clipboard')
+			return false;
+
         // The DropDownTerminal extension uses the POPUP_MENU window type hint
         // so we match its window by wm class instead
         if (metaWindow.get_wm_class() === 'DropDownTerminalWindow')


### PR DESCRIPTION
A temporary fix of `wl-clipboard` appearing in the running apps section (https://github.com/micheleg/dash-to-dock/issues/2193) and causing a hidden dock to show up for a brief moment when launched.

The problem is caused by not only the `wl-clipboard` but also other short-lived programs stealing focus so, as proposed in https://github.com/micheleg/dash-to-dock/issues/988 and https://github.com/micheleg/dash-to-dock/issues/2064, it would be nice to take it further and implement an option to ignore apps specified by the user.