### PR TITLE
locations: handle lack of dock manager in GetApps()

### DIFF
--- a/locations.js
+++ b/locations.js
@@ -1486,12 +1486,13 @@ function getApps() {
     const dockManager = Docking.DockManager.getDefault();
     const locationApps = [];
 
-    if (dockManager.removables)
-        locationApps.push(...dockManager.removables.getApps());
+    if (dockManager) {
+        if (dockManager.removables)
+            locationApps.push(...dockManager.removables.getApps());
 
-    if (dockManager.trash)
-        locationApps.push(dockManager.trash.getApp());
-
+        if (dockManager.trash)
+            locationApps.push(dockManager.trash.getApp());
+    }
     return locationApps;
 }
 


### PR DESCRIPTION
This method may be called in situations where there is no dock manager, so handle it gracefully, rather than letting an exception propagate.

In some situations, this method may end up getting called in the context of another extension and the un-caught exception can terminate that extension.