### PR TITLE
Fix the problem with auto hide dock (v103) (Issue #2501)

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1249,8 +1249,10 @@ const DockedDash = GObject.registerClass({
     }
 
     _updateStaticBox() {
+        const [absX] = this._box.get_transformed_position();
+
         this.staticBox.init_rect(
-            this.x + this._slider.x - (this._position === St.Side.RIGHT ? this._box.width : 0),
+            absX,
             this.y + this._slider.y - (this._position === St.Side.BOTTOM ? this._box.height : 0),
             this._box.width,
             this._box.height


### PR DESCRIPTION
After the latest update I ran into the same overlap issue and did some investigation. It turned out that the box area used to calculate overlaps was aligned correctly on the X axis, but not on the Y axis. Interestingly, when I reverted the previous fix, the behavior flipped — the Y axis became correct while the X axis was off.

As a (temporary?) workaround, I combined the adjustments so that both axes are positioned correctly.  Now the overlap box boundaries seem to work properly for people. (see https://github.com/micheleg/dash-to-dock/issues/2501)

It may be worth revisiting the root cause later for a cleaner long-term solution.