### PR TITLE
UDENG-3111: allow to disable an icon in the dock during updates

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -740,6 +740,10 @@ class UnityIndicator extends IndicatorBase {
             'urgent-changed',
             (sender, {urgent}) => this.setUrgent(urgent),
         ], [
+            remoteEntry,
+            'updating-changed',
+            (sender, {updating}) => this.setUpdating(updating),
+        ], [
             notificationsMonitor,
             'changed',
             () => this._updateNotificationsCount(),
@@ -759,6 +763,7 @@ class UnityIndicator extends IndicatorBase {
         this._notificationBadgeBin = null;
         this._hideProgressOverlay();
         this.setUrgent(false);
+        this.setUpdating(false);
         this._remoteEntry = null;
 
         super.destroy();
@@ -1017,6 +1022,16 @@ class UnityIndicator extends IndicatorBase {
             this._isUrgent = urgent;
         else
             delete this._isUrgent;
+    }
+
+    setUpdating(updating) {
+        if (updating || this._isUpdating !== undefined)
+            this._source.updating = updating;
+
+        if (updating)
+            this._isUpdating = updating;
+        else
+            delete this._isUpdating;
     }
 }
 

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -1025,13 +1025,7 @@ class UnityIndicator extends IndicatorBase {
     }
 
     setUpdating(updating) {
-        if (updating || this._isUpdating !== undefined)
-            this._source.updating = updating;
-
-        if (updating)
-            this._isUpdating = updating;
-        else
-            delete this._isUpdating;
+        this._source.updating = updating;
     }
 }
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -106,6 +106,10 @@ const DockAbstractAppIcon = GObject.registerClass({
             'urgent', 'urgent', 'urgent',
             GObject.ParamFlags.READWRITE,
             false),
+        'updating': GObject.ParamSpec.boolean(
+            'updating', 'updating', 'updating',
+            GObject.ParamFlags.READWRITE,
+            false),
         'windows-count': GObject.ParamSpec.uint(
             'windows-count', 'windows-count', 'windows-count',
             GObject.ParamFlags.READWRITE,
@@ -187,6 +191,13 @@ const DockAbstractAppIcon = GObject.registerClass({
             }
         });
 
+        this.connect('notify::updating', () => {
+            const icon = this.icon._iconBin;
+            if (this.updating)
+                icon.set_opacity(128);
+            else
+                icon.set_opacity(255);
+        });
         this._urgentWindows = new Set();
         this._progressOverlayArea = null;
         this._progress = 0;

--- a/launcherAPI.js
+++ b/launcherAPI.js
@@ -160,6 +160,7 @@ const launcherEntryDefaults = Object.freeze({
     count: 0,
     progress: 0,
     urgent: false,
+    updating: false,
     quicklist: null,
     'count-visible': false,
     'progress-visible': false,


### PR DESCRIPTION
For the new RAA we need to be able to mark an icon as "disabled" while it is being updated. The current Unity LauncherAPI (https://wiki.ubuntu.com/Unity/LauncherAPI) doesn't support this, so this patch adds an extra option for this.

https://docs.google.com/document/d/1--DgBRl6AqNiyjW_luOjl1dDzsIZPlF0Ukc7INW9_XQ