### PR TITLE
Implementing #1029, icons now bounce if toggled to do so in preferences.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ BASE_MODULES = extension.js \
 
 EXTRA_MODULES = \
                 appSpread.js \
+                bounceAnimation.js \
                 dash.js \
                 docking.js \
                 appIcons.js \

--- a/Settings.ui
+++ b/Settings.ui
@@ -1358,6 +1358,43 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkListBoxRow" id="bounce_icons_row">
+                        <property name="child">
+                          <object class="GtkGrid">
+                            <property name="can_focus">0</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <property name="column_spacing">32</property>
+                            <child>
+                              <object class="GtkSwitch" id="bounce_icons_switch">
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="can_focus">0</property>
+                                <property name="hexpand">1</property>
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">Icons bounce when launching?</property>
+
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkListBoxRow" id="hide_tooltip_row">
                         <property name="child">
                           <object class="GtkGrid">

--- a/bounceAnimation.js
+++ b/bounceAnimation.js
@@ -1,0 +1,220 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+import {
+    Clutter,
+    GLib,
+} from './dependencies/gi.js';
+
+import {
+    Main,
+} from './dependencies/shell/ui.js';
+import {
+    St,
+} from './dependencies/gi.js';
+
+/**
+ * Performs a bouncing animation on an icon
+ * @param {Clutter.Actor} icon - The icon to animate
+ */
+export function startBounceAnimation(icon) {
+    if (!icon) {
+        return;
+    }
+
+    const BOUNCE_HEIGHT = 18;
+    const BOUNCE_DURATION = 260;
+    let running = true;
+    let bounceCount = 0;
+    const MAX_BOUNCES = 5;
+
+    const wasReactive = icon.reactive;
+    icon.reactive = false;
+
+    icon.set_pivot_point(0.5, 0.5);
+
+    let placeholder = null;
+    let target = icon;
+    let originalParent = icon.get_parent();
+    let originalParentIndex = -1;
+    let placeholderConnId = 0;
+    let placeholderConnActor = null;
+    let hasCompletedOneBounce = false;
+    let shouldStop = false;
+
+    try {
+        const [gx, gy] = icon.get_transformed_position();
+        const [gw, gh] = icon.get_transformed_size();
+
+        // create placeholder to hold the icon's position in the dock
+        placeholder = new St.Bin();
+        placeholder.set_size(Math.max(1, Math.round(gw)), Math.max(1, Math.round(gh)));
+        placeholder.set_pivot_point(0.5, 0.5);
+
+        // get the icon's index in parent before reparenting
+        if (originalParent) {
+            const children = originalParent.get_children();
+            originalParentIndex = children.indexOf(icon);
+
+            // insert placeholder at the same position
+            if (originalParentIndex >= 0) {
+                originalParent.insert_child_at_index(placeholder, originalParentIndex);
+            } else {
+                originalParent.add_child(placeholder);
+            }
+
+            // listen to placeholder allocation changes to track dock reflows
+            try {
+                placeholderConnActor = placeholder;
+                placeholderConnId = placeholder.connect('allocation-changed', () => {
+                    try {
+                        const [px, py] = placeholder.get_transformed_position();
+                        const [currentX, currentY] = icon.get_position();
+                        // sync icon position to follow placeholder when dock layout changes
+                        icon.set_position(Math.round(px), currentY);
+                    } catch (e) { /* ignore */ }
+                });
+            } catch (e) { /* ignore */ }
+        }
+
+        // reparent icon to Main.uiGroup for animation
+        if (originalParent) {
+            originalParent.remove_child(icon);
+        }
+        icon.set_position(Math.round(gx), Math.round(gy));
+        Main.uiGroup.add_child(icon);
+        target = icon;
+    } catch (e) {
+        placeholder = null;
+        target = icon;
+    }
+
+    function syncPositionToPlaceholder() {
+        if (!running || !placeholder || !icon || !originalParent) return;
+        try {
+            const [px, py] = placeholder.get_transformed_position();
+            const [currentX, currentY] = icon.get_position();
+            // sync icon x position to follow placeholder when dock layout changes
+            icon.set_position(Math.round(px), currentY);
+        } catch (e) { /* ignore */ }
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 16, () => { syncPositionToPlaceholder(); return GLib.SOURCE_REMOVE; });
+    }
+
+    function step() {
+        if (!running) return;
+        bounceCount++;
+        try { target.remove_all_transitions(); } catch (e) { /* ignore */ }
+        target.ease({
+            translation_y: -BOUNCE_HEIGHT,
+            scale_y: 1.08,
+            duration: Math.floor(BOUNCE_DURATION / 2),
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+            onComplete: () => {
+                if (!running) return;
+                target.ease({
+                    translation_y: 0,
+                    scale_y: 1.0,
+                    duration: Math.floor(BOUNCE_DURATION / 2),
+                    mode: Clutter.AnimationMode.EASE_IN_QUAD,
+                    onComplete: () => {
+                        if (!running) return;
+                        // Mark that we've completed at least one bounce
+                        hasCompletedOneBounce = true;
+
+                        // If stop was requested while bouncing, honor it now
+                        if (shouldStop) {
+                            running = false;
+                            handle.isActive = false;
+                            cleanup();
+                            return;
+                        }
+
+                        if (bounceCount >= MAX_BOUNCES) {
+                            running = false;
+                            handle.isActive = false;
+                            cleanup();
+                            return;
+                        }
+                        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 80, () => { step(); return GLib.SOURCE_REMOVE; });
+                    },
+                });
+            },
+        });
+    }
+
+    function cleanup() {
+        try {
+            running = false;
+            // disconnect placeholder allocation listener
+            if (placeholderConnActor && placeholderConnId) {
+                try { placeholderConnActor.disconnect(placeholderConnId); } catch (e) { /* ignore */ }
+                placeholderConnActor = null;
+                placeholderConnId = 0;
+            }
+            // remove placeholder from dock
+            if (placeholder) {
+                try {
+                    const parent = placeholder.get_parent();
+                    if (parent) {
+                        parent.remove_child(placeholder);
+                    }
+                } catch (e) { /* ignore */ }
+                placeholder = null;
+            }
+            // reparent icon back to original parent
+            if (originalParent && icon) {
+                try {
+                    // ensure icon is removed from Main.uiGroup first
+                    if (Main.uiGroup.contains(icon)) {
+                        Main.uiGroup.remove_child(icon);
+                    }
+                    // reparent back to original location
+                    if (originalParentIndex >= 0 && originalParentIndex < originalParent.get_n_children()) {
+                        originalParent.insert_child_at_index(icon, originalParentIndex);
+                    } else {
+                        originalParent.add_child(icon);
+                    }
+                } catch (e) {
+                    // ignore
+                }
+                originalParent = null;
+            }
+            // always restore icon reactivity, regardless of reparent success
+            if (icon) {
+                try {
+                    icon.reactive = wasReactive;
+                } catch (e) {
+                    // ignore
+                }
+            }
+        } catch (e) { /* ignore */ }
+    }
+
+    step();
+    syncPositionToPlaceholder();
+
+    const handle = {
+        isActive: true,
+        stop() {
+            // If we haven't completed one bounce yet, mark that we should stop after the first completes
+            if (!hasCompletedOneBounce) {
+                shouldStop = true;
+                return;
+            }
+            // We've completed at least one bounce, so stop immediately
+            running = false;
+            handle.isActive = false;
+            try { target.remove_all_transitions(); } catch (e) { /* ignore */ }
+            try {
+                target.ease({
+                    translation_y: 0,
+                    scale_y: 1.0,
+                    duration: 120,
+                    mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+                    onComplete: () => { cleanup(); }
+                });
+            } catch (e) { cleanup(); }
+        }
+    };
+
+    return handle;
+}

--- a/docking.js
+++ b/docking.js
@@ -575,6 +575,11 @@ const DockedDash = GObject.registerClass({
             Utils.SignalsHandlerFlags.CONNECT_AFTER,
         ], [
             settings,
+            'changed::bounce-icons',
+            () => this.dash.resetAppIcons(),
+            Utils.SignalsHandlerFlags.CONNECT_AFTER,
+        ], [
+            settings,
             'changed::show-running',
             () => {
                 this.dash.resetAppIcons();

--- a/imports.js
+++ b/imports.js
@@ -2,6 +2,7 @@ export * as AppIconIndicators from './appIconIndicators.js';
 export * as AppIcons from './appIcons.js';
 export * as AppIconsDecorator from './appIconsDecorator.js';
 export * as AppSpread from './appSpread.js';
+export * as BounceAnimation from './bounceAnimation.js';
 export * as DockDash from './dash.js';
 export * as DBusMenuUtils from './dbusmenuUtils.js';
 export * as DesktopIconsIntegration from './desktopIconsIntegration.js';

--- a/prefs.js
+++ b/prefs.js
@@ -706,6 +706,10 @@ const DockSettings = GObject.registerClass({
             this._builder.get_object('wiggle_urgent_applications_switch'),
             'active',
             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('bounce-icons',
+            this._builder.get_object('bounce_icons_switch'),
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('hide-tooltip',
             this._builder.get_object('hide_tooltip_switch'),
             'active',

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -286,6 +286,11 @@
       <summary>Wiggle urgent applications</summary>
       <description>Wiggle urgent application icons in the dash</description>
     </key>
+    <key type="b" name="bounce-icons">
+      <default>true</default>
+      <summary>Bounce icons when launching</summary>
+      <description>Bounce icons when launching applications</description>
+    </key>
     <key type="b" name="show-show-apps-button">
       <default>true</default>
       <summary>Show applications button</summary>


### PR DESCRIPTION
**DISCLAIMER**: I used GitHub Copilot to help implement this feature.  If this is not allowed or not wanted, please close this PR without merging and I will rewrite the logic myself and re-submit at a later date.

This PR implements the enhancement request in [#1029](https://github.com/micheleg/dash-to-dock/issues/1029).

**Features implemented**:
- Toggle preference for "Icons bounce when launching?" (Needs localization)
- When enabled, upon clicking an application icon that has no launched windows, the icon will bounce a minimum of 1 time and a maximum of 5 times.  If it is able to detect the application target is RUNNING, it will ease out the bounce back to the original location and will not perform another bounce.
- When disabled, the icons do not bounce.