### PR TITLE
Fix normal icons offset when intelligent autohide is disabled

### DIFF
--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -241,6 +241,12 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
             }
         }
 
+        &.fixed {
+            #dash {
+                margin-#{opposite($side)}: $fixed_inner_margin;
+            }
+        }
+
     }
 }
 


### PR DESCRIPTION
Fixes an offset to the normal icons by 2px to 4px toward the workarea, when intelligent autohide is disabled (fixed dock). Tested on top of v103 in extended, shrink, LTR, RTL, panel, all dock positions.