### PR TITLE
Fix null errors

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -785,8 +785,8 @@ export class UnityIndicator extends IndicatorBase {
         const defaultFontSize = fontDesc.get_size() / 1024;
         let fontSize = defaultFontSize * 0.9;
         const {iconSize} = Main.overview.dash;
-        const defaultIconSize = Docking.DockManager.settings.get_default_value(
-            'dash-max-icon-size').unpack();
+        const defaultIconSize = Docking.DockManager.settings?.get_default_value(
+            'dash-max-icon-size').unpack() ?? 64;
 
         if (!fontDesc.get_size_is_absolute()) {
             // fontSize was expressed in points, so convert to pixel

--- a/docking.js
+++ b/docking.js
@@ -1749,7 +1749,7 @@ export class DockManager {
     }
 
     static get settings() {
-        return DockManager.getDefault().settings;
+        return DockManager.getDefault()?.settings;
     }
 
     get extension() {
@@ -2545,6 +2545,7 @@ export class DockManager {
     }
 
     destroy() {
+        this._signalsHandler.destroy();
         this.emit('destroy');
         if (this._toggleLater) {
             Utils.laterRemove(this._toggleLater);

--- a/locations.js
+++ b/locations.js
@@ -1484,6 +1484,9 @@ Signals.addSignalMethods(Removables.prototype);
  */
 function getApps() {
     const dockManager = Docking.DockManager.getDefault();
+    if (dockManager == null) {
+        return [];
+    }
     const locationApps = [];
 
     if (dockManager.removables)

--- a/locations.js
+++ b/locations.js
@@ -1484,9 +1484,9 @@ Signals.addSignalMethods(Removables.prototype);
  */
 function getApps() {
     const dockManager = Docking.DockManager.getDefault();
-    if (dockManager == null) {
+    if (dockManager == null)
         return [];
-    }
+
     const locationApps = [];
 
     if (dockManager.removables)


### PR DESCRIPTION
Several errors are shown when the extension is disabled and re-enabled during desktop lock.

Fix https://github.com/micheleg/dash-to-dock/issues/1351
