### PR TITLE
Progress bar theming tuning

### DIFF
--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -413,6 +413,8 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
      *   -progress-bar-line-width: 1
      *   -progress-bar-top-offset: undefined
      *   -progress-bar-valign: 1.0
+     *   -progress-bar-horizontal-padding: 0.05 (5% of icon size)
+     *   -progress-bar-vertical-padding: 0.05 (5% of icon size)
      */
     -progress-bar-track-background: rgba(0, 0, 0, 0.45);
     -progress-bar-track-border: rgba(0, 0, 0, 0.7);

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -410,6 +410,7 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
      *   -progress-bar-track-line-width: 1
      *   -progress-bar-background: 204, 204, 204, 1.0
      *   -progress-bar-border: 230, 230, 230, 1.0
+     *   -progress-bar-height-factor: (0.20) 20% of the icon size
      *   -progress-bar-line-width: 1
      *   -progress-bar-top-offset: undefined
      *   -progress-bar-valign: 1.0

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -426,9 +426,15 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
 #overview,
 .apps-scroll-view {
     .progress-bar {
+        -progress-bar-height-factor: 0.15;
         -progress-bar-top-offset: 0;
         -progress-bar-valign: 0.95;
     }
+}
+
+#overview .grid-search-results .overview-tile .progress-bar,
+#overview .app-folder-dialog .progress-bar {
+    -progress-bar-height-factor: 0.13;
 }
 
 #dashtodockContainer.top #dash .placeholder,

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -426,7 +426,7 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
 .apps-scroll-view {
     .progress-bar {
         -progress-bar-top-offset: 0;
-        -progress-bar-valign: 0.8;
+        -progress-bar-valign: 0.95;
     }
 }
 

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -1003,13 +1003,17 @@ export class UnityIndicator extends IndicatorBase {
         y = readThemeValue('top-offset') ?? y;
 
         const baseLineWidth = Math.floor(Number(scaleFactor));
-        const padding = Math.floor(iconSize * 0.05);
-        let width = iconSize - 2.0 * padding;
+        const horizontalPadding = iconSize *
+            Utils.clampDouble(readThemeValue('horizontal-padding') ?? 0.05);
+        const verticalPadding = iconSize *
+            Utils.clampDouble(readThemeValue('vertical-padding') ?? 0.05);
+
+        let width = iconSize - 2.0 * horizontalPadding;
         let height = Math.floor(Math.min(18.0 * scaleFactor, 0.20 * iconSize));
-        x += padding;
+        x += horizontalPadding;
 
         const valign = Utils.clampDouble(readThemeValue('valign') ?? 1);
-        y += (iconSize - height - padding) * valign;
+        y += (iconSize - height - verticalPadding) * valign;
 
         const progressBarTrack = this._readElementData(node,
             '-progress-bar-track',

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -1007,9 +1007,11 @@ export class UnityIndicator extends IndicatorBase {
             Utils.clampDouble(readThemeValue('horizontal-padding') ?? 0.05);
         const verticalPadding = iconSize *
             Utils.clampDouble(readThemeValue('vertical-padding') ?? 0.05);
+        const heightFactor =
+            Utils.clampDouble(readThemeValue('height-factor') ?? 0.20);
 
         let width = iconSize - 2.0 * horizontalPadding;
-        let height = Math.floor(Math.min(18.0 * scaleFactor, 0.20 * iconSize));
+        let height = Math.floor(Math.min(18.0 * scaleFactor, heightFactor * iconSize));
         x += horizontalPadding;
 
         const valign = Utils.clampDouble(readThemeValue('valign') ?? 1);

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -1009,8 +1009,7 @@ export class UnityIndicator extends IndicatorBase {
             '-progress-bar-valign', false);
         const [hasValign] = valignParameters;
         let [, valign] = valignParameters;
-        if (!hasValign)
-            valign = 1.0;
+        valign = Utils.clampDouble(hasValign ? valign : 1);
         y += (iconSize - height - padding) * valign;
 
         const progressBarTrack = this._readElementData(node,

--- a/appIcons.js
+++ b/appIcons.js
@@ -751,7 +751,7 @@ const DockAbstractAppIcon = GObject.registerClass({
         if (this.updating) {
             const icon = Gio.Icon.new_for_string('action-unavailable-symbolic');
             Main.osdWindowManager.show(-1, icon,
-                _('%s is currently updating, cannot launch it!').format(this.name),
+                _('%s is updating, try again later').format(this.name),
                 null);
             return;
         }
@@ -1079,7 +1079,7 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
         this.removeAll();
 
         const appItemLabel = this.sourceActor.updating
-            ? _('%s is being updated...').format(this.sourceActor.name)
+            ? _('%s is being updated…').format(this.sourceActor.name)
             : this.sourceActor.name;
         this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem(appItemLabel));
 

--- a/appIconsDecorator.js
+++ b/appIconsDecorator.js
@@ -102,7 +102,7 @@ export class AppIconsDecorator {
                 if (this.updating) {
                     const icon = Gio.Icon.new_for_string('action-unavailable-symbolic');
                     Main.osdWindowManager.show(-1, icon,
-                        _('%s is currently updating, cannot launch it!').format(this.name),
+                        _('%s is updating, try again later').format(this.name),
                         null);
                     return;
                 }

--- a/utils.js
+++ b/utils.js
@@ -730,3 +730,6 @@ export function addActor(element, actor) {
     else
         element.add_child(actor);
 }
+
+export const clamp = (v, m, M) => Math.min(Math.max(v, m), M);
+export const clampDouble = v => clamp(v, 0, 1);


### PR DESCRIPTION
Move progress bar on icon baseline on overview and permit tuning their positioning and size better via style variables.

This is following the upstream theme, while for yaru some further customization will be done