### PR TITLE
Revert "Fix Autohide Location calculation bug (Issue #2413)"

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1249,10 +1249,9 @@ const DockedDash = GObject.registerClass({
     }
 
     _updateStaticBox() {
-        const [absX, absY] = this._box.get_transformed_position();
         this.staticBox.init_rect(
-            absX,
-            absY,
+            this.x + this._slider.x - (this._position === St.Side.RIGHT ? this._box.width : 0),
+            this.y + this._slider.y - (this._position === St.Side.BOTTOM ? this._box.height : 0),
             this._box.width,
             this._box.height
         );


### PR DESCRIPTION
`Clutter.Actor.get_transformed_position()` accounts for animations etc... which means that it cannot be used to compute the "theoretical" global position of the dock, which indeed might be part of an animation at the moment that the method is called.

This reverts commit 3e0c24f7b09708757e70565a6e449b6143cd2b08.

Closes: https://github.com/micheleg/dash-to-dock/issues/2501