### PR TITLE
Icon indicators everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ EXTRA_MEDIA = logo.svg \
               $(NULL)
 
 TOLOCALIZE =  prefs.js \
+			  docking.js \
               appIcons.js \
               locations.js \
               $(NULL)

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ EXTRA_MODULES = \
                 dash.js \
                 docking.js \
                 appIcons.js \
+				appIconsDecorator.js \
                 appIconIndicators.js \
                 fileManager1API.js \
                 imports.js \
@@ -38,6 +39,7 @@ EXTRA_MEDIA = logo.svg \
 TOLOCALIZE =  prefs.js \
 			  docking.js \
               appIcons.js \
+              appIconsDecorator.js \
               locations.js \
               $(NULL)
 

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -364,7 +364,9 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
     background: $dash_background_color;
 }
 
-#dashtodockContainer.dashtodock .progress-bar {
+#dashtodockContainer.dashtodock .progress-bar,
+.overview-tile .progress-bar,
+.icon-grid .progress-bar {
     /* Customization of the progress bar style. The possible elements
      * are:
      *
@@ -442,13 +444,17 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
     transition-duration: 500ms;
 }
 
-#dashtodockContainer .number-overlay {
+#dashtodockContainer .number-overlay,
+.overview-tile .number-overlay,
+.icon-grid .number-overlay {
     color: rgba(255, 255, 255, 1);
     background-color: rgba(0, 0, 0, 0.8);
     text-align: center;
 }
 
-#dashtodockContainer .notification-badge {
+#dashtodockContainer .notification-badge,
+.overview-tile .notification-badge,
+.icon-grid .notification-badge {
     color: rgba(255, 255, 255, 1);
     background-color: rgba(255, 0, 0, 1);
     padding: 0.2em 0.5em;

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -411,11 +411,21 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
      *   -progress-bar-background: 204, 204, 204, 1.0
      *   -progress-bar-border: 230, 230, 230, 1.0
      *   -progress-bar-line-width: 1
+     *   -progress-bar-top-offset: undefined
+     *   -progress-bar-valign: 1.0
      */
     -progress-bar-track-background: rgba(0, 0, 0, 0.45);
     -progress-bar-track-border: rgba(0, 0, 0, 0.7);
     -progress-bar-background: rgba(255, 255, 255, 1.0);
     -progress-bar-border: rgba(255, 255, 255, 1.0);
+}
+
+#overview,
+.apps-scroll-view {
+    .progress-bar {
+        -progress-bar-top-offset: 0;
+        -progress-bar-valign: 0.8;
+    }
 }
 
 #dashtodockContainer.top #dash .placeholder,

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -217,7 +217,8 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
                     };
                 }
 
-                .app-well-app {
+                .app-well-app,
+                .overview-tile {
                     &.running .overview-icon {
                         background-image: none;
                     }
@@ -225,7 +226,8 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
                         background-color: $remark_color;
                     }
 
-                    .app-well-app-running-dot {
+                    .app-well-app-running-dot,
+                    .app-grid-running-dot {
                         margin-bottom: 2px;
                     }
                 }

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -760,6 +760,12 @@ class UnityIndicator extends IndicatorBase {
             'style-changed',
             () => this._updateIconStyle(),
         ]);
+
+        this._updateNotificationsCount();
+        this.setProgress(this._remoteEntry.progress_visible
+            ? this._remoteEntry.progress : -1);
+        this.setUrgent(this._remoteEntry.urgent);
+        this.setUpdating(this._remoteEntry.updating);
     }
 
     destroy() {

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -676,7 +676,7 @@ class RunningIndicatorBinary extends RunningIndicatorDots {
 /*
  * Unity like notification and progress indicators
  */
-class UnityIndicator extends IndicatorBase {
+export class UnityIndicator extends IndicatorBase {
     static defaultProgressBar = {
         // default values for the progress bar itself
         background: {

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -755,6 +755,10 @@ class UnityIndicator extends IndicatorBase {
             this._source._iconContainer,
             'notify::size',
             this.updateNotificationBadgeStyle.bind(this),
+        ], [
+            this._source,
+            'style-changed',
+            () => this._updateIconStyle(),
         ]);
     }
 
@@ -1026,6 +1030,16 @@ class UnityIndicator extends IndicatorBase {
 
     setUpdating(updating) {
         this._source.updating = updating;
+    }
+
+    _updateIconStyle() {
+        const opacityLookup =
+            this._source.get_theme_node().lookup_double('opacity', true);
+        const [hasOpacity] = opacityLookup;
+        let [, opacity] = opacityLookup;
+        if (!hasOpacity)
+            opacity = this._source.updating ? 0.5 : 1;
+        this._source.icon.set_opacity(255 * opacity);
     }
 }
 

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -953,20 +953,30 @@ export class UnityIndicator extends IndicatorBase {
         const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
         const [surfaceWidth, surfaceHeight] = area.get_surface_size();
         const cr = area.get_context();
-
+        const node = this._progressOverlayArea.get_theme_node();
         const iconSize = this._source.icon.iconSize * scaleFactor;
 
         let x = Math.floor((surfaceWidth - iconSize) / 2);
         let y = Math.floor((surfaceHeight - iconSize) / 2);
+
+        const [hasTopOffset, topOffset] = node.lookup_double(
+            '-progress-bar-top-offset', false);
+        if (hasTopOffset)
+            y = topOffset;
 
         const baseLineWidth = Math.floor(Number(scaleFactor));
         const padding = Math.floor(iconSize * 0.05);
         let width = iconSize - 2.0 * padding;
         let height = Math.floor(Math.min(18.0 * scaleFactor, 0.20 * iconSize));
         x += padding;
-        y += iconSize - height - padding;
 
-        const node = this._progressOverlayArea.get_theme_node();
+        const valignParameters = node.lookup_double(
+            '-progress-bar-valign', false);
+        const [hasValign] = valignParameters;
+        let [, valign] = valignParameters;
+        if (!hasValign)
+            valign = 1.0;
+        y += (iconSize - height - padding) * valign;
 
         const progressBarTrack = this._readElementData(node,
             '-progress-bar-track',

--- a/appIcons.js
+++ b/appIcons.js
@@ -364,6 +364,12 @@ const DockAbstractAppIcon = GObject.registerClass({
             this._addUrgentWindow(window);
     }
 
+    _updateDotStyle() {
+        super._updateDotStyle();
+        const themeNode = this._dot.get_theme_node();
+        this._dot.translationX = themeNode.get_length('offset-x');
+    }
+
     _addUrgentWindow(window) {
         if (this._urgentWindows.has(window))
             return;

--- a/appIcons.js
+++ b/appIcons.js
@@ -24,8 +24,6 @@ import {
     ParentalControlsManager,
 } from './dependencies/shell/misc.js';
 
-import {Config} from './dependencies/shell/misc.js';
-
 import {
     AppIconIndicators,
     DBusMenuUtils,
@@ -1177,20 +1175,14 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
                 this._appendSeparator();
 
                 const isFavorite = AppFavorites.getAppFavorites().isFavorite(app.get_id());
-                const [majorVersion] = Config.PACKAGE_VERSION.split('.');
-
                 if (isFavorite) {
-                    const label = majorVersion >= 42 ? _('Unpin')
-                        : _('Remove from Favorites');
-                    const item = this._appendMenuItem(label);
+                    const item = this._appendMenuItem(_('Unpin'));
                     item.connect('activate', () => {
                         const favs = AppFavorites.getAppFavorites();
                         favs.removeFavorite(app.get_id());
                     });
                 } else {
-                    const label = majorVersion >= 42 ? _('Pin to Dock')
-                        : _('Add to Favorites');
-                    const item = this._appendMenuItem(label);
+                    const item = this._appendMenuItem(_('Pin to Dock'));
                     item.connect('activate', () => {
                         const favs = AppFavorites.getAppFavorites();
                         favs.addFavorite(app.get_id());

--- a/appIcons.js
+++ b/appIcons.js
@@ -1088,7 +1088,10 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
     _rebuildMenu() {
         this.removeAll();
 
-        this._appendMenuItem(this.sourceActor.name).sensitive = false;
+        const appItemLabel = this.sourceActor.updating
+            ? _('%s is being updated...').format(this.sourceActor.name)
+            : this.sourceActor.name;
+        this._appendMenuItem(appItemLabel).sensitive = false;
         this._appendSeparator();
 
         const {app} = this.sourceActor;

--- a/appIcons.js
+++ b/appIcons.js
@@ -1189,7 +1189,7 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
                         favs.removeFavorite(app.get_id());
                     });
                 } else {
-                    const label = majorVersion >= 42 ? _('Pin to Dash')
+                    const label = majorVersion >= 42 ? _('Pin to Dock')
                         : _('Add to Favorites');
                     const item = this._appendMenuItem(label);
                     item.connect('activate', () => {

--- a/appIcons.js
+++ b/appIcons.js
@@ -758,8 +758,13 @@ const DockAbstractAppIcon = GObject.registerClass({
     // particular, if the application doesn't allow to launch a new window, activate
     // the existing window instead.
     launchNewWindow() {
-        if (this.updating)
+        if (this.updating) {
+            const icon = Gio.Icon.new_for_string('action-unavailable-symbolic');
+            Main.osdWindowManager.show(-1, icon,
+                _('%s is currently updating, cannot launch it!').format(this.name),
+                null);
             return;
+        }
 
         if (this.app.state === Shell.AppState.RUNNING &&
             this.app.can_open_new_window()) {

--- a/appIcons.js
+++ b/appIcons.js
@@ -1090,8 +1090,7 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
         const appItemLabel = this.sourceActor.updating
             ? _('%s is being updated...').format(this.sourceActor.name)
             : this.sourceActor.name;
-        this._appendMenuItem(appItemLabel).sensitive = false;
-        this._appendSeparator();
+        this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem(appItemLabel));
 
         const {app} = this.sourceActor;
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -719,9 +719,8 @@ const DockAbstractAppIcon = GObject.registerClass({
     }
 
     shouldShowTooltip() {
-        return this.hover && (!this._menu || !this._menu.isOpen) &&
-                            (!this._previewMenu || !this._previewMenu.isOpen) &&
-                            !Docking.DockManager.settings.hideTooltip;
+        return super.shouldShowTooltip() && !this._previewMenu?.isOpen &&
+            !Docking.DockManager.settings.hideTooltip;
     }
 
     _windowPreviews() {

--- a/appIcons.js
+++ b/appIcons.js
@@ -165,6 +165,13 @@ const DockAbstractAppIcon = GObject.registerClass({
                 this.remove_style_class_name('focused');
         });
 
+        this.connect('notify::updating', () => {
+            if (this.updating)
+                this.add_style_class_name('updating');
+            else
+                this.remove_style_class_name('updating');
+        });
+
         const {notificationsMonitor} = Docking.DockManager.getDefault();
 
         this.connect('notify::urgent', () => {
@@ -188,24 +195,6 @@ const DockAbstractAppIcon = GObject.registerClass({
                 this._updateUrgentWindows();
             }
         });
-
-        const updateUpdatingState = () => {
-            if (this.updating)
-                this.add_style_class_name('updating');
-            else
-                this.remove_style_class_name('updating');
-        };
-        this.connect('style-changed', () => {
-            const opacityLookup =
-                this.get_theme_node().lookup_double('opacity', true);
-            const [hasOpacity] = opacityLookup;
-            let [, opacity] = opacityLookup;
-            if (!hasOpacity)
-                opacity = this.updating ? 0.5 : 1;
-            this.icon.set_opacity(255 * opacity);
-        });
-        this.connect('notify::updating', updateUpdatingState);
-        updateUpdatingState();
 
         this._urgentWindows = new Set();
         this._progressOverlayArea = null;

--- a/appIcons.js
+++ b/appIcons.js
@@ -141,8 +141,8 @@ const DockAbstractAppIcon = GObject.registerClass({
             this._onWindowDemandsAttention(window));
 
         // In Wayland sessions, this signal is needed to track the state of windows dragged
-        // from one monitor to another. As this is triggered quite often (whenever a new window
-        // of any application opened or moved to a different desktop),
+        // from one monitor to another. As this is triggered quite often (whenever a new
+        // window of any application opened or moved to a different desktop),
         // we restrict this signal to  the case when Labels.ISOLATE_MONITORS is true,
         // and if there are at least 2 monitors.
         if (Docking.DockManager.settings.isolateMonitors &&

--- a/appIcons.js
+++ b/appIcons.js
@@ -247,8 +247,8 @@ const DockAbstractAppIcon = GObject.registerClass({
         // This is necessary due to an upstream bug
         // https://bugzilla.gnome.org/show_bug.cgi?id=757556
         // It can be safely removed once it get solved upstream.
-        if (this._menu)
-            this._menu.close(false);
+        this._menu?.close(false);
+        delete this._menu;
     }
 
     ownsWindow(window) {

--- a/appIcons.js
+++ b/appIcons.js
@@ -123,6 +123,7 @@ const DockAbstractAppIcon = GObject.registerClass({
         this._signalsHandler = new Utils.GlobalSignalsHandler(this);
         this.iconAnimator = iconAnimator;
         this._indicator = new AppIconIndicators.AppIconIndicator(this);
+        this._urgentWindows = new Set();
 
         // Monitor windows-changes instead of app state.
         // Keep using the same Id and function callback (that is extended)
@@ -157,6 +158,7 @@ const DockAbstractAppIcon = GObject.registerClass({
             else
                 this.remove_style_class_name('running');
         });
+        this.notify('running');
 
         this.connect('notify::focused', () => {
             if (this.focused)
@@ -164,6 +166,7 @@ const DockAbstractAppIcon = GObject.registerClass({
             else
                 this.remove_style_class_name('focused');
         });
+        this.notify('focused');
 
         this.connect('notify::updating', () => {
             if (this.updating)
@@ -171,6 +174,7 @@ const DockAbstractAppIcon = GObject.registerClass({
             else
                 this.remove_style_class_name('updating');
         });
+        this.notify('updating');
 
         const {notificationsMonitor} = Docking.DockManager.getDefault();
 
@@ -195,8 +199,8 @@ const DockAbstractAppIcon = GObject.registerClass({
                 this._updateUrgentWindows();
             }
         });
+        this.notify('urgent');
 
-        this._urgentWindows = new Set();
         this._progressOverlayArea = null;
         this._progress = 0;
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -143,7 +143,7 @@ const DockAbstractAppIcon = GObject.registerClass({
         // In Wayland sessions, this signal is needed to track the state of windows dragged
         // from one monitor to another. As this is triggered quite often (whenever a new window
         // of any application opened or moved to a different desktop),
-        // we restrict this signal to  the case when 'isolate-monitors' is true,
+        // we restrict this signal to  the case when Labels.ISOLATE_MONITORS is true,
         // and if there are at least 2 monitors.
         if (Docking.DockManager.settings.isolateMonitors &&
             Main.layoutManager.monitors.length > 1) {

--- a/appIcons.js
+++ b/appIcons.js
@@ -1067,8 +1067,8 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
         this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
     }
 
-    _appendMenuItem(labelText) {
-        const item = new PopupMenu.PopupMenuItem(labelText);
+    _appendMenuItem(labelText, params) {
+        const item = new PopupMenu.PopupMenuItem(labelText, params);
         this.addMenuItem(item);
         return item;
     }
@@ -1087,6 +1087,9 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
 
     _rebuildMenu() {
         this.removeAll();
+
+        this._appendMenuItem(this.sourceActor.name).sensitive = false;
+        this._appendSeparator();
 
         const {app} = this.sourceActor;
 

--- a/appIconsDecorator.js
+++ b/appIconsDecorator.js
@@ -1,0 +1,85 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+
+import {
+    Docking,
+    AppIconIndicators,
+    Utils,
+} from './imports.js';
+
+import {
+    AppDisplay,
+} from './dependencies/shell/ui.js';
+
+export class AppIconsDecorator {
+    constructor() {
+        this._signals = new Utils.GlobalSignalsHandler();
+        this._iconSignals = new Utils.GlobalSignalsHandler();
+        this._methodInjections = new Utils.InjectionsHandler();
+        this._indicators = new Set();
+
+        this._patchAppIcons();
+        this._decorateIcons();
+    }
+
+    destroy() {
+        this._signals?.destroy();
+        delete this._signals;
+        this._iconSignals?.destroy();
+        delete this._iconSignals;
+        this._methodInjections?.destroy();
+        delete this._methodInjections;
+        this._indicators?.clear();
+        delete this._indicators;
+    }
+
+    _decorateIcon(parentIcon) {
+        const indicator = new AppIconIndicators.UnityIndicator(parentIcon);
+        this._indicators.add(indicator);
+        this._signals.add(parentIcon, 'destroy', () => {
+            this._indicators.delete(indicator);
+            indicator.destroy();
+        });
+        return indicator;
+    }
+
+    _decorateIcons() {
+        const {appDisplay} = Docking.DockManager.getDefault().overviewControls;
+
+        const decorateAppIcons = () => {
+            this._indicators.clear();
+            this._iconSignals.clear();
+
+            const decorateViewIcons = view => {
+                const items = view.getAllItems();
+                items.forEach(i => {
+                    if (i instanceof AppDisplay.AppIcon) {
+                        this._decorateIcon(i);
+                    } else if (i instanceof AppDisplay.FolderIcon) {
+                        decorateViewIcons(i.view);
+                        this._iconSignals.add(i.view, 'view-loaded', () =>
+                            decorateAppIcons());
+                    }
+                });
+            };
+            decorateViewIcons(appDisplay);
+        };
+
+        this._signals.add(appDisplay, 'view-loaded', () => decorateAppIcons());
+        decorateAppIcons();
+    }
+
+    _patchAppIcons() {
+        const self = this;
+
+        this._methodInjections.add(AppDisplay.AppSearchProvider.prototype,
+            'createResultObject', function (originalFunction, ...args) {
+                /* eslint-disable no-invalid-this */
+                const result = originalFunction.call(this, ...args);
+                if (result instanceof AppDisplay.AppIcon)
+                    self._decorateIcon(result);
+                return result;
+                /* eslint-enable no-invalid-this */
+            });
+    }
+}

--- a/appIconsDecorator.js
+++ b/appIconsDecorator.js
@@ -8,7 +8,12 @@ import {
 } from './imports.js';
 
 import {
+    Gio,
+} from './dependencies/gi.js';
+
+import {
     AppDisplay,
+    Main,
 } from './dependencies/shell/ui.js';
 
 export class AppIconsDecorator {
@@ -82,6 +87,21 @@ export class AppIconsDecorator {
                 if (result instanceof AppDisplay.AppIcon)
                     self._decorateIcon(result);
                 return result;
+                /* eslint-enable no-invalid-this */
+            });
+
+        this._methodInjections.add(AppDisplay.AppIcon.prototype,
+            'activate', function (originalFunction, ...args) {
+                /* eslint-disable no-invalid-this */
+                if (this.updating) {
+                    const icon = Gio.Icon.new_for_string('action-unavailable-symbolic');
+                    Main.osdWindowManager.show(-1, icon,
+                        _('%s is currently updating, cannot launch it!').format(this.name),
+                        null);
+                    return;
+                }
+
+                originalFunction.call(this, ...args);
                 /* eslint-enable no-invalid-this */
             });
 

--- a/appIconsDecorator.js
+++ b/appIconsDecorator.js
@@ -16,6 +16,7 @@ export class AppIconsDecorator {
         this._signals = new Utils.GlobalSignalsHandler();
         this._iconSignals = new Utils.GlobalSignalsHandler();
         this._methodInjections = new Utils.InjectionsHandler();
+        this._propertyInjections = new Utils.PropertyInjectionsHandler({allowNewProperty: true});
         this._indicators = new Set();
 
         this._patchAppIcons();
@@ -29,6 +30,8 @@ export class AppIconsDecorator {
         delete this._iconSignals;
         this._methodInjections?.destroy();
         delete this._methodInjections;
+        this._propertyInjections?.destroy();
+        delete this._propertyInjections;
         this._indicators?.clear();
         delete this._indicators;
     }
@@ -81,5 +84,28 @@ export class AppIconsDecorator {
                 return result;
                 /* eslint-enable no-invalid-this */
             });
+
+        const appIconsTypes = [
+            AppDisplay.AppSearchProvider,
+            AppDisplay.AppIcon,
+        ];
+        appIconsTypes.forEach(type =>
+            this._propertyInjections.add(type.prototype, 'updating', {
+                get() {
+                    // eslint-disable-line no-invalid-this
+                    return !!this.__d2dUpdating;
+                },
+                set(updating) {
+                    /* eslint-disable no-invalid-this */
+                    if (this.updating === updating)
+                        return;
+                    this.__d2dUpdating = updating;
+                    if (updating)
+                        this.add_style_class_name('updating');
+                    else
+                        this.remove_style_class_name('updating');
+                    /* eslint-enable no-invalid-this */
+                },
+            }));
     }
 }

--- a/dependencies/shell/ui.js
+++ b/dependencies/shell/ui.js
@@ -1,4 +1,5 @@
 export * as AppDisplay from 'resource:///org/gnome/shell/ui/appDisplay.js';
+export * as AppMenu from 'resource:///org/gnome/shell/ui/appMenu.js';
 export * as AppFavorites from 'resource:///org/gnome/shell/ui/appFavorites.js';
 export * as BoxPointer from 'resource:///org/gnome/shell/ui/boxpointer.js';
 export * as DND from 'resource:///org/gnome/shell/ui/dnd.js';

--- a/docking.js
+++ b/docking.js
@@ -11,6 +11,7 @@ import {
 } from './dependencies/gi.js';
 
 import {
+    AppMenu,
     AppDisplay,
     Layout,
     Main,
@@ -1725,6 +1726,8 @@ export class DockManager {
         this._allDocks = [];
         this._createDocks();
 
+        this._overrideAppMenus();
+
         // status variable: true when the overview is shown through the dash
         // applications button.
         this._forcedOverview = false;
@@ -2521,6 +2524,21 @@ export class DockManager {
 
         // Because we "disconnected" from the search controller, we have to manage its state.
         this.searchController._setSearchActive(false);
+    }
+
+    _overrideAppMenus() {
+        this._methodInjections.add(AppMenu.AppMenu.prototype,
+            '_updateFavoriteItem', function (originalFunction, ...args) {
+                /* eslint-disable no-invalid-this */
+                originalFunction.call(this, ...args);
+                if (!this._toggleFavoriteItem.visible)
+                    return;
+
+                const {id} = this._app;
+                this._toggleFavoriteItem.label.text = this._appFavorites.isFavorite(id)
+                    ? _('Unpin') : _('Pin to Dock');
+                /* eslint-enable no-invalid-this */
+            });
     }
 
     destroy() {

--- a/docking.js
+++ b/docking.js
@@ -28,6 +28,7 @@ import {
 } from './dependencies/shell/misc.js';
 
 import {
+    AppIconsDecorator,
     AppSpread,
     DockDash,
     DesktopIconsIntegration,
@@ -1687,17 +1688,19 @@ export class DockManager {
 
         const needsRemoteModel = () =>
             !this._notificationsMonitor.dndMode && this._settings.showIconsEmblems;
-        if (needsRemoteModel)
-            this._remoteModel = new LauncherAPI.LauncherEntryRemoteModel();
 
         const ensureRemoteModel = () => {
             if (needsRemoteModel && !this._remoteModel) {
                 this._remoteModel = new LauncherAPI.LauncherEntryRemoteModel();
-            } else if (!needsRemoteModel && this._remoteModel) {
-                this._remoteModel.destroy();
+                this._appIconsDecorator = new AppIconsDecorator.AppIconsDecorator();
+            } else if (!needsRemoteModel) {
+                this._remoteModel?.destroy();
                 delete this._remoteModel;
+                this._appIconsDecorator?.destroy();
+                delete this._appIconsDecorator;
             }
         };
+        ensureRemoteModel();
 
         this._notificationsMonitor.connect('changed', ensureRemoteModel);
         this._settings.connect('changed::show-icons-emblems', ensureRemoteModel);
@@ -2565,6 +2568,7 @@ export class DockManager {
         this._removables = null;
         this._iconTheme = null;
         this._remoteModel?.destroy();
+        this._appIconsDecorator?.destroy();
         this._settings = null;
         this._appSwitcherSettings = null;
         this._oldDash = null;

--- a/imports.js
+++ b/imports.js
@@ -1,5 +1,6 @@
 export * as AppIconIndicators from './appIconIndicators.js';
 export * as AppIcons from './appIcons.js';
+export * as AppIconsDecorator from './appIconsDecorator.js';
 export * as AppSpread from './appSpread.js';
 export * as DockDash from './dash.js';
 export * as DBusMenuUtils from './dbusmenuUtils.js';

--- a/launcherAPI.js
+++ b/launcherAPI.js
@@ -224,7 +224,7 @@ const LauncherEntry = class DashToDockLauncherEntry {
 };
 
 for (const [name, defaultValue] of Object.entries(launcherEntryDefaults)) {
-    const jsName = name.replace(/-/g, '_');
+    const jsName = name.replaceAll('-', '_');
     LauncherEntry.prototype[jsName] = defaultValue;
     if (jsName !== name) {
         Object.defineProperty(LauncherEntry.prototype, name, {

--- a/notificationsMonitor.js
+++ b/notificationsMonitor.js
@@ -92,8 +92,9 @@ export class NotificationsMonitor {
 
                 source.notifications.forEach(notification => {
                     const app = notification.source?.app ?? notification.source?._app;
+                    const appId = app?.id ?? app?._appId;
 
-                    if (app?.id) {
+                    if (appId) {
                         if (notification.resident) {
                             if (notification.acknowledged)
                                 return;
@@ -106,8 +107,8 @@ export class NotificationsMonitor {
                         this._signalsHandler.addWithLabel(Labels.NOTIFICATIONS,
                             notification, 'destroy', () => this._checkNotifications());
 
-                        this._appNotifications[app.id] =
-                            (this._appNotifications[app.id] ?? 0) + 1;
+                        this._appNotifications[appId] =
+                            (this._appNotifications[appId] ?? 0) + 1;
                     }
                 });
             });

--- a/po/de.po
+++ b/po/de.po
@@ -101,8 +101,8 @@ msgid "Remove from Favorites"
 msgstr "Aus Favoriten entfernen"
 
 #: appIcons.js:1138
-msgid "Pin to Dash"
-msgstr "An Dash anheften"
+msgid "Pin to Dock"
+msgstr "An Dock anheften"
 
 #: appIcons.js:1139
 msgid "Add to Favorites"

--- a/po/ko.po
+++ b/po/ko.po
@@ -94,8 +94,8 @@ msgid "Remove from Favorites"
 msgstr "즐겨찾기에서 제거"
 
 #: appIcons.js:1138
-msgid "Pin to Dash"
-msgstr "Dash에 고정"
+msgid "Pin to Dock"
+msgstr "Dock에 고정"
 
 #: appIcons.js:1139
 msgid "Add to Favorites"

--- a/utils.js
+++ b/utils.js
@@ -320,7 +320,7 @@ export class InjectionsHandler extends BasicHandler {
         const original = object[name];
 
         if (!(original instanceof Function))
-            throw new Error(`Virtual function ${name}() is not available for ${object}`);
+            throw new Error(`Function ${name}() is not available for ${object}`);
 
         object[name] = function (...args) {
             return injectedFunction.call(this, original, ...args);
@@ -380,8 +380,13 @@ export class VFuncInjectionsHandler extends BasicHandler {
  * and restored
  */
 export class PropertyInjectionsHandler extends BasicHandler {
+    constructor(params) {
+        super();
+        this._params = params;
+    }
+
     _create(instance, name, injectedPropertyDescriptor) {
-        if (!(name in instance))
+        if (!this._params?.allowNewProperty && !(name in instance))
             throw new Error(`Object ${instance} has no '${name}' property`);
 
         const {prototype} = instance.constructor;


### PR DESCRIPTION
Shows Unity Icons indicators everywhere (overview, search results...) when they are enabled.

Handles updating applications better when in they're not pinned to the dock.