### PR TITLE
Don't show error messages when disabling

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2551,7 +2551,7 @@ export class DockManager {
         this._appSwitcherSettings = null;
         this._oldDash = null;
 
-        this._desktopIconsUsableArea.destroy();
+        this._desktopIconsUsableArea?.destroy();
         this._desktopIconsUsableArea = null;
         this._extension = null;
         DockManager._singleton = null;

--- a/notificationsMonitor.js
+++ b/notificationsMonitor.js
@@ -50,7 +50,7 @@ export class NotificationsMonitor {
 
     destroy() {
         this.emit('destroy');
-        this._signalsHandler.destroy();
+        this._signalsHandler?.destroy();
         this._signalsHandler = null;
         this._appNotifications = null;
         this._settings = null;


### PR DESCRIPTION
Since the destroy() function can be called several times, it is paramount to don't call objects that have been freed in previous calls.