### PR TITLE
Remove Animate Show Applications from the desktop (Fix "Show Applications" button)

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -15,7 +15,6 @@ import {
     AppDisplay,
     Layout,
     Main,
-    Overview,
     OverviewControls,
     PointerWatcher,
     Workspace,
@@ -2483,37 +2482,10 @@ export class DockManager {
 
         if (!Main.overview.visible) {
             this.mainDock.dash.showAppsButton._fromDesktop = true;
-            if (this._settings.animateShowApps) {
-                Main.overview.show(OverviewControls.ControlsState.APP_GRID);
-            } else {
-                GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
-                    const oldAnimationTime = OverviewControls.SIDE_CONTROLS_ANIMATION_TIME;
-                    Overview.ANIMATION_TIME = 1;
-                    const id = Main.overview.connect('shown', () => {
-                        Overview.ANIMATION_TIME = oldAnimationTime;
-                        Main.overview.disconnect(id);
-                    });
-                    Main.overview.show(OverviewControls.ControlsState.APP_GRID);
-                    return GLib.SOURCE_REMOVE;
-                });
-            }
+            Main.overview.show(OverviewControls.ControlsState.APP_GRID);
         } else if (!checked && this.mainDock.dash.showAppsButton._fromDesktop) {
-            if (this._settings.animateShowApps) {
-                Main.overview.hide();
-                this.mainDock.dash.showAppsButton._fromDesktop = false;
-            } else {
-                GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
-                    const oldAnimationTime = Overview.ANIMATION_TIME;
-                    Overview.ANIMATION_TIME = 1;
-                    const id = Main.overview.connect('hidden', () => {
-                        Overview.ANIMATION_TIME = oldAnimationTime;
-                        Main.overview.disconnect(id);
-                    });
-                    Main.overview.hide();
-                    this.mainDock.dash.showAppsButton._fromDesktop = false;
-                    return GLib.SOURCE_REMOVE;
-                });
-            }
+            Main.overview.hide();
+            this.mainDock.dash.showAppsButton._fromDesktop = false;
         } else {
             // TODO: I'm not sure how reliable this is, we might need to move the
             // _onShowAppsButtonToggled logic into the extension.

--- a/prefs.js
+++ b/prefs.js
@@ -752,10 +752,6 @@ const DockSettings = GObject.registerClass({
             this._builder.get_object('application_button_first_button'),
             'sensitive',
             Gio.SettingsBindFlags.DEFAULT);
-        this._settings.bind('animate-show-apps',
-            this._builder.get_object('application_button_animation_button'),
-            'active',
-            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('show-show-apps-button',
             this._builder.get_object('application_button_animation_button'),
             'sensitive',

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -299,11 +299,6 @@
       <default>true</default>
       <summary>Show application button on the edge when using centered panel mode</summary>
     </key>
-    <key type="b" name="animate-show-apps">
-      <default>true</default>
-      <summary>Animate Show Applications from the desktop</summary>
-      <description>Animate Show Applications from the desktop</description>
-    </key>
     <key type="b" name="bolt-support">
       <default>true</default>
       <summary>Basic compatibility with bolt extensions</summary>


### PR DESCRIPTION
The "Show Applications" button fails because the Overview.ANIMATION_TIME property is now read-only (it has a "const" prefix), so it's not possible to overwrite it to show the applications list "instantaneously". It "does nothing" and shows this error in the log:

```
ago 28 12:20:46 raster3-PROX14-AMD gnome-shell[534248]: JS ERROR: TypeError: "ANIMATION_TIME" is read-only
                                                        _onShowAppsButtonToggled/<@file:///home/raster/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/docking.js:2491:21
                                                        @resource:///org/gnome/shell/ui/init.js:21:20
```

This patch removes the option of disabling the animation, thus fixing the problem.