### PR TITLE
Correct German translation of threshold

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -743,7 +743,7 @@ msgstr "Einblende-Verzögerung in s"
 
 #: Settings.ui.h:131
 msgid "Pressure threshold"
-msgstr "Stoßschwellwert"
+msgstr "Stoßschwellenwert"
 
 #~ msgid "Remove from Favorites"
 #~ msgstr "Aus Favoriten entfernen"


### PR DESCRIPTION
Fixes a funny translation.

- Schwellwert = value that relates to a swelling
- Schwellenwert = value that relates to a threshold

## Resources

- [Duden: Schwellenwert](https://www.duden.de/suchen/dudenonline/Schwellenwert)
- [LEO: Schwellenwert](https://dict.leo.org/german-english/Schwellenwert)
- [LEO: Threshold](https://dict.leo.org/german-english/Threshold)
- [LEO: Schwellung](https://dict.leo.org/german-english/Schwellung)