### PR TITLE
appIconsDecorator: Keep track of icons and results appIcons separately

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -93,7 +93,7 @@ let recentlyClickedAppMonitor = -1;
  * - Update minimization animation target
  * - Update menu if open on windows change
  */
-const DockAbstractAppIcon = GObject.registerClass({
+export const DockAbstractAppIcon = GObject.registerClass({
     GTypeFlags: GObject.TypeFlags.ABSTRACT,
     Properties: {
         'focused': GObject.ParamSpec.boolean(
@@ -429,6 +429,14 @@ const DockAbstractAppIcon = GObject.registerClass({
         // it called by the parent constructor.
     }
 
+    notifyAppIconUpdating(monitorIndex) {
+        const icon = Gio.Icon.new_for_string('action-unavailable-symbolic');
+        const {osdWindowManager} = Main;
+        const showOsd = osdWindowManager.showOne ?? osdWindowManager.show;
+        showOsd.call(osdWindowManager, monitorIndex ?? this.monitorIndex, icon,
+            _('%s is updating, try again later').format(this.name), null);
+    }
+
     popupMenu() {
         this._removeMenuTimeout?.();
         this.fake_release();
@@ -754,19 +762,7 @@ const DockAbstractAppIcon = GObject.registerClass({
     // the existing window instead.
     launchNewWindow() {
         if (this.updating) {
-            const icon = Gio.Icon.new_for_string('action-unavailable-symbolic');
-            const osdShowArgs = [
-                Main.layoutManager.primaryMonitor.index,
-                icon,
-                _('%s is updating, try again later').format(this.name),
-                null,
-            ];
-
-            if (Main.osdWindowManager.showOne)
-                Main.osdWindowManager.showOne(...osdShowArgs);
-            else
-                Main.osdWindowManager.show(...osdShowArgs);
-
+            this.notifyAppIconUpdating();
             return;
         }
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -755,9 +755,18 @@ const DockAbstractAppIcon = GObject.registerClass({
     launchNewWindow() {
         if (this.updating) {
             const icon = Gio.Icon.new_for_string('action-unavailable-symbolic');
-            Main.osdWindowManager.show(-1, icon,
+            const osdShowArgs = [
+                Main.layoutManager.primaryMonitor.index,
+                icon,
                 _('%s is updating, try again later').format(this.name),
-                null);
+                null,
+            ];
+
+            if (Main.osdWindowManager.showOne)
+                Main.osdWindowManager.showOne(...osdShowArgs);
+            else
+                Main.osdWindowManager.show(...osdShowArgs);
+
             return;
         }
 

--- a/appIconsDecorator.js
+++ b/appIconsDecorator.js
@@ -28,6 +28,7 @@ export class AppIconsDecorator {
             null, {allowNewProperty: true});
         this._indicators = new Set();
         this._resultIndicators = new Set();
+        this._updatingIcons = new WeakSet();
 
         this._patchAppIcons();
         this._decorateIcons();
@@ -44,6 +45,7 @@ export class AppIconsDecorator {
         this._clearIndicators(Labels.RESULTS);
         delete this._indicators;
         delete this._resultIndicators;
+        delete this._updatingIcons;
     }
 
     _indicatorsSet(label) {
@@ -129,16 +131,19 @@ export class AppIconsDecorator {
         appIconsTypes.forEach(type =>
             this._propertyInjections.add(type.prototype, 'updating', {
                 get() {
-                    return !!this.__d2dUpdating;
+                    return self._updatingIcons.has(this);
                 },
                 set(updating) {
                     if (this.updating === updating)
                         return;
-                    this.__d2dUpdating = updating;
-                    if (updating)
+
+                    if (updating) {
+                        self._updatingIcons.add(this);
                         this.add_style_class_name('updating');
-                    else
+                    } else {
+                        self._updatingIcons.delete(this);
                         this.remove_style_class_name('updating');
+                    }
                 },
             }));
 

--- a/appIconsDecorator.js
+++ b/appIconsDecorator.js
@@ -116,9 +116,18 @@ export class AppIconsDecorator {
                 /* eslint-disable no-invalid-this */
                 if (this.updating) {
                     const icon = Gio.Icon.new_for_string('action-unavailable-symbolic');
-                    Main.osdWindowManager.show(-1, icon,
+                    const osdShowArgs = [
+                        Main.layoutManager.primaryMonitor.index,
+                        icon,
                         _('%s is updating, try again later').format(this.name),
-                        null);
+                        null,
+                    ];
+
+                    if (Main.osdWindowManager.showOne)
+                        Main.osdWindowManager.showOne(...osdShowArgs);
+                    else
+                        Main.osdWindowManager.show(...osdShowArgs);
+
                     return;
                 }
 

--- a/appIconsDecorator.js
+++ b/appIconsDecorator.js
@@ -19,7 +19,7 @@ import {
 } from './dependencies/shell/ui.js';
 
 const Labels = Object.freeze({
-    GENERIC: Symbol('generic'),
+    RESULTS: Symbol('results'),
     ICONS: Symbol('icons'),
 });
 
@@ -30,6 +30,7 @@ export class AppIconsDecorator {
         this._propertyInjections = new Utils.PropertyInjectionsHandler(
             null, {allowNewProperty: true});
         this._indicators = new Set();
+        this._resultIndicators = new Set();
 
         this._patchAppIcons();
         this._decorateIcons();
@@ -42,28 +43,41 @@ export class AppIconsDecorator {
         delete this._methodInjections;
         this._propertyInjections?.destroy();
         delete this._propertyInjections;
-        this._indicators?.forEach(i => i.destroy());
-        this._indicators?.clear();
+        this._clearIndicators(Labels.ICONS);
+        this._clearIndicators(Labels.RESULTS);
         delete this._indicators;
+        delete this._resultIndicators;
     }
 
-    _decorateIcon(parentIcon, signalLabel = Labels.GENERIC) {
+    _indicatorsSet(label) {
+        return {
+            [Labels.ICONS]: this._indicators,
+            [Labels.RESULTS]: this._resultIndicators,
+        }[label];
+    }
+
+    _clearIndicators(label) {
+        const indicatorsSet = this._indicatorsSet(label);
+        indicatorsSet.forEach(i => i.destroy());
+        indicatorsSet.clear();
+    }
+
+    _decorateIcon(parentIcon, signalLabel) {
         const indicator = new AppIconIndicators.UnityIndicator(parentIcon);
-        this._indicators.add(indicator);
+        const indicatorsSet = this._indicatorsSet(signalLabel);
+        indicatorsSet.add(indicator);
         this._signals.addWithLabel(signalLabel, parentIcon, 'destroy', () => {
-            this._indicators.delete(indicator);
+            indicatorsSet.delete(indicator);
             indicator.destroy();
         });
-        return indicator;
     }
 
     _decorateIcons() {
         const {appDisplay} = Docking.DockManager.getDefault().overviewControls;
 
         const decorateAppIcons = () => {
-            this._indicators.forEach(i => i.destroy());
-            this._indicators.clear();
             this._signals.removeWithLabel(Labels.ICONS);
+            this._clearIndicators(Labels.ICONS);
 
             const decorateViewIcons = view => {
                 const items = view.getAllItems();
@@ -92,7 +106,7 @@ export class AppIconsDecorator {
                 /* eslint-disable no-invalid-this */
                 const result = originalFunction.call(this, ...args);
                 if (result instanceof AppDisplay.AppIcon)
-                    self._decorateIcon(result);
+                    self._decorateIcon(result, Labels.RESULTS);
                 return result;
                 /* eslint-enable no-invalid-this */
             });

--- a/appIconsDecorator.js
+++ b/appIconsDecorator.js
@@ -2,14 +2,11 @@
 
 
 import {
-    Docking,
     AppIconIndicators,
+    AppIcons,
+    Docking,
     Utils,
 } from './imports.js';
-
-import {
-    Gio,
-} from './dependencies/gi.js';
 
 import {
     AppMenu,
@@ -115,19 +112,9 @@ export class AppIconsDecorator {
             'activate', function (originalFunction, ...args) {
                 /* eslint-disable no-invalid-this */
                 if (this.updating) {
-                    const icon = Gio.Icon.new_for_string('action-unavailable-symbolic');
-                    const osdShowArgs = [
-                        Main.layoutManager.primaryMonitor.index,
-                        icon,
-                        _('%s is updating, try again later').format(this.name),
-                        null,
-                    ];
-
-                    if (Main.osdWindowManager.showOne)
-                        Main.osdWindowManager.showOne(...osdShowArgs);
-                    else
-                        Main.osdWindowManager.show(...osdShowArgs);
-
+                    const {notifyAppIconUpdating} = AppIcons.DockAbstractAppIcon.prototype;
+                    notifyAppIconUpdating.call(this,
+                        Main.layoutManager.primaryMonitor.index);
                     return;
                 }
 

--- a/docking.js
+++ b/docking.js
@@ -1709,10 +1709,11 @@ export class DockManager {
             !this._notificationsMonitor.dndMode && this._settings.showIconsEmblems;
 
         const ensureRemoteModel = () => {
-            if (needsRemoteModel && !this._remoteModel) {
+            const shouldHaveRemoteModel = needsRemoteModel();
+            if (shouldHaveRemoteModel && !this._remoteModel) {
                 this._remoteModel = new LauncherAPI.LauncherEntryRemoteModel();
                 this._appIconsDecorator = new AppIconsDecorator.AppIconsDecorator();
-            } else if (!needsRemoteModel) {
+            } else if (!shouldHaveRemoteModel) {
                 this._remoteModel?.destroy();
                 delete this._remoteModel;
                 this._appIconsDecorator?.destroy();


### PR DESCRIPTION
 We used the indicators set to track all the indicators kinds, however
this was problematic when the 'view-loaded' signal was emitted, because
it lead all the indicators being cleared, and not only the icons ones.

Thus when the destroyed signal was called for an indicator that we
cleared from the set, its source was invalid.

Split the handling of those in two different sets, so that we do not
clear what should not be cleared when signals or events happen

Closes: #2482

LP: #2146632