### PR TITLE
fix: add null check in setUrgent and setUpdating methods

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -1096,7 +1096,7 @@ export class UnityIndicator extends IndicatorBase {
     }
 
     setUrgent(urgent) {
-        if (urgent || this._isUrgent !== undefined)
+        if (this._source && (urgent || this._isUrgent !== undefined))
             this._source.urgent = urgent;
 
         if (urgent)
@@ -1106,7 +1106,8 @@ export class UnityIndicator extends IndicatorBase {
     }
 
     setUpdating(updating) {
-        this._source.updating = updating;
+        if (this._source)
+            this._source.updating = updating;
     }
 
     _updateIconStyle() {


### PR DESCRIPTION
## Summary
- Adds null checks to prevent accessing `this._source` after it's been set to null
- Fixes race condition during cleanup when exiting activities pane
- Prevents JavaScript error: "can't access property 'updating', this._source is null"

## Fixes
Closes #2482

## Changes
Modified `setUrgent()` and `setUpdating()` methods in `appIconIndicators.js` to check if `this._source` is null before accessing it. This handles the case where these methods are called during the destroy sequence after the parent class has already nulled the source.

## Test plan
- Open GNOME Shell with dash-to-dock enabled
- Open activities pane
- Exit activities pane
- Verify no JavaScript errors are logged
- Check that icon indicators still function normally during normal operation