### PR TITLE
Fix set_style(null) crashes on GNOME 50 / GJS 1.88

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -217,14 +217,15 @@ class RunningIndicatorBase extends IndicatorBase {
     }
 
     _disableBacklight() {
-        this._source._iconContainer.set_style(null);
+        this._source._iconContainer.set_style('');
     }
 
     destroy() {
         this._disableBacklight();
         // Remove glossy background if the children still exists
-        if (this._source._iconContainer.get_children().length > 1)
-            this._source._iconContainer.get_children()[1].set_style(null);
+        const children = this._source._iconContainer.get_children();
+        if (children.length > 1)
+            children[1].set_style('');
         this._restoreDefaultDot();
 
         super.destroy();
@@ -328,16 +329,21 @@ class RunningIndicatorDots extends RunningIndicatorBase {
         if (!Docking.DockManager.settings.applyCustomTheme &&
             Docking.DockManager.settings.unityBacklitItems) {
             const [icon] = this._source._iconContainer.get_children();
-            icon.set_style(
-                Docking.DockManager.settings.applyGlossyEffect
-                    ? this._glossyBackgroundStyle : null);
+            if (icon) {
+                icon.set_style(
+                    Docking.DockManager.settings.applyGlossyEffect &&
+                    this._glossyBackgroundStyle
+                        ? this._glossyBackgroundStyle : '');
+            }
             if (this._source.running)
                 this._enableBacklight();
             else
                 this._disableBacklight();
         } else {
             this._disableBacklight();
-            this._source._iconContainer.get_children()[1].set_style(null);
+            const children = this._source._iconContainer.get_children();
+            if (children.length > 1)
+                children[1].set_style('');
         }
 
         if (this._area)

--- a/theming.js
+++ b/theming.js
@@ -142,7 +142,7 @@ export class ThemeManager {
     _getDefaultColors() {
         // Remove custom style
         const oldStyle = this._dash._background.get_style();
-        this._dash._background.set_style(null);
+        this._dash._background.set_style('');
 
         const themeNode = this._dash._background.get_theme_node();
         this._dash._background.set_style(oldStyle);
@@ -253,7 +253,7 @@ export class ThemeManager {
         const {settings} = Docking.DockManager;
 
         // Remove prior style edits
-        this._dash._background.set_style(null);
+        this._dash._background.set_style('');
         this._transparency.disable();
 
         // If built-in theme is enabled do nothing else


### PR DESCRIPTION
## Summary

- Replace all `set_style(null)` calls with `set_style('')` to fix strict type enforcement in GJS 1.88+
- Guard against uninitialized `_glossyBackgroundStyle` in `RunningIndicatorDots.update()` (called from parent constructor before field is set)
- Add bounds checking for `get_children()[1]` access in the else branch of `update()` and in `destroy()`

## Problem

On GNOME 50 with GJS 1.88, toggling off the built-in theme (`apply-custom-theme = false`) with `unity-backlit-items` enabled crashes with:

```
Error: Expected type string for argument 'style' but got type undefined
    update@appIconIndicators.js:331
    RunningIndicatorBase@appIconIndicators.js:157
    RunningIndicatorDots@appIconIndicators.js:266
```

**Root cause:** `RunningIndicatorBase`'s constructor calls `this.update()` at line 157, which dispatches to `RunningIndicatorDots.update()`. This runs *before* `RunningIndicatorDots`'s constructor body initializes `this._glossyBackgroundStyle` (lines 320-321). When `applyGlossyEffect` is true, the ternary passes `undefined` to `set_style()`.

Additionally, GJS 1.88 rejects `null` for `set_style()` — it now requires a string argument. Multiple call sites in `appIconIndicators.js` and `theming.js` pass `null`.

## Test plan

- [ ] Enable `unity-backlit-items` and `apply-glossy-effect` in settings
- [ ] Toggle `apply-custom-theme` off — dock should continue displaying all pinned/running apps
- [ ] Toggle `apply-custom-theme` back on — no errors
- [ ] Test with DASHES running indicator style
- [ ] Verify no regression with built-in theme enabled

Tested on: Arch Linux, GNOME 50.1, GJS 1.88.0, Mutter 50.1

🤖 Generated with [Claude Code](https://claude.ai/code)