### PR TITLE
theming: Give Clutter.Color priority over Cogl.Color

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -359,7 +359,7 @@ class RunningIndicatorDots extends RunningIndicatorBase {
         const {settings} = Docking.DockManager;
         if (!settings.applyCustomTheme) {
             // Adjust for the backlit case
-            const Color = Cogl.Color ?? Clutter.Color;
+            const Color = Clutter.Color ?? Cogl.Color;
 
             if (settings.unityBacklitItems) {
                 // Use dominant color for dots too if the backlit is enables

--- a/theming.js
+++ b/theming.js
@@ -169,7 +169,7 @@ export class ThemeManager {
 
             ({backgroundColor} = settings);
             // backgroundColor is a string like rgb(0,0,0)
-            const Color = Cogl.Color ?? Clutter.Color;
+            const Color = Clutter.Color ?? Cogl.Color;
             const [ret, color] = Color.from_string(backgroundColor);
             if (!ret) {
                 logError(new Error(`${backgroundColor} is not a valid color string`));


### PR DESCRIPTION
While now there's only Cogl.Color, in previous versions we had both so giving Cogl priority broke the theming support

Closes: #2307