### PR TITLE
CSS: fix syntax style

### DIFF
--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -139,8 +139,8 @@ $dock_icons_distance: 4px;
     }
 }
 
-$dock_sides: [bottom, top, left, right];
-$dock_style_modes: [null, shrink, extended, extended-shrink];
+$dock_sides: bottom, top, left, right;
+$dock_style_modes: null, shrink, extended, extended-shrink;
 
 @mixin dock-container-style($side, $style_mode, $parameters) {
     $style_selector: '';


### PR DESCRIPTION
The SASS documentation specifies that a list of elements for the @each statement should be defined without square brackets, but there are two definitions in the .scss file that uses them. This patch fixes it.

source: https://sass-lang.com/documentation/at-rules/control/each/