### PR TITLE
appIcons: Fix DEFAULT dot position

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -363,6 +363,7 @@ export const DockAbstractAppIcon = GObject.registerClass({
         super._updateDotStyle();
         const themeNode = this._dot.get_theme_node();
         this._dot.translationX = themeNode.get_length('offset-x');
+        this._dot.translationY = 0;
     }
 
     _addUrgentWindow(window) {


### PR DESCRIPTION
Until now, the dot vertical position was -12, inherited from code from Gnome Shell. But with the current layout, that value is wrong and must be zero to ensure that the dot is placed outside the icon, below it.

This patch fixes it.

[LP: #2155129](https://bugs.launchpad.net/ubuntu/+source/gnome-shell-ubuntu-extensions/+bug/2155129)