### PR TITLE
Fix crash on disposed ScrollView in ensureActorVisibleInScrollView

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -142,6 +142,7 @@ export const DockDash = GObject.registerClass({
         this._shownInitially = false;
         this._initializeIconSize(this.iconSize);
         this._signalsHandler = new Utils.GlobalSignalsHandler(this);
+        this._appIconSignals = [];
 
         this._separator = null;
 
@@ -313,6 +314,16 @@ export const DockDash = GObject.registerClass({
 
     _onDestroy() {
         this.iconAnimator.destroy();
+
+        // Disconnect scrollView-related signals to prevent access to disposed objects
+        for (const signal of this._appIconSignals) {
+            try {
+                signal.obj.disconnect(signal.id);
+            } catch (e) {
+                // appIcon may already be destroyed
+            }
+        }
+        this._appIconSignals = [];
 
         if (this._requiresVisibilityTimeout) {
             GLib.source_remove(this._requiresVisibilityTimeout);
@@ -524,11 +535,11 @@ export const DockDash = GObject.registerClass({
         item.setChild(appIcon);
 
         appIcon.connect('notify::hover', a => this._ensureItemVisibility(a));
-        appIcon.connect('clicked', actor => {
+        const clickedId = appIcon.connect('clicked', actor => {
             ensureActorVisibleInScrollView(this._scrollView, actor);
         });
 
-        appIcon.connect('key-focus-in', actor => {
+        const keyFocusId = appIcon.connect('key-focus-in', actor => {
             const [xShift, yShift] = ensureActorVisibleInScrollView(this._scrollView, actor);
 
             // This signal is triggered also by mouse click. The popup menu is opened at the original
@@ -539,19 +550,26 @@ export const DockDash = GObject.registerClass({
             }
         });
 
-        appIcon.connect('notify::focused', () => {
+        const focusedId = appIcon.connect('notify::focused', () => {
             const {settings} = Docking.DockManager;
             if (appIcon.focused && settings.scrollToFocusedApplication)
                 ensureActorVisibleInScrollView(this._scrollView, item);
         });
 
-        appIcon.connect('notify::urgent', () => {
+        const urgentId = appIcon.connect('notify::urgent', () => {
             if (appIcon.urgent) {
                 ensureActorVisibleInScrollView(this._scrollView, item);
                 if (Docking.DockManager.settings.showDockUrgentNotify)
                     this._requireVisibility();
             }
         });
+
+        this._appIconSignals.push(
+            {obj: appIcon, id: clickedId},
+            {obj: appIcon, id: keyFocusId},
+            {obj: appIcon, id: focusedId},
+            {obj: appIcon, id: urgentId}
+        );
 
         // Override default AppIcon label_actor, now the
         // accessible_name is set at DashItemContainer.setLabelText
@@ -1116,6 +1134,15 @@ export const DockDash = GObject.registerClass({
  * @param actor
  */
 function ensureActorVisibleInScrollView(scrollView, actor) {
+    // Guard against disposed scrollView (e.g. when alt-tab extensions trigger
+    // notify::focused after the dash has been destroyed)
+    if (!scrollView || !actor)
+        return [0, 0];
+    try {
+        scrollView.vadjustment;
+    } catch (e) {
+        return [0, 0];
+    }
     // access to scrollView.[hv]scroll was deprecated in gnome 46
     // instead, adjustment can be accessed directly
     // keep old way for backwards compatibility (gnome <= 45)


### PR DESCRIPTION
## Summary

Fixes #2532 — `ensureActorVisibleInScrollView()` crashes when the dash's `ScrollView` has been disposed, typically triggered by alt-tab extensions calling `Main.activateWindow()` after a screen lock/unlock cycle.

## Changes

Two-part fix in `dash.js`:

### 1. Root cause fix: disconnect signals in `_onDestroy()`

The `clicked`, `key-focus-in`, `notify::focused`, and `notify::urgent` signal handlers connected in `_createAppItem()` all call `ensureActorVisibleInScrollView(this._scrollView, ...)` but were never disconnected when the dash is destroyed. This means they could fire after `this._scrollView` is disposed.

- Added `this._appIconSignals` array to track signal connections
- Stored signal IDs when connecting in `_createAppItem()`
- Disconnect all tracked signals in `_onDestroy()`

### 2. Defensive guard in `ensureActorVisibleInScrollView()`

Added a null/disposed check at the function entry point, returning `[0, 0]` if the `scrollView` or `actor` is invalid. This follows the same pattern as PR #1366 which added disposal guards for icon animations.

## Context

This bug is the same class of disposed-object access that was fixed in:
- PR #1366 (disposed icon animation guards)
- Issue #1332 (disposed `St.Bin` flooding journal)
- Issue #2255 (disposed `DockDash` on autohide + suspend)

The crash is reliably triggered when using extensions that call `Main.activateWindow()` externally (e.g. Advanced Alt-Tab Window Switcher), combined with screen lock/unlock or suspend/resume cycles.

## Test plan

- [x] Syntax validated with `node --check`
- [ ] Verify no more `ScrollView disposed` errors in journal after lock/unlock + alt-tab
- [ ] Verify dock scroll-to-focused behavior still works normally
- [ ] Verify dock behavior on extension disable/enable cycle