### PR TITLE
appIcons: Show app details menu for snap applications

### DIFF
--- a/appIconsDecorator.js
+++ b/appIconsDecorator.js
@@ -145,10 +145,14 @@ export class AppIconsDecorator {
                 if (this.isEmpty())
                     return;
 
-                // Temporarily hide all the menu items a part the Pinning one
-                // while we're updating.
+                // Temporarily hide all the menu items a part the Pinning and
+                // the details one while we're updating.
+                const validItems = [
+                    this._toggleFavoriteItem,
+                    this._detailsItem,
+                ];
                 const items = this._getMenuItems().filter(
-                    i => i !== this._toggleFavoriteItem).map(i =>
+                    i => !validItems.includes(i)).map(i =>
                     i instanceof PopupMenu.PopupMenuBase ? i.actor : i);
                 const itemsVisibility = items.map(i => i.visible);
                 items.forEach(i => (i.visible = false));


### PR DESCRIPTION
If an application is a snap package, and the snap store is installed we can show the snap packages details as we do for other non-snap applications if GNOME Software is installed

UDENG-4316
UDENG-4700