### PR TITLE
Add dock margin size customization feature

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -779,6 +779,46 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkListBoxRow" id="dock_margin_size_listboxrow">
+                        <property name="child">
+                          <object class="GtkGrid" id="dock_margin_size_grid">
+                            <property name="can_focus">0</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <property name="column_spacing">32</property>
+                            <child>
+                              <object class="GtkLabel" id="dock_margin_size_label">
+                                <property name="can_focus">0</property>
+                                <property name="label" translatable="yes">Dock margin size</property>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkScale" id="dock_margin_size_scale">
+                                <property name="draw-value">1</property>
+                                <property name="valign">baseline</property>
+                                <property name="hexpand">1</property>
+                                <property name="adjustment">dock_margin_size_adjustment</property>
+                                <property name="round_digits">0</property>
+                                <property name="digits">0</property>
+                                <property name="value_pos">right</property>
+                                <signal name="value-changed" handler="dock_margin_size_value_changed_cb" />
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkListBoxRow" id="icon_size_listboxrow">
                         <property name="child">
                           <object class="GtkGrid" id="icon_size_grid">
@@ -2071,7 +2111,6 @@
                                           <item translatable="yes">Ciliora</item>
                                           <item translatable="yes">Metro</item>
                                           <item translatable="yes">Binary</item>
-                                          <item translatable="yes">Dot</item>
                                         </items>
                                       </object>
                                     </child>
@@ -2401,6 +2440,12 @@ See the &lt;a href=&quot;https://www.gnu.org/licenses/old-licenses/gpl-2.0.html&
       </object>
     </child>
   </object>
+  <object class="GtkAdjustment" id="dock_margin_size_adjustment">
+  <property name="lower">0</property>
+  <property name="upper">300</property>
+  <property name="step-increment">1</property>
+  <property name="page-increment">10</property>
+</object>
   <object class="GtkAdjustment" id="max_opacity_adjustement">
     <property name="upper">1</property>
     <property name="step-increment">0.01</property>

--- a/Settings.ui
+++ b/Settings.ui
@@ -2111,6 +2111,7 @@
                                           <item translatable="yes">Ciliora</item>
                                           <item translatable="yes">Metro</item>
                                           <item translatable="yes">Binary</item>
+                                          <item translatable="yes">Dot</item>
                                         </items>
                                       </object>
                                     </child>

--- a/Settings.ui
+++ b/Settings.ui
@@ -807,7 +807,6 @@
                                 <property name="round_digits">0</property>
                                 <property name="digits">0</property>
                                 <property name="value_pos">right</property>
-                                <signal name="value-changed" handler="dock_margin_size_value_changed_cb" />
                                 <layout>
                                   <property name="column">1</property>
                                   <property name="row">0</property>

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -352,6 +352,14 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
     border-radius: 0px;
 }
 
+#dashtodockContainer.extended.dock-margin #dash .dash-background {
+    border-radius: $dash_border_radius;
+}
+
+#dashtodockContainer.extended.shrink.dock-margin #dash .dash-background {
+    border-radius: shrink_light($dash_border_radius);
+}
+
 /* Scrollview style */
 .bottom #dashtodockDashScrollview,
 .top #dashtodockDashScrollview {

--- a/docking.js
+++ b/docking.js
@@ -538,6 +538,11 @@ const DockedDash = GObject.registerClass({
                 this.dash.setIconSize(settings.dashMaxIconSize);
             },
         ], [
+            settings, 
+            "changed::dock-margin-size", 
+            this._resetPosition.bind(this)
+
+        ], [
             settings,
             'changed::show-favorites',
             () => {
@@ -1168,7 +1173,7 @@ const DockedDash = GObject.registerClass({
         // Ensure variables linked to settings are updated.
         this._updateVisibilityMode();
 
-        const {dockFixed: fixedIsEnabled, dockExtended: extendHeight} = DockManager.settings;
+        const {dockFixed: fixedIsEnabled, dockExtended: extendHeight, dockMarginSize: margin} = DockManager.settings;
 
         if (fixedIsEnabled)
             this.add_style_class_name('fixed');
@@ -1197,7 +1202,7 @@ const DockedDash = GObject.registerClass({
             this.y = posY;
 
             if (extendHeight) {
-                this.dash._container.set_width(this.width);
+                this.dash._container.set_width(this.width - margin * 2);
                 this.add_style_class_name('extended');
             } else {
                 this.dash._container.set_width(-1);
@@ -1214,7 +1219,7 @@ const DockedDash = GObject.registerClass({
             this.y = workArea.y + Math.round((1 - fraction) / 2 * workArea.height);
 
             if (extendHeight) {
-                this.dash._container.set_height(this.height);
+                this.dash._container.set_height(this.height - margin * 2);
                 this.add_style_class_name('extended');
             } else {
                 this.dash._container.set_height(-1);

--- a/docking.js
+++ b/docking.js
@@ -541,7 +541,6 @@ const DockedDash = GObject.registerClass({
             settings, 
             "changed::dock-margin-size", 
             this._resetPosition.bind(this)
-
         ], [
             settings,
             'changed::show-favorites',
@@ -1226,6 +1225,11 @@ const DockedDash = GObject.registerClass({
                 this.remove_style_class_name('extended');
             }
         }
+
+        if (margin > 0)
+            this.add_style_class_name('dock-margin');
+        else
+            this.remove_style_class_name('dock-margin');
     }
 
     _updateVisibleDesktop() {

--- a/prefs.js
+++ b/prefs.js
@@ -285,14 +285,6 @@ const DockSettings = GObject.registerClass({
             });
     }
 
-    dock_margin_size_value_changed_cb(scale) {
-        // Get the current value of the scale
-        const value = scale.get_value();
-  
-        // Update the GSettings key
-        this._settings.set_int("dock-margin-size", value);
-      }
-
     icon_size_scale_value_changed_cb(scale) {
         // Avoid settings the size consinuosly
         if (this._icon_size_timeout > 0)
@@ -595,26 +587,18 @@ const DockSettings = GObject.registerClass({
         });
         this._builder.get_object('preview_size_scale').set_value(
             this._settings.get_double('preview-size-scale'));
-        
 
         // Dock Margin Size
         const dockMarginSizeScale = this._builder.get_object(
             "dock_margin_size_scale"
         );
-        dockMarginSizeScale.set_range(0, 300); // Set the range for the margin size
-        dockMarginSizeScale.set_value(this._settings.get_int("dock-margin-size")); // Initialize with the current value
         dockMarginSizeScale.set_format_value_func((_, value) => {
             return `${value} px`; // Display the value in pixels
         });
 
-        dockMarginSizeScale.connect("value-changed", (scale) => {
-            // Update the GSettings key when the value changes
-            this._settings.set_int("dock-margin-size", scale.get_value());
-        });
-
         this._settings.bind(
             "dock-margin-size",
-            dockMarginSizeScale,
+            this._builder.get_object("dock_margin_size_adjustment"),
             "value",
             Gio.SettingsBindFlags.DEFAULT
         );

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -317,6 +317,11 @@
       <default>false</default>
       <summary>Center icons when dock container is extended to all the available size</summary>
     </key>
+    <key name="dock-margin-size" type="i">
+      <default>0</default>
+      <summary>Dock margin size</summary>
+      <description>The margin size around the dock in pixels.</description>
+    </key>
     <key type="i" name="preferred-monitor">
       <default>-2</default>
       <summary>DEPRECATED: Monitor on which putting the dock (by index)</summary>


### PR DESCRIPTION
### Description

I added a feature to customize the dock margin size when panel mode is enabled. This feature introduces a slider in the settings, allowing users to adjust the margin from the edge of the screen (default: 0px) up to 300px.

This is particularly useful for setups with differently sized monitors, where getting a consistent amount of space from the edge of the screen can be difficult without access to dynamic units (e.g. vw, %, etc.)
![dock-margin-demonstration](https://github.com/user-attachments/assets/d7f042bb-35b6-4594-8583-3f119146782b)

### Implementation Details

Added a new GSettings key ([dock-margin-size](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)) to store the margin value.
Updated the settings UI ([Settings.ui](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)) to include a slider for margin adjustment.
Modified the dock positioning logic in [docking.js](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to respect the margin value.
Bound the slider to the GSettings key in [prefs.js](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).

### Testing

Tested on GNOME Shell 46 with a dual-monitor setup. (1920x1080 and 3440x1440)
Verified that the margin applies correctly in panel mode, both vertically and horizontally.
Confirmed that the default behavior (0px margin) remains unchanged.

#### Sidenote
This is my first contribution to anything open-source, so feedback is very welcome. If you'd like me to change anything, please let me know.