### PR TITLE
Reimplement Clutter.Color.Shade in RunningIndicatorMetro

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -625,8 +625,10 @@ class RunningIndicatorMetro extends RunningIndicatorDots {
                 const blackenedLength = (1 / 48) * this._width;
                 const darkenedLength = this._source.focused
                     ? (2 / 48) * this._width : (10 / 48) * this._width;
-                const blackenedColor = this._bodyColor.shade(.3);
-                const darkenedColor = this._bodyColor.shade(.7);
+                const [h,s,l] = this._bodyColor.to_hsl();
+                const blackenedColor = Cogl.Color.init_from_hsl(h, s*0.3, l*0.3);
+                const darkenedColor = Cogl.Color.init_from_hsl(h, s*0.7, l*0.7);
+
 
                 cr.translate(0, yOffset);
 


### PR DESCRIPTION
Fixes #2461. 

It seems that the `_bodyColor` returned by `get_theme_node` is now `Cogl.Color` rather than `Clutter.Color`. 

This PR re-implements [the functionality of `Clutter.Color.shade`](https://github.com/ebassi/clutter/blob/1227f7c489e838c963aaf76328d4b381c51f9fe1/clutter/clutter-color.c#L376-L392) to define `blackenedColor` and `darkenedColor` as before.

Tested without issues on GNOME 49.2.