### PR TITLE
Fixing 'Pin to Dock' translation in GNOME list of applications menu

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -40,6 +40,12 @@ import {
     Utils,
 } from './imports.js';
 
+import {Extension} from './dependencies/shell/extensions/extension.js';
+
+// Use __ () and N__() for the extension gettext domain, and reuse
+// the shell domain with the default _() and N_()
+const {gettext: __, ngettext} = Extension;
+
 const {signals: Signals} = imports;
 
 const DOCK_DWELL_CHECK_INTERVAL = 100;
@@ -2521,7 +2527,7 @@ export class DockManager {
 
                 const {id} = this._app;
                 this._toggleFavoriteItem.label.text = this._appFavorites.isFavorite(id)
-                    ? _('Unpin') : _('Pin to Dock');
+                    ? _('Unpin') : __('Pin to Dock');
                 /* eslint-enable no-invalid-this */
             });
     }


### PR DESCRIPTION
In pull request #2331 you fixed the 'Pin to Dock' translation in [appIcons.js](https://github.com/micheleg/dash-to-dock/blob/master/appIcons.js) but you forgot that the same translation is used also in [docking.js](https://github.com/micheleg/dash-to-dock/blob/master/docking.js).

I changed the `_` shell translation function to the `__` extension function and added the needed imports.

Now in the GNOME list of applications, the correct translation for 'Pin to Dock' is picked up for the languages that provide it. Previously it was working only in the Dock context menu.