### PR TITLE
Revert "Makefile: Do not ship settings schema on zip file"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ ifeq ($(INSTALLTYPE),system)
 	# system-wide settings and locale files
 	rm -r $(INSTALLBASE)/$(INSTALLNAME)/schemas $(INSTALLBASE)/$(INSTALLNAME)/locale
 	mkdir -p $(SHARE_PREFIX)/glib-2.0/schemas $(SHARE_PREFIX)/locale
-	cp -r ./schemas/*.gschema.xml $(SHARE_PREFIX)/glib-2.0/schemas
+	cp -r ./schemas/*gschema.* $(SHARE_PREFIX)/glib-2.0/schemas
 	cp -r ./_build/locale/* $(SHARE_PREFIX)/locale
 endif
 	-rm -fR _build
@@ -125,7 +125,8 @@ _build: all
 	mkdir -p _build/media
 	cd media ; cp $(EXTRA_MEDIA) ../_build/media/
 	mkdir -p _build/schemas
-	cp schemas/*.gschema.xml _build/schemas/
+	cp schemas/*.xml _build/schemas/
+	cp schemas/gschemas.compiled _build/schemas/
 	mkdir -p _build/locale
 	for l in $(MSGSRC:.po=.mo) ; do \
 		lf=_build/locale/`basename $$l .mo`; \


### PR DESCRIPTION
This reverts commit 1ad2628e32e596b32fbdb1bcf3d1088f7eb50033.

Lack of `gschemas.compiled` was causing the extension to never load:
```
(gnome-shell:48607): GNOME Shell-CRITICAL **: 15:05:45.071: Extension dash-to-dock@micxgx.gmail.com: GLib.FileError: Failed to open file “/home/dan/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/schemas/gschemas.compiled”: open() failed: No such file or directory

Stack trace:
  getSettings@resource:///org/gnome/shell/extensions/sharedInternals.js:101:53
  DockManager@file:///home/dan/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/docking.js:1711:42
  enable@file:///home/dan/.local/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/extension.js:11:23
  ...
```