### PR TITLE
Use the DEFAULT value from GSettings

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -58,11 +58,13 @@ export class AppIconIndicator {
             this._indicators.push(unityIndicator);
         }
 
-        switch (runningIndicatorStyle) {
-        case RunningIndicatorStyle.DEFAULT:
-            runningIndicator = new RunningIndicatorDefault(source);
-            break;
+        if (runningIndicatorStyle === RunningIndicatorStyle.DEFAULT) {
+            // If DEFAULT is choosen, use the GSettings default value
+            const defaultValue = settings.get_default_value('running-indicator-style');
+            runningIndicatorStyle = RunningIndicatorStyle[defaultValue.get_string()[0]];
+        }
 
+        switch (runningIndicatorStyle) {
         case RunningIndicatorStyle.DOTS:
             runningIndicator = new RunningIndicatorDots(source);
             break;

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -235,6 +235,7 @@ class RunningIndicatorBase extends IndicatorBase {
 
 // We add a css class so third parties themes can limit their indicator customization
 // to the case we do nothing
+/* eslint-disable no-unused-vars */
 class RunningIndicatorDefault extends RunningIndicatorBase {
     constructor(source) {
         super(source);
@@ -246,6 +247,7 @@ class RunningIndicatorDefault extends RunningIndicatorBase {
         super.destroy();
     }
 }
+/* eslint-enable no-unused-vars */
 
 const IndicatorDrawingArea = GObject.registerClass(
 class IndicatorDrawingArea extends St.DrawingArea {

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -92,7 +92,7 @@
       <description>FIXED: constant transparency. DYNAMIC: dock takes the opaque style only when windows are close to it.</description>
     </key>
     <key name="running-indicator-style" enum="org.gnome.shell.extensions.dash-to-dock.running-indicator-style">
-      <default>'DEFAULT'</default>
+      <default>'DOTS'</default>
       <summary>...</summary>
       <description>DEFAULT: .... DOTS: ....</description>
     </key>


### PR DESCRIPTION
Currently, the DEFAULT setting for the number-of-open-windows indicator is broken. It should look like the DOTS, but the style is broken because it uses its own class/CSS (the dots are placed over the icon). All other styles work as expected.

This patch changes the behavior, and when the user sets the DEFAULT setting, it will read the default value in GSettigs and use that one. For example, Ubuntu uses the DOTS as default in GSettings, so it will use exactly the same code path as DOTS when choosing DEFAULT. Other distros can change that default, and the code will work as expected, using the default value set in GSettings.