### PR TITLE
Fix communication with DING

### DIFF
--- a/desktopIconsIntegration.js
+++ b/desktopIconsIntegration.js
@@ -153,7 +153,8 @@ export class DesktopIconsUsableAreaClass {
     _sendMarginsToExtension(extension) {
         // check that the extension is an extension that has the logic to accept
         // working margins
-        if (extension?.state !== ExtensionUtils.ExtensionState.ENABLED)
+        if ((extension?.state !== ExtensionUtils.ExtensionState.ENABLED) &&
+            (extension?.state !== ExtensionUtils.ExtensionState.ACTIVE))
             return;
 
         const usableArea = extension?.stateObj?.DesktopIconsUsableArea;

--- a/desktopIconsIntegration.js
+++ b/desktopIconsIntegration.js
@@ -64,7 +64,8 @@ const IDENTIFIER_UUID = '130cbc66-235c-4bd6-8571-98d2d8bba5e2';
 
 export class DesktopIconsUsableAreaClass {
     _checkIfExtensionIsEnabled(extension) {
-        return ((extension?.state === ExtensionUtils.ExtensionState.ENABLED) || (extension?.state === ExtensionUtils.ExtensionState.ACTIVE));
+        return (extension?.state === ExtensionUtils.ExtensionState.ENABLED) ||
+               (extension?.state === ExtensionUtils.ExtensionState.ACTIVE);
     }
 
     constructor() {

--- a/desktopIconsIntegration.js
+++ b/desktopIconsIntegration.js
@@ -63,6 +63,10 @@ import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 const IDENTIFIER_UUID = '130cbc66-235c-4bd6-8571-98d2d8bba5e2';
 
 export class DesktopIconsUsableAreaClass {
+    _checkIfExtensionIsEnabled(extension) {
+        return ((extension?.state === ExtensionUtils.ExtensionState.ENABLED) || (extension?.state === ExtensionUtils.ExtensionState.ACTIVE));
+    }
+
     constructor() {
         const Me = Extension.lookupByURL(import.meta.url);
         this._UUID = Me.uuid;
@@ -75,7 +79,7 @@ export class DesktopIconsUsableAreaClass {
 
             // If an extension is being enabled and lacks the
             // DesktopIconsUsableArea object, we can avoid launching a refresh
-            if (extension.state === ExtensionUtils.ExtensionState.ENABLED) {
+            if (this._checkIfExtensionIsEnabled(extension)) {
                 this._sendMarginsToExtension(extension);
                 return;
             }
@@ -153,8 +157,7 @@ export class DesktopIconsUsableAreaClass {
     _sendMarginsToExtension(extension) {
         // check that the extension is an extension that has the logic to accept
         // working margins
-        if ((extension?.state !== ExtensionUtils.ExtensionState.ENABLED) &&
-            (extension?.state !== ExtensionUtils.ExtensionState.ACTIVE))
+        if (!this._checkIfExtensionIsEnabled(extension))
             return;
 
         const usableArea = extension?.stateObj?.DesktopIconsUsableArea;


### PR DESCRIPTION
The extension state naming has changed from gnome shell 45 to gnome shell 46, so the code to notify margins to DING wasn't being able to detect when an extension was active, and so it didn't prevent to put icons below the dock.

This patch fixes it.