### PR TITLE
fix: drop direction argument from workspaceSwitcherPopup.display()

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1408,7 +1408,7 @@ const DockedDash = GObject.registerClass({
 
                 // Do not show workspaceSwitcher in overview
                 if (!Main.overview.visible)
-                    Main.wm._workspaceSwitcherPopup.display(direction, ws.index());
+                    Main.wm._workspaceSwitcherPopup.display(ws.index());
 
                 return true;
             } else {


### PR DESCRIPTION
GNOME Shell dropped the direction parameter from WorkspaceSwitcherPopup.display() in this commit:
_https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/209d8c7f10b2753a0d3e665f56c4156d4fa03492_

Ubuntu-dock still passes direction as the first argument, which lands in activeWorkspaceIndex. Since direction is never a valid workspace index, no workspace dot is ever highlighted as active.

Fixes: _https://bugs.launchpad.net/ubuntu/+source/gnome-shell-extension-ubuntu-dock/+bug/1966681_