### PR TITLE
docking: Unfocus currently focused window when getting the a11y focus

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1281,7 +1281,9 @@ const DockedDash = GObject.registerClass({
     /**
      * Show dock and give key focus to it
      */
-    _onAccessibilityFocus() {
+    _onAccessibilityFocus(timestamp) {
+        if (!Main.overview.visible)
+            global.display.unset_input_focus(timestamp);
         this._box.navigate_focus(null, St.DirectionType.TAB_FORWARD, false);
         this._animateIn(DockManager.settings.animationTime, 0);
     }

--- a/docking.js
+++ b/docking.js
@@ -1293,7 +1293,7 @@ const DockedDash = GObject.registerClass({
         // Restore dash accessibility
         Main.ctrlAltTabManager.addGroup(
             this.dash, _('Dash'), 'user-bookmarks-symbolic',
-            {focusCallback: this._onAccessibilityFocus.bind(this)});
+            {focusCallback: timestamp => this._onAccessibilityFocus(timestamp)});
     }
 
     /**


### PR DESCRIPTION
When the dock gets focused through the Ctrl+Alt+Tab switcher we are
getting the focus, but the currently focused application still preserves
the focused appearance.

Adjust this by ensuring the focus is unset.

See: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/4164

LP: #2147922
