### PR TITLE
Revert "Fix Autohide Location calculation bug (Issue #2413)"

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1249,10 +1249,9 @@ const DockedDash = GObject.registerClass({
     }
 
     _updateStaticBox() {
-        const [absX, absY] = this._box.get_transformed_position();
         this.staticBox.init_rect(
-            absX,
-            absY,
+            this.x + this._slider.x - (this._position === St.Side.RIGHT ? this._box.width : 0),
+            this.y + this._slider.y - (this._position === St.Side.BOTTOM ? this._box.height : 0),
             this._box.width,
             this._box.height
         );


### PR DESCRIPTION
This reverts commit 3e0c24f7b09708757e70565a6e449b6143cd2b08.

That commit causes regression where the autohide is broken for regular cases.

Closes: #2501