### PR TITLE
docking: Use default showAppsButton behavior when used in Ctrl+Alt+Tab

### DIFF
--- a/dependencies/shell/ui.js
+++ b/dependencies/shell/ui.js
@@ -12,6 +12,7 @@ export * as PointerWatcher from 'resource:///org/gnome/shell/ui/pointerWatcher.j
 export * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 export * as SearchController from 'resource:///org/gnome/shell/ui/searchController.js';
 export * as ShellMountOperation from 'resource:///org/gnome/shell/ui/shellMountOperation.js';
+export * as SwitcherPopup from 'resource:///org/gnome/shell/ui/switcherPopup.js';
 export * as Workspace from 'resource:///org/gnome/shell/ui/workspace.js';
 export * as WorkspaceSwitcherPopup from 'resource:///org/gnome/shell/ui/workspaceSwitcherPopup.js';
 export * as WorkspaceThumbnail from 'resource:///org/gnome/shell/ui/workspaceThumbnail.js';

--- a/docking.js
+++ b/docking.js
@@ -17,6 +17,7 @@ import {
     Main,
     OverviewControls,
     PointerWatcher,
+    SwitcherPopup,
     Workspace,
     WorkspacesView,
     WorkspaceSwitcherPopup,
@@ -2388,6 +2389,24 @@ export class DockManager {
                 return workspaceBoxOriginFixer.call(this, originalFunction, ...args);
                 /* eslint-enable no-invalid-this */
             },
+        ], [
+            // Sadly CtrlAltTabPopup is not exported, so we cannot just patch it.
+            SwitcherPopup.SwitcherPopup.prototype,
+            '_finish',
+            function (originalFunction, ...args) {
+                /* eslint-disable no-invalid-this */
+                if (this.constructor.name === 'CtrlAltTabPopup') {
+                    const dockManager = DockManager.getDefault();
+                    if (dockManager._inCtrlAltTabSwitcher)
+                        return;
+
+                    dockManager._inCtrlAltTabSwitcher = true;
+                    this.constructor.prototype._finish.call(this, ...args);
+                    delete dockManager._inCtrlAltTabSwitcher;
+                }
+                originalFunction.call(this, ...args);
+                /* eslint-enable no-invalid-this */
+            },
         ]);
 
         this._vfuncInjections.addWithLabel(Labels.MAIN_DASH, Workspace.WorkspaceBackground.prototype,
@@ -2516,7 +2535,8 @@ export class DockManager {
         if (!Main.overview.visible) {
             this.mainDock.dash.showAppsButton._fromDesktop = true;
             Main.overview.show(OverviewControls.ControlsState.APP_GRID);
-        } else if (!checked && this.mainDock.dash.showAppsButton._fromDesktop) {
+        } else if (!checked && this.mainDock.dash.showAppsButton._fromDesktop &&
+            !this._inCtrlAltTabSwitcher) {
             Main.overview.hide();
             this.mainDock.dash.showAppsButton._fromDesktop = false;
         } else {


### PR DESCRIPTION
Ctrl+Alt+Tab switcher is used to switch focus to shell elements, and with dash to dock is currently broken when it comes to select windows or apps overview states.

So track when this happens and rely on the default behavior

LP: #2148513