### PR TITLE
Hide overview before locking screen

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1663,7 +1663,7 @@ const WorkspaceIsolation = class DashToDockWorkspaceIsolation {
 
 export class DockManager {
     _restoreLock() {
-        Main.screenShield.__proto__.lock = this._oldLock;
+        Object.getPrototypeOf(Main.screenShield).lock = this._oldLock;
         Main.overview.disconnect(this._lockHiddenID);
         this._lockHiddenID = 0;
     }
@@ -1673,17 +1673,16 @@ export class DockManager {
         // to ensure that trying to lock the screen in Overview mode will return first
         // to normal mode. This is needed to avoid https://github.com/micheleg/dash-to-dock/issues/2214
         // until a definitive fix is sent.
-        let oldLock = Main.screenShield.__proto__.lock;
+        const oldLock = Object.getPrototypeOf(Main.screenShield).lock;
         this._oldLock = oldLock;
-        this._lockHiddenID = Main.overview.connect("hidden", () => {
+        this._lockHiddenID = Main.overview.connect('hidden', () => {
             if (this._lockAfterHide) {
                 this._lockAfterHide = false;
-                if (!Main.overview.visible) {
+                if (!Main.overview.visible)
                     oldLock.bind(Main.screenShield)(this._lockAnimate);
-                }
             }
         });
-        Main.screenShield.__proto__.lock = function(animate) {
+        Object.getPrototypeOf(Main.screenShield).lock = function (animate) {
             if (!Main.overview.visible) {
                 oldLock.bind(Main.screenShield)(animate);
                 return;
@@ -1693,6 +1692,7 @@ export class DockManager {
             Main.overview.hide();
         }.bind(this);
     }
+
     constructor(extension) {
         if (DockManager._singleton)
             throw new Error('DashToDock has been already initialized');


### PR DESCRIPTION
There seems to be a bug in St/Clutter that crashes Gnome Shell if Dash to Dock is enabled and the user locks the screen from the overview mode.

This patch is a workaround in the meantime, while the true bug is found, to avoid this. It exits the overview mode before locking the screen.

Fix https://github.com/micheleg/dash-to-dock/issues/2216