### PR TITLE
Community Edition v106: merge 5 bug fixes + dock margin feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,87 @@
-# Dash to Dock
+# Dash to Dock — Community Edition
+
 ![screenshot](https://github.com/micheleg/dash-to-dock/raw/master/media/screenshot.jpg)
 
-## A dock for the GNOME Shell
-This extension enhances the dash moving it out of the overview and transforming it in a dock for an easier launching of applications and a faster switching between windows and desktops without having to leave the desktop view.
+> A maintained fork of [dash-to-dock](https://github.com/micheleg/dash-to-dock) incorporating community bug fixes and feature contributions that have been awaiting review upstream.
 
-[<img src="https://micheleg.github.io/dash-to-dock/media/get-it-on-ego.png" height="100">](https://extensions.gnome.org/extension/307/dash-to-dock)
+## What's different here
 
-For additional installation instructions and more information visit [https://micheleg.github.io/dash-to-dock/](https://micheleg.github.io/dash-to-dock/).
+This fork merges the most impactful open pull requests from the upstream project. Changes are focused on stability on GNOME 48/49 and quality-of-life improvements.
+
+### Bug fixes merged
+
+| PR | Description | Status |
+|----|-------------|--------|
+| [#2552](https://github.com/micheleg/dash-to-dock/pull/2552) | `intellihide`: Fix overlap check permanently stuck after null workspace on GNOME 48 | ✅ Merged |
+| [#2511](https://github.com/micheleg/dash-to-dock/pull/2511) | Fix autohide not working when panel mode is disabled | ✅ Merged |
+| [#2506](https://github.com/micheleg/dash-to-dock/pull/2506) | Fix 2–4 px icon offset in fixed dock mode | ✅ Merged |
+| [#2467](https://github.com/micheleg/dash-to-dock/pull/2467) | Fix crash in Metro indicator (`Clutter.Color.shade` removed in GNOME 49) | ✅ Merged |
+| [#2244](https://github.com/micheleg/dash-to-dock/pull/2244) | Prevent `wl-clipboard` from appearing in the dock on Wayland | ✅ Merged |
+
+### Features merged
+
+| PR | Description | Status |
+|----|-------------|--------|
+| [#2390](https://github.com/micheleg/dash-to-dock/pull/2390) | **Dock margin size** — new slider in settings (0–300 px) to add space between the dock and the screen edge when using extended/panel mode | ✅ Merged |
+
+## GNOME Shell compatibility
+
+| GNOME | Status |
+|-------|--------|
+| 45–50 | ✅ Supported |
 
 ## Installation from source
 
-The extension can be installed directly from source, either for the convenience of using git or to test the latest development version. Clone the desired branch with git
-
-### Build Dependencies
-
-To compile the stylesheet you'll need an implementation of SASS. Dash to Dock supports `dart-sass` (`sass`), `sassc`, and `ruby-sass`. Every distro should have at least one of these implementations, we recommend using `dart-sass` (`sass`) or `sassc` over `ruby-sass` as `ruby-sass` is deprecated.
-
-By default, Dash to Dock will attempt to build with `sassc`. To change this behavior set the `SASS` environment variable to either `dart` or `ruby`.
-
 ```bash
-export SASS=dart
-# or...
-export SASS=ruby
-```
-
-### Building
-
-Clone the repository or download the branch from github. A simple Makefile is included.
-
-Next use `make` to install the extension into your home directory. A Shell reload is required <kbd>Alt</kbd> + <kbd>F2</kbd> <kbd>r</kbd> <kbd>Enter</kbd> under Xorg or under Wayland you may have to logout and login. The extension has to be enabled  with *gnome-extensions-app* (GNOME Extensions) or with *dconf*.
-
-```bash
-git clone https://github.com/micheleg/dash-to-dock.git
+git clone https://github.com/YOUR_USERNAME/dash-to-dock.git
 make -C dash-to-dock install
 ```
 
-If `msgfmt` is not available on your system, you will see an error message like the following:
+Then reload GNOME Shell:
+- **Xorg**: <kbd>Alt</kbd>+<kbd>F2</kbd> → type `r` → <kbd>Enter</kbd>
+- **Wayland**: Log out and log back in
+
+Enable the extension with *GNOME Extensions* app or with:
 
 ```bash
-make: msgfmt: No such file or directory
+gnome-extensions enable dash-to-dock@micxgx.gmail.com
 ```
 
-In this case install the `gettext` package from your distribution's repository.
+### Build dependencies
 
+You need one of: `dart-sass` (`sass`), `sassc`, or `ruby-sass` to compile the stylesheet.
 
-## Bug Reporting
+```bash
+# Arch
+sudo pacman -S sassc
 
-Bugs should be reported to the Github bug tracker [https://github.com/micheleg/dash-to-dock/issues](https://github.com/micheleg/dash-to-dock/issues).
+# Ubuntu / Debian
+sudo apt install sassc
+
+# Fedora
+sudo dnf install sassc
+```
+
+If `msgfmt` is missing, install `gettext` from your distribution.
+
+## Reporting issues
+
+Please open issues on this repository. When reporting a bug, include:
+
+- GNOME Shell version (`gnome-shell --version`)
+- Extension version (visible in GNOME Extensions app)
+- Steps to reproduce
+- Any errors from `journalctl -f -o cat /usr/bin/gnome-shell` while reproducing
+
+## Contributing
+
+Pull requests are welcome. If you want to include an upstream PR that has been waiting for a while, link it in the PR description so we can track attribution.
+
+## Credits
+
+- Original author: [Michele G (micheleg)](https://github.com/micheleg)
+- All upstream contributors whose PRs are merged here (see table above)
 
 ## License
-Dash to Dock Gnome Shell extension is distributed under the terms of the GNU General Public License,
-version 2 or later. See the COPYING file for details.
+
+GPL-2.0 — see [COPYING](COPYING).

--- a/Settings.ui
+++ b/Settings.ui
@@ -779,6 +779,45 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkListBoxRow" id="dock_margin_size_listboxrow">
+                        <property name="child">
+                          <object class="GtkGrid" id="dock_margin_size_grid">
+                            <property name="can_focus">0</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <property name="column_spacing">32</property>
+                            <child>
+                              <object class="GtkLabel" id="dock_margin_size_label">
+                                <property name="can_focus">0</property>
+                                <property name="label" translatable="yes">Dock margin size</property>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkScale" id="dock_margin_size_scale">
+                                <property name="draw-value">1</property>
+                                <property name="valign">baseline</property>
+                                <property name="hexpand">1</property>
+                                <property name="adjustment">dock_margin_size_adjustment</property>
+                                <property name="round_digits">0</property>
+                                <property name="digits">0</property>
+                                <property name="value_pos">right</property>
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkListBoxRow" id="icon_size_listboxrow">
                         <property name="child">
                           <object class="GtkGrid" id="icon_size_grid">
@@ -2414,6 +2453,12 @@ See the &lt;a href=&quot;https://www.gnu.org/licenses/old-licenses/gpl-2.0.html&
         </property>
       </object>
     </child>
+  </object>
+  <object class="GtkAdjustment" id="dock_margin_size_adjustment">
+    <property name="lower">0</property>
+    <property name="upper">300</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="max_opacity_adjustement">
     <property name="upper">1</property>

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -248,19 +248,10 @@ $dock_style_modes: null, shrink, extended, extended-shrink;
 
         &.fixed {
             #dash {
-                .dash-background {
-                    margin-#{opposite($side)}: $fixed_inner_margin;
-                }
-
-                .dash-item-container {
-
-                    .app-well-app,
-                    .show-apps {
-                        padding-#{opposite($side)}: $padding + $fixed_inner_margin;
-                    }
-                }
+                margin-#{opposite($side)}: $fixed_inner_margin;
             }
         }
+
     }
 }
 
@@ -355,6 +346,14 @@ $dock_style_modes: null, shrink, extended, extended-shrink;
 #dashtodockContainer.straight-corner #dash .dash-background,
 #dashtodockContainer.shrink.straight-corner #dash .dash-background {
     border-radius: 0px;
+}
+
+#dashtodockContainer.extended.dock-margin #dash .dash-background {
+    border-radius: $dash_border_radius;
+}
+
+#dashtodockContainer.extended.shrink.dock-margin #dash .dash-background {
+    border-radius: shrink_light($dash_border_radius);
 }
 
 /* Scrollview style */

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -626,8 +626,9 @@ class RunningIndicatorMetro extends RunningIndicatorDots {
                 const blackenedLength = (1 / 48) * this._width;
                 const darkenedLength = this._source.focused
                     ? (2 / 48) * this._width : (10 / 48) * this._width;
-                const blackenedColor = this._bodyColor.shade(.3);
-                const darkenedColor = this._bodyColor.shade(.7);
+                const [h, s, l] = this._bodyColor.to_hsl();
+                const blackenedColor = Cogl.Color.init_from_hsl(h, s * 0.3, l * 0.3);
+                const darkenedColor = Cogl.Color.init_from_hsl(h, s * 0.7, l * 0.7);
 
                 cr.translate(0, yOffset);
 

--- a/dash.js
+++ b/dash.js
@@ -812,7 +812,9 @@ export const DockDash = GObject.registerClass({
 
             // Second: add the new apps
             running.forEach(app => {
-                if (!showFavorites || !(app.get_id() in favorites))
+                const windows = app.get_windows();
+                if ((!showFavorites || !(app.get_id() in favorites)) &&
+                    !(windows[0] && windows[0].get_title() === 'wl-clipboard'))
                     newApps.push(app);
             });
         }

--- a/docking.js
+++ b/docking.js
@@ -440,17 +440,19 @@ const DockedDash = GObject.registerClass({
     }
 
     _trackDock() {
+        if (this.get_parent())
+            Main.layoutManager.removeChrome(this);
+
         if (DockManager.settings.dockFixed) {
-            if (this.get_parent())
-                Main.layoutManager.removeChrome(this);
             Main.layoutManager.addChrome(this, {
                 trackFullscreen: true,
                 affectsStruts: true,
             });
         } else {
-            if (this.get_parent())
-                Main.layoutManager.removeChrome(this);
-            Main.layoutManager.addChrome(this);
+            Main.layoutManager.addChrome(this, {
+                trackFullscreen: true,
+                affectsStruts: false,
+            });
         }
 
         // Set the initial position.
@@ -553,6 +555,10 @@ const DockedDash = GObject.registerClass({
             () => {
                 this.dash.setIconSize(settings.dashMaxIconSize);
             },
+        ], [
+            settings,
+            'changed::dock-margin-size',
+            this._resetPosition.bind(this),
         ], [
             settings,
             'changed::icon-size-fixed',
@@ -1190,7 +1196,7 @@ const DockedDash = GObject.registerClass({
         // Ensure variables linked to settings are updated.
         this._updateVisibilityMode();
 
-        const {dockFixed: fixedIsEnabled, dockExtended: extendHeight} = DockManager.settings;
+        const {dockFixed: fixedIsEnabled, dockExtended: extendHeight, dockMarginSize: margin} = DockManager.settings;
 
         if (fixedIsEnabled)
             this.add_style_class_name('fixed');
@@ -1219,7 +1225,7 @@ const DockedDash = GObject.registerClass({
             this.y = posY;
 
             if (extendHeight) {
-                this.dash._container.set_width(this.width);
+                this.dash._container.set_width(this.width - margin * 2);
                 this.add_style_class_name('extended');
             } else {
                 this.dash._container.set_width(-1);
@@ -1236,13 +1242,18 @@ const DockedDash = GObject.registerClass({
             this.y = workArea.y + Math.round((1 - fraction) / 2 * workArea.height);
 
             if (extendHeight) {
-                this.dash._container.set_height(this.height);
+                this.dash._container.set_height(this.height - margin * 2);
                 this.add_style_class_name('extended');
             } else {
                 this.dash._container.set_height(-1);
                 this.remove_style_class_name('extended');
             }
         }
+
+        if (margin > 0)
+            this.add_style_class_name('dock-margin');
+        else
+            this.remove_style_class_name('dock-margin');
     }
 
     _updateVisibleDesktop() {
@@ -1992,6 +2003,7 @@ export class DockManager {
         });
         Object.defineProperties(this.settings, {
             dockExtended: {get: () => this.settings.extendHeight},
+            dockMarginSize: {get: () => this.settings.get_int('dock-margin-size')},
         });
     }
 

--- a/intellihide.js
+++ b/intellihide.js
@@ -107,6 +107,11 @@ export class Intellihide {
     enable() {
         this._isEnabled = true;
         this._status = OverlapStatus.UNDEFINED;
+        this._checkOverlapTimeoutContinue = false;
+        if (this._checkOverlapTimeoutId > 0) {
+            GLib.source_remove(this._checkOverlapTimeoutId);
+            this._checkOverlapTimeoutId = 0;
+        }
         global.get_window_actors().forEach(function (wa) {
             this._addWindowSignals(wa);
         }, this);
@@ -128,11 +133,15 @@ export class Intellihide {
     }
 
     _windowCreated(display, metaWindow) {
-        this._addWindowSignals(metaWindow.get_compositor_private());
+        const dominated = metaWindow.get_compositor_private();
+        if (dominated)
+            this._addWindowSignals(dominated);
         this._doCheckOverlap();
     }
 
     _addWindowSignals(wa) {
+        if (this._trackedWindows.has(wa))
+            return;
         if (!this._handledWindow(wa))
             return;
 
@@ -178,7 +187,11 @@ export class Intellihide {
 
         this._checkOverlapTimeoutId = GLib.timeout_add(
             GLib.PRIORITY_DEFAULT, INTELLIHIDE_CHECK_INTERVAL, () => {
-                this._doCheckOverlap();
+                try {
+                    this._doCheckOverlap();
+                } catch (e) {
+                    logError(e, 'intellihide overlap check failed');
+                }
                 if (this._checkOverlapTimeoutContinue) {
                     this._checkOverlapTimeoutContinue = false;
                     return GLib.SOURCE_CONTINUE;
@@ -251,8 +264,12 @@ export class Intellihide {
     // Optionally skip windows of other applications
     _intellihideFilterInteresting(wa) {
         const metaWin = wa.get_meta_window();
+        if (!metaWin)
+            return false;
         const currentWorkspace = global.workspace_manager.get_active_workspace_index();
         const workspace = metaWin.get_workspace();
+        if (!workspace)
+            return false;
         const workspaceIndex = workspace.index();
 
         // Depending on the intellihide mode, exclude non-relevent windows
@@ -318,6 +335,9 @@ export class Intellihide {
         // so we match its window by application id and window property.
         const wmApp = metaWindow.get_gtk_application_id();
         if (ignoreApps.includes(wmApp) && metaWindow.is_skip_taskbar())
+            return false;
+
+        if (metaWindow.get_title() === 'wl-clipboard')
             return false;
 
         // The DropDownTerminal extension uses the POPUP_MENU window type hint

--- a/metadata.json
+++ b/metadata.json
@@ -13,5 +13,5 @@
 "original-author": "micxgx@gmail.com",
 "url": "https://micheleg.github.io/dash-to-dock/",
 "gettext-domain": "dashtodock",
-"version": 105
+"version": 106
 }

--- a/prefs.js
+++ b/prefs.js
@@ -593,17 +593,32 @@ const DockSettings = GObject.registerClass({
         this._builder.get_object('preview_size_scale').set_value(
             this._settings.get_double('preview-size-scale'));
 
+        // Dock Margin Size
+        const dockMarginSizeScale = this._builder.get_object('dock_margin_size_scale');
+        dockMarginSizeScale.set_format_value_func((_, value) => {
+            return `${value} px`;
+        });
+        this._settings.bind(
+            'dock-margin-size',
+            this._builder.get_object('dock_margin_size_adjustment'),
+            'value',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
         // Corrent for rtl languages
         if (this._rtl) {
             // Flip value position: this is not done automatically
             dockSizeScale.set_value_pos(Gtk.PositionType.LEFT);
             iconSizeScale.set_value_pos(Gtk.PositionType.LEFT);
+            dockMarginSizeScale.set_value_pos(Gtk.PositionType.LEFT);
             // I suppose due to a bug, having a more than one mark and one above
             // a value of 100 makes the rendering of the marks wrong in rtl.
             // This doesn't happen setting the scale as not flippable
             // and then manually inverting it
             iconSizeScale.set_flippable(false);
             iconSizeScale.set_inverted(true);
+            dockMarginSizeScale.set_flippable(false);
+            dockMarginSizeScale.set_inverted(true);
         }
 
         this._settings.bind('icon-size-fixed',
@@ -624,6 +639,10 @@ const DockSettings = GObject.registerClass({
             Gio.SettingsBindFlags.DEFAULT);
         this._settings.bind('extend-height',
             this._builder.get_object('dock_center_icons_check'),
+            'sensitive',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('extend-height',
+            this._builder.get_object('dock_margin_size_scale'),
             'sensitive',
             Gio.SettingsBindFlags.DEFAULT);
 

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -317,6 +317,11 @@
       <default>false</default>
       <summary>Center icons when dock container is extended to all the available size</summary>
     </key>
+    <key name="dock-margin-size" type="i">
+      <default>0</default>
+      <summary>Dock margin size</summary>
+      <description>The margin size around the dock in pixels when panel mode is enabled (0-300).</description>
+    </key>
     <key type="i" name="preferred-monitor">
       <default>-2</default>
       <summary>DEPRECATED: Monitor on which putting the dock (by index)</summary>


### PR DESCRIPTION
Bug fixes (upstream PRs):
- intellihide: fix overlap check permanently stuck on GNOME 48 (PR #2552)
  - try-catch in timeout callback, null guards for workspace/compositor
  - prevent duplicate signal handlers, clear stale timeout on enable()
- Fix autohide not working when panel mode is disabled (PR #2511)
  - addChrome now always passes trackFullscreen regardless of dock-fixed
- Fix 2-4px icon offset in fixed dock mode (PR #2506)
  - consolidate margin onto #dash directly instead of child elements
- Fix Metro running indicator crash on GNOME 49 (PR #2467)
  - Clutter.Color.shade removed; reimplemented via Cogl.Color.init_from_hsl
- Prevent wl-clipboard from appearing in dock on Wayland (PR #2244)

New feature:
- Dock margin size customization (PR #2390)
  - Settings slider (0-300 px) when panel/extended mode is active
  - New GSettings key: dock-margin-size
  - Enabled only when extend-height is on

Version bumped to 106.