### PR TITLE
Makefile: Remember gschemas.compiled for local installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ ifeq ($(INSTALLTYPE),system)
 	cp -r ./schemas/*.gschema.xml $(SHARE_PREFIX)/glib-2.0/schemas
 	cp -r ./_build/locale/* $(SHARE_PREFIX)/locale
 endif
+	cp schemas/gschemas.compiled $(INSTALLBASE)/$(INSTALLNAME)/schemas/
 	-rm -fR _build
 	echo done
 


### PR DESCRIPTION
Or else the extension won't load at all.

Closes: https://github.com/micheleg/dash-to-dock/issues/2595
Fixes: 1ad2628e32 ("Makefile: Do not ship settings schema on zip file")