### PR TITLE
Typo Fix: Added the missing `</kbd>` tag for the shell reload key sequence under the "Building" section of the READ.me document

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ export SASS=ruby
 
 Clone the repository or download the branch from github. A simple Makefile is included.
 
-Next use `make` to install the extension into your home directory. A Shell reload is required <kbd>Alt+<kbd>F2</kbd> <kbd>r</kbd> <kbd>Enter</kbd> under Xorg or under Wayland you may have to logout and login. The extension has to be enabled  with *gnome-extensions-app* (GNOME Extensions) or with *dconf*.
+Next use `make` to install the extension into your home directory. A Shell reload is required <kbd>Alt</kbd> + <kbd>F2</kbd> <kbd>r</kbd> <kbd>Enter</kbd> under Xorg or under Wayland you may have to logout and login. The extension has to be enabled  with *gnome-extensions-app* (GNOME Extensions) or with *dconf*.
 
 ```bash
 git clone https://github.com/micheleg/dash-to-dock.git


### PR DESCRIPTION
Typo fix: added the missing `</kbd>` tag for the shell reload key sequence under the "**Building**" section of the READ.me document.