### PR TITLE
Add `Dot` running indicator style

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -2071,6 +2071,7 @@
                                           <item translatable="yes">Ciliora</item>
                                           <item translatable="yes">Metro</item>
                                           <item translatable="yes">Binary</item>
+                                          <item translatable="yes">Dot</item>
                                         </items>
                                       </object>
                                     </child>

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -26,6 +26,7 @@ const RunningIndicatorStyle = Object.freeze({
     CILIORA: 6,
     METRO: 7,
     BINARY: 8,
+    DOT: 9,
 });
 
 const MAX_WINDOWS_CLASSES = 4;
@@ -88,8 +89,13 @@ export class AppIconIndicator {
         case RunningIndicatorStyle.METRO:
             runningIndicator = new RunningIndicatorMetro(source);
             break;
+
         case RunningIndicatorStyle.BINARY:
             runningIndicator = new RunningIndicatorBinary(source);
+            break;
+
+        case RunningIndicatorStyle.DOT:
+            runningIndicator = new RunningIndicatorDot(source);
             break;
 
         default:
@@ -670,6 +676,35 @@ class RunningIndicatorBinary extends RunningIndicatorDots {
             Utils.cairoSetSourceColor(cr, this._bodyColor);
             cr.fill();
         }
+    }
+}
+
+class RunningIndicatorDot extends RunningIndicatorDots {
+    _computeStyle() {
+        super._computeStyle();
+
+        this._radius = Math.max(this._width / 26, this._borderWidth / 2);
+    }
+
+    _drawIndicator(cr) {
+        if (!this._source.running)
+            return;
+
+        cr.setLineWidth(this._borderWidth);
+        Utils.cairoSetSourceColor(cr, this._borderColor);
+
+        // draw from the bottom case:
+        cr.translate(
+            (this._width - 2 * this._radius) / 2,
+            this._height - this._padding);
+        cr.newSubPath();
+        cr.arc(this._radius,
+            -this._radius - this._borderWidth / 2,
+            this._radius, 0, 2 * Math.PI);
+
+        cr.strokePreserve();
+        Utils.cairoSetSourceColor(cr, this._bodyColor);
+        cr.fill();
     }
 }
 

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -48,6 +48,7 @@
     <value value='6' nick='CILIORA'/>
     <value value='7' nick='METRO'/>
     <value value='8' nick='BINARY'/>
+    <value value='9' nick='DOT'/>
   </enum>
   <schema path="/org/gnome/shell/extensions/dash-to-dock/" id="org.gnome.shell.extensions.dash-to-dock">
     <key name="dock-position" enum="org.gnome.shell.extensions.dash-to-dock.position">


### PR DESCRIPTION
![Dot indicator](https://github.com/user-attachments/assets/6431fa34-b36a-4d8a-8f4c-d2aac722c876)


It is known that in GNOME 46.2 the default indicator has undergone breaking changes, and now its positioning is faulty: #2222. So I decided it would be nice to make a custom indicator like `Dots`, but with just one dot and as close in size and style as possible to the default indicator.

P.S: It doesn't replace the default indicator for backwards compatibility reasons, but it does provide an alternative in newer versions of GNOME. In the future, this could be made the default, instead of the current `Dots` option.