### PR TITLE
Makefile: Ensure schemas dir exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ ifeq ($(INSTALLTYPE),system)
 	cp -r ./schemas/*.gschema.xml $(SHARE_PREFIX)/glib-2.0/schemas
 	cp -r ./_build/locale/* $(SHARE_PREFIX)/locale
 endif
+	mkdir -p $(INSTALLBASE)/$(INSTALLNAME)/schemas/
 	cp schemas/gschemas.compiled $(INSTALLBASE)/$(INSTALLNAME)/schemas/
 	-rm -fR _build
 	echo done


### PR DESCRIPTION
Since https://github.com/micheleg/dash-to-dock/commit/2bc44a6addc1c58360b12038ef5a0bec14403548 building package fails as directory does not exist.

https://github.com/aminvakil/aur/actions/runs/26433076564/job/77810069385