### PR TITLE
docking: drop direction argument from workspaceSwitcherPopup.display()

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1407,7 +1407,7 @@ const DockedDash = GObject.registerClass({
 
                 // Do not show workspaceSwitcher in overview
                 if (!Main.overview.visible)
-                    Main.wm._workspaceSwitcherPopup.display(direction, ws.index());
+                    Main.wm._workspaceSwitcherPopup.display(ws.index());
 
                 return true;
             } else {


### PR DESCRIPTION
GNOME Shell dropped the direction parameter from
WorkspaceSwitcherPopup.display() in commit [1] included starting from GNOME shell 42.

Ubuntu-dock still passes direction as the first argument, which lands in activeWorkspaceIndex. Since direction is never a valid workspace index, no workspace dot is ever highlighted as active.

LP: #1966681

[1] https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/209d8c7f10b2753

Coming from https://github.com/micheleg/dash-to-dock/pull/2540