### PR TITLE
Fix dot position on Gnome 46.2 and greater

### DIFF
--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -272,7 +272,7 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
 
 .dash-item-container .overview-tile .app-grid-running-dot {
     margin-bottom: $dash_padding_gnome - 4px;
-    //offset-y: -$dash_padding + $dash_edge_offset;
+    offset-y: -$dash_padding + $dash_edge_offset;
 }
 
 @each $side in $dock_sides {

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -22,6 +22,8 @@ $dash_padding: $base_padding*2; // 12px
 $dash_border_radius: $modal_radius + $dash_padding;
 $dash_padding_gnome: $dash_padding;
 
+$dash_edge_offset: $base_margin * 3;
+
 // Dash to dock specifics
 $dash_padding: $base_padding + 4px; // 10px
 $dash_border_radius: $modal_radius * 1.5;
@@ -270,6 +272,7 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
 
 .dash-item-container .overview-tile .app-grid-running-dot {
     margin-bottom: $dash_padding_gnome - 4px;
+    //offset-y: -$dash_padding + $dash_edge_offset;
 }
 
 @each $side in $dock_sides {


### PR DESCRIPTION
This patch fixes the dot in Default mode when not enabling "Few customizations".

Tested in Ubuntu Noble, Fedora 46 (100% and 200% scale), and Ubuntu Oracular (both in Ubuntu Desktop and Classic Gnome sessions).

Fix: #2222 