### PR TITLE
Don't install gschemas.compiled for $(INSTALLTYPE)==system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,9 @@ ifeq ($(INSTALLTYPE),system)
 	mkdir -p $(SHARE_PREFIX)/glib-2.0/schemas $(SHARE_PREFIX)/locale
 	cp -r ./schemas/*.gschema.xml $(SHARE_PREFIX)/glib-2.0/schemas
 	cp -r ./_build/locale/* $(SHARE_PREFIX)/locale
-endif
+else
 	cp schemas/gschemas.compiled $(INSTALLBASE)/$(INSTALLNAME)/schemas/
+endif
 	-rm -fR _build
 	echo done
 


### PR DESCRIPTION
Because $(INSTALLTYPE)==system starts by deleting the target directory so our copy would fail.

Closes: https://github.com/micheleg/dash-to-dock/issues/2602
Fixes: 2bc44a6add ("Makefile: Remember gschemas.compiled for local installs")