### PR TITLE
Fix overview state stuck at WINDOW_PICKER when disableOverviewOnStartup is enabled

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2444,8 +2444,12 @@ export class DockManager {
             const hadOverview = Main.sessionMode.hasOverview;
 
             // Convince LayoutManager to use the legacy startup animation:
-            if (this._settings.disableOverviewOnStartup)
+            // Reset overview controls state to HIDDEN, as skipping the startup
+            // overview leaves it stuck at WINDOW_PICKER
+            if (this._settings.disableOverviewOnStartup) {
                 Main.sessionMode.hasOverview = false;
+                Main.overview._overview.controls._stateAdjustment.value = OverviewControls.ControlsState.HIDDEN;
+            }
 
             this._signalsHandler.addWithLabel(Labels.STARTUP_ANIMATION,
                 Main.layoutManager, 'startup-complete', () => {


### PR DESCRIPTION
**Initial problem**
There is a minor bug (more of inconvenience) right after the session start up. Using the 3 finger swipe the the application windows opens skipping the overview. After that it comes to its regular behavior

**One line solution**
When overview is disabled the state at start up is stuck at WINDOW_PICKER, this line just sets it HIDDEN