### PR TITLE
Explain why "scroll over icon" doesn't work

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1763,6 +1763,20 @@
                               </object>
                             </child>
                             <child>
+                              <object class="GtkLabel" id="note_about_fixed_size_icon">
+                                <property name="margin_top">5</property>
+                                <property name="can_focus">0</property>
+                                <property name="hexpand">1</property>
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">Won't work over icons because 'Fixed icon size' is enabled.</property>
+
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">2</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
                               <object class="GtkBox" id="click_box_scroll">
                                 <property name="can_focus">0</property>
                                 <property name="spacing">6</property>

--- a/prefs.js
+++ b/prefs.js
@@ -400,6 +400,11 @@ const DockSettings = GObject.registerClass({
             dockMonitorCombo.set_active(primaryIndex);
     }
 
+    _update_scroll_action_warning() {
+        const sensitive = !this._builder.get_object('icon_size_fixed_checkbutton').get_active();
+        this._builder.get_object('note_about_fixed_size_icon').set_visible(!sensitive);
+    }
+
     _bindSettings() {
         // Position and size panel
 
@@ -785,6 +790,11 @@ const DockSettings = GObject.registerClass({
         this._builder.get_object('click_action_combo').connect('changed', widget => {
             this._settings.set_enum('click-action', widget.get_active());
         });
+
+        this._builder.get_object('icon_size_fixed_checkbutton').connect('toggled', () => {
+            this._update_scroll_action_warning();
+        });
+        this._update_scroll_action_warning();
 
         this._builder.get_object('scroll_action_combo').set_active(this._settings.get_enum('scroll-action'));
         this._builder.get_object('scroll_action_combo').connect('changed', widget => {


### PR DESCRIPTION
When the "Fixed icon size" setting in the first tab is enabled, the "Scroll action" in the third tab does nothing when scrolling over an application icon, although it still works when using it over the "Show applications" icon.

This PR adds a notification to inform the user about this and avoid misunderstandings and bug reports like https://github.com/micheleg/dash-to-dock/issues/2374 .

Closes: https://github.com/micheleg/dash-to-dock/issues/2374