### PR TITLE
metadata.json: Enable support for gnome-shell 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,8 @@
 {
 "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
 ],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",


### PR DESCRIPTION
Closes: https://github.com/micheleg/dash-to-dock/issues/2246