### PR TITLE
Fix window selected from preview not getting focus

### DIFF
--- a/windowPreview.js
+++ b/windowPreview.js
@@ -645,8 +645,8 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
     }
 
     activate() {
-        this._getTopMenu().close();
         Main.activateWindow(this._window);
+        this._getTopMenu().close();
     }
 
     _onDestroy() {


### PR DESCRIPTION
This is a fix for an issue where activating a window from the window preview list would not reliably give focus to that window (#1972)

I don't know why reordering these two lines of code fixes it, but there's [confirmation](https://github.com/micheleg/dash-to-dock/issues/1972#issuecomment-2200097373) from another user that the change also works for them.
