### PR TITLE
docking: Avoid inserting ("tracking") docks during the login animation

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -411,9 +411,6 @@ const DockedDash = GObject.registerClass({
         this._slider.set_child(this._box);
         this._box.add_child(this.dash);
 
-        // Add aligning container without tracking it for input region
-        this._trackDock();
-
         // Create and apply height/width constraint to the dash.
         if (this._isHorizontal) {
             this.connect('notify::width', () => {
@@ -2129,6 +2126,8 @@ export class DockManager {
         DockManager.allDocks.forEach(dock => {
             const {dash} = dock;
 
+            dock._trackDock();
+
             switch (dock.position) {
             case St.Side.LEFT:
                 dash.translation_x = -dash.width;
@@ -2457,6 +2456,8 @@ export class DockManager {
                     Main.sessionMode.hasOverview = hadOverview;
                     this._runStartupAnimation();
                 });
+        } else {
+            DockManager.allDocks.forEach(dock => dock._trackDock());
         }
     }
 


### PR DESCRIPTION
Up until GNOME 49 we could be confident that extensions were activated before the login animation, but that's not true in GNOME 50 (gnome-shell#8917). In GNOME 50 we get constructed _during_ the GNOME login animation so inserting docks at that moment creates a visible glitch.

Now we wait until the GNOME login animation is done before starting our own dock login animation. Or if we're not starting up then insert docks immediately.

Closes: https://bugs.launchpad.net/bugs/2146516