### PR TITLE
intellihide: Fix dock not hiding when windows touch dock edge

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -224,9 +224,9 @@ export class Intellihide {
                         const rect = win.get_frame_rect();
 
                         const test = (rect.x < this._targetBox.x2) &&
-                                   (rect.x + rect.width > this._targetBox.x1) &&
+                                   (rect.x + rect.width >= this._targetBox.x1) &&
                                    (rect.y < this._targetBox.y2) &&
-                                   (rect.y + rect.height > this._targetBox.y1);
+                                   (rect.y + rect.height >= this._targetBox.y1);
 
                         if (test) {
                             overlaps = OverlapStatus.TRUE;


### PR DESCRIPTION
## Summary

The overlap test in `_doCheckOverlap()` uses strict `>` to compare window edges against the dock target box. On a bottom dock at y=1080, a maximized window with its bottom edge at exactly y=1080 produces `1080 > 1080 = false`, incorrectly reporting no overlap. This causes the dock to show and stay visible.

Change `>` to `>=` so that windows touching the dock edge are correctly detected as overlapping.

## Reproduction

On a HiDPI display (e.g. 2880×1800 at 1.667× scaling → 1728×1080 logical), the maximized window height (1048) plus the panel (32) yields a bottom edge of exactly 1080, matching the dock's `targetBox.y1`. The strict `>` makes this a deterministic boundary condition. Opening/closing apps rapidly causes the dock to flash or get stuck visible.

The `>` has been in the codebase since the beginning but only manifests when window geometry lands exactly on the dock boundary, which became deterministic with mutter's geometry calculation on certain scaled displays.

Note: on `window-created`, the new window's `frame_rect` is still 0×0, so `_doCheckOverlap()` can also produce false negatives there. This is mitigated by the existing `notify::allocation` handler in `_addWindowSignals` which rechecks overlap once geometry is set, but a separate fix to remove the immediate `_doCheckOverlap()` call in `_windowCreated` would further improve robustness.