### PR TITLE
Feature: Put Location Apps In its Separate Section

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -946,7 +946,12 @@ export const DockDash = GObject.registerClass({
                 pos++;
             const removedFavorites = removedActors.filter(a =>
                 children.indexOf(a) < oldSeparatorPos);
-            pos += removedFavorites.length;
+
+            // Workaround: when a favorite app (running) located exactly one slot above the separator
+            // is unpinned, its icon does not automatically move below the separator.
+            // Fixes issue: https://github.com/micheleg/dash-to-dock/issues/2445
+            if (!removedFavorites.some(a => oldSeparatorPos - children.indexOf(a) === 1))
+                pos += removedFavorites.length;
             this._box.insert_child_at_index(this._separator, pos);
         } else if (this._separator) {
             this._separator.destroy();

--- a/locations.js
+++ b/locations.js
@@ -1118,6 +1118,7 @@ function makeLocationApp(params) {
     shellApp._setDtdData({
         location: () => shellApp.appInfo.location,
         isTrash: shellApp.appInfo instanceof TrashAppInfo,
+        isMountableVolume: shellApp.appInfo instanceof MountableVolumeAppInfo,
     }, {getter: true, enumerable: true});
 
     shellApp._mi('toString', defaultToString =>


### PR DESCRIPTION
- [x] Fix unpinned favorites not moving below the separator:
When a favorite app (running) located 1 slot above the separator is unpinned, its icon was not repositioned correctly below the separator. This patch adds a workaround to ensure the position updates as expected.

closes: https://github.com/micheleg/dash-to-dock/issues/2445

- [x] Implement location apps separate section:
Any location app opened or preset (e.g trash bin, network volume) will be placed into a separate section. If there are not opened normal apps, the dedicated separator will disappear. The location apps will not move when opened or close just like in the favorites section.

closes: https://github.com/micheleg/dash-to-dock/issues/2443

[Screencast From 2025-09-21 20-07-34.webm](https://github.com/user-attachments/assets/75e3ef3f-c48a-49ad-a71e-12603dbc09f2)
