### PR TITLE
metadata.json: Declare support for GNOME 50

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
     "46",
     "47",
     "48",
-    "49"
+    "49",
+    "50"
 ],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",


### PR DESCRIPTION
50.alpha is coming soon and it seems to work well enough to declare support. This has to be done before Ubuntu gets GNOME 50.alpha.