### PR TITLE
utils: Use an extra parameter for property injector constructor

### DIFF
--- a/appIconsDecorator.js
+++ b/appIconsDecorator.js
@@ -27,7 +27,8 @@ export class AppIconsDecorator {
     constructor() {
         this._signals = new Utils.GlobalSignalsHandler();
         this._methodInjections = new Utils.InjectionsHandler();
-        this._propertyInjections = new Utils.PropertyInjectionsHandler({allowNewProperty: true});
+        this._propertyInjections = new Utils.PropertyInjectionsHandler(
+            null, {allowNewProperty: true});
         this._indicators = new Set();
 
         this._patchAppIcons();

--- a/utils.js
+++ b/utils.js
@@ -412,8 +412,8 @@ export class VFuncInjectionsHandler extends BasicHandler {
  * and restored
  */
 export class PropertyInjectionsHandler extends BasicHandler {
-    constructor(params) {
-        super();
+    constructor(parentObject, params) {
+        super(parentObject);
         this._params = params;
     }
 


### PR DESCRIPTION
By adding parameters in commit 611690cc33 we ended up hiding the base object constructor parameter, and so the support for automatic disconnection on parent object destruction.

Fixes: #2297