### PR TITLE
fix: correct French translation typo in Unity API description

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -441,7 +441,7 @@ msgid ""
 "bars (if Unity API is used)."
 msgstr ""
 "Si activé, les icônes d’application afficheront des compteurs de "
-"notification et des barres de progression (si l’API Unity est utilsée)."
+"notification et des barres de progression (si l'API Unity est utilisée)."
 
 #: Settings.ui.h:63
 msgid "Show the number of unread notifications"


### PR DESCRIPTION
## Summary
- Fixes a typo in the French translation file
- Changes "utilsée" to "utilisée" in the Unity API description

## Details
The French translation for the Unity API notification counter feature had a missing letter "i" in the word "utilsée", which should be "utilisée".

## Testing
- Verified the correction in po/fr.po
- Single character fix with no functional impact

Fixes #2480