### PR TITLE
docking: Fix allocation failure in GNOME 47 that completely broke the shell

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2230,7 +2230,7 @@ export class DockManager {
                 const oldPostAllocation = this._runPostAllocation;
                 this._runPostAllocation = () => {};
 
-                const monitor = Main.layoutManager.findMonitorForActor(this._container);
+                const monitor = Main.layoutManager.findMonitorForActor(container);
                 const workArea = Main.layoutManager.getWorkAreaForMonitor(monitor.index);
                 const startX = workArea.x - monitor.x;
                 const startY = workArea.y - monitor.y;


### PR DESCRIPTION
Since `this._container` no longer exists (gnome-shell@b58119d5c6?) in GNOME 47, allocating the entire overview would fail and the shell was non-functional.

Fixes:
```
Gjs-CRITICAL **: 17:10:01.720: JS ERROR: TypeError: actor is undefined
findIndexForActor@resource:///org/gnome/shell/ui/layout.js:992:22
findMonitorForActor@resource:///org/gnome/shell/ui/layout.js:999:26
_prepareMainDash/<@file:///home/dan/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/docking.js:2233:52
@resource:///org/gnome/shell/ui/init.js:21:20
```