### PR TITLE
Fix autohide after drag event

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1265,6 +1265,7 @@ const DockedDash = GObject.registerClass({
             this._ignoreHover = this._oldIgnoreHover;
         this._oldIgnoreHover = null;
         this._box.sync_hover();
+        this._updateDashVisibility();
     }
 
     /**


### PR DESCRIPTION
Issue: When starting a drag event while the dock is overlapping (e.g., when a window is maximized) and intelligent autohide is enabled, the dock fails to hide after the drag event ends.
This pull request invokes `_updateDashVisibility` after the drag event concludes to ensure the dock's state is correctly updated.

Fix: #2174 