### PR TITLE
Make the 'Pin to Dock' label translatable

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -1180,7 +1180,7 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
                         favs.removeFavorite(app.get_id());
                     });
                 } else {
-                    const item = this._appendMenuItem(_('Pin to Dock'));
+                    const item = this._appendMenuItem(__('Pin to Dock'));
                     item.connect('activate', () => {
                         const favs = AppFavorites.getAppFavorites();
                         favs.addFavorite(app.get_id());


### PR DESCRIPTION
With the single underscore (_) we can re-use original translation.   
However, for the 'Pin to Dock' there's no match since GNOME 42-47 original label is 'Pin to Dash'.   
Using two underscores (__) as a translation function resolves #2330 