### PR TITLE
docking: Fix notification badges/dots vanishing after DND toggle

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1738,7 +1738,7 @@ export class DockManager {
         };
         ensureRemoteModel();
 
-        this._signalsHandler.add(this._notificationsMonitor, 'changed',
+        this._signalsHandler.add(this._notificationsMonitor, 'state-changed',
             () => ensureRemoteModel());
         this._signalsHandler.add(this._settings, 'changed::show-icons-emblems',
             () => ensureRemoteModel());


### PR DESCRIPTION
Regression of 2852c99 (v105). On DND-off, NotificationsMonitor emits
  state-changed before 'changed':

      this.emit('state-changed');   // AppIcon rebuilds UnityIndicator here
      this._updateState();          // 'changed' fires here → ensureRemoteModel

  ensureRemoteModel was wired to 'changed', so _remoteModel was still
  undefined when AppIcon's state-changed handler ran. UnityIndicator's
  `remoteModel.lookupById(...)` threw, `this._indicator = new ...` never
  landed, and the icon stayed in destroyed state — no running dot, no
  notification badge — until relogin or disable/enable.

  Pre-2852c99 this was latent because _remoteModel was never actually
  destroyed (function-reference truthiness bug). 2852c99 exposed it.

  Move ensureRemoteModel to 'state-changed'. DockManager connects in its
  constructor, before _createDocks creates the AppIcons that also listen
  to state-changed, so the remote model is recreated first. Also stops
  ensureRemoteModel running on every notification arrival.

  Repro on GNOME 50 / dash-to-dock v105: toggle DND from Quick Settings
  on, then off. Tested fix on Wayland; badges + dots persist correctly.