### PR TITLE
docking: Use a place-holder dash actor during startup

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2184,20 +2184,17 @@ export class DockManager {
     }
 
     _prepareMainDash() {
+        this._propertyInjections.removeWithLabel(Labels.MAIN_DASH);
+
         // Ensure Main.overview.dash is set to our dash in dummy mode
         // while just use the default getter otherwise.
-        // The getter must be dynamic and not set only when we've a dummy
-        // overview because the mode can change dynamically.
-        this._propertyInjections.removeWithLabel(Labels.MAIN_DASH);
-        const defaultDashGetter = Object.getOwnPropertyDescriptor(
-            Main.overview.constructor.prototype, 'dash').get;
-        this._propertyInjections.addWithLabel(Labels.MAIN_DASH, Main.overview, 'dash', {
-            get: () => Main.overview.isDummy
-                ? this.mainDock.dash : defaultDashGetter.call(Main.overview),
-        });
+        if (Main.overview.isDummy) {
+            this._propertyInjections.addWithLabel(Labels.MAIN_DASH, Main.overview, 'dash', {
+                get: () => this.mainDock.dash,
+            });
 
-        if (Main.overview.isDummy)
             return;
+        }
 
         // Hide usual Dash
         this._oldDash.hide();

--- a/docking.js
+++ b/docking.js
@@ -2515,7 +2515,7 @@ export class DockManager {
     }
 
     _restoreDash() {
-        if (!this._oldDash)
+        if (!this._oldDash || this.overviewControls.dash === this._oldDash)
             return;
 
         this._signalsHandler.removeWithLabel(Labels.OLD_DASH_CHANGES);

--- a/docking.js
+++ b/docking.js
@@ -2222,8 +2222,10 @@ export class DockManager {
 
         // Pretend I'm the dash: meant to make app grid swarm animation come from
         // the right position of the appShowButton.
-        this.overviewControls.dash = this.mainDock.dash;
-        this.searchController._showAppsButton = this.mainDock.dash.showAppsButton;
+        const replaceMainDash = () => {
+            this.overviewControls.dash = this.mainDock.dash;
+            this.searchController._showAppsButton = this.mainDock.dash.showAppsButton;
+        };
 
         // We also need to ignore max-size changes
         this._methodInjections.addWithLabel(Labels.MAIN_DASH, this._oldDash,
@@ -2482,12 +2484,24 @@ export class DockManager {
                     OverviewControls.ControlsState.HIDDEN;
             }
 
+            // Use a dummy actor as dash during the startup animation, until
+            // we're done with it, so that nothing is really shown or modified
+            // during the upstream startup animation, that still requires to
+            // have a valid actor.
+            const dummyDash = new Clutter.Actor({visible: false, opacity: 0});
+            this.overviewControls.dash = dummyDash;
+            Main.uiGroup.add_child(dummyDash);
+
             this._signalsHandler.addWithLabel(Labels.STARTUP_ANIMATION,
                 Main.layoutManager, 'startup-complete', () => {
                     this._signalsHandler.removeWithLabel(Labels.STARTUP_ANIMATION);
                     Main.sessionMode.hasOverview = hadOverview;
+                    replaceMainDash();
+                    dummyDash.destroy();
                     this._runStartupAnimation();
                 });
+        } else {
+            replaceMainDash();
         }
     }
 

--- a/docking.js
+++ b/docking.js
@@ -2476,9 +2476,11 @@ export class DockManager {
             // Reset overview controls state to HIDDEN, as skipping the startup
             // overview leaves it stuck at WINDOW_PICKER
             if (this._settings.disableOverviewOnStartup) {
-                Main.sessionMode.hasOverview = false;
-                Main.overview._overview.controls._stateAdjustment.value =
-                    OverviewControls.ControlsState.HIDDEN;
+                const {OverviewAdjustment} = OverviewControls;
+                this._propertyInjections.addWithLabel(Labels.STARTUP_ANIMATION,
+                    OverviewAdjustment.prototype, 'value', {
+                        get: () => OverviewControls.ControlsState.HIDDEN,
+                    });
             }
 
             // Use a dummy actor as dash during the startup animation, until
@@ -2496,6 +2498,11 @@ export class DockManager {
                     replaceMainDash();
                     dummyDash.destroy();
                     this._runStartupAnimation();
+                    if (this._settings.disableOverviewOnStartup) {
+                        this._propertyInjections.removeWithLabel(Labels.STARTUP_ANIMATION);
+                        Main.overview._overview.controls._stateAdjustment.value =
+                            OverviewControls.ControlsState.HIDDEN;
+                    }
                 });
         } else {
             replaceMainDash();


### PR DESCRIPTION
When starting-up we do not want to show the real dash, but neither
to warn when upstream code tries to use the upstream dash features.

So during that phase, replace the upstream dash with a dummy empty actor
that is still part of the UI group.

LP: #2150429

Closes: https://github.com/micheleg/dash-to-dock/issues/2582 
Closes: #2592