### PR TITLE
GitHub pages: Correct a typo in `_includes/default_footer.html`

### DIFF
--- a/_includes/default_footer.html
+++ b/_includes/default_footer.html
@@ -9,7 +9,7 @@
       </p>
     </div>
     <p>Source code on <a href="https://github.com/micheleg/dash-to-dock">GitHub</a>.</p>
-    <p>Dash to Dock exists in the first place to suit my own needs. However, it might be usefull to you too. This software is distributed under the terms of the <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html">GNU General Public License, version 2 or later</a>.</p>
+    <p>Dash to Dock exists in the first place to suit my own needs. However, it might be useful to you too. This software is distributed under the terms of the <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html">GNU General Public License, version 2 or later</a>.</p>
   </div>
 </footer>
 


### PR DESCRIPTION
Personal notes: [Benjamin_Loison/dash-to-dock/issues/9](https://codeberg.org/Benjamin_Loison/dash-to-dock/issues/9)