### PR TITLE
stylesheet: fix show-apps icon gap inconsistency

### DIFF
--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -195,6 +195,11 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
                 padding-#{$side}: 0;
                 padding-#{opposite($side)}: 0;
 
+                > #dashtodockDashScrollview {
+                    @include set-internal-children-property($side, margin,
+                        0, $dock_icons_distance / 2);
+                }
+
                 @if ($is_extended) {
                     @include padded-dash-edge-items($side, $edge_items_padding);
                 }


### PR DESCRIPTION
Fixes inconsistent spacing between Applications icon and adjacent normal icons by applying the same half-gap spacing at the dash scrollview edge. As of v103 distance between normal icons is 4px, and distance between Applications icon and normal icons is 2px.

Fixes #2025 