### PR TITLE
Add per-monitor dock position overrides

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -556,7 +556,7 @@
                                 <property name="can_focus">0</property>
                                 <property name="hexpand">1</property>
                                 <property name="xalign">0</property>
-                                <property name="label" translatable="yes">Position on screen</property>
+                                <property name="label" translatable="yes">Global position on screen</property>
 
                               </object>
                             </child>

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -149,7 +149,7 @@ class RunningIndicatorBase extends IndicatorBase {
     constructor(source) {
         super(source);
 
-        this._side = Utils.getPosition();
+        this._side = Utils.getPosition(this._source.monitorIndex);
         this._dominantColorExtractor = new DominantColorExtractor(this._source.app);
         this._signalsHandler.add(this._source, 'notify::running', () => this.update());
         this._signalsHandler.add(this._source, 'notify::focused', () => this.update());

--- a/appIcons.js
+++ b/appIcons.js
@@ -461,7 +461,7 @@ export const DockAbstractAppIcon = GObject.registerClass({
                     // scrollable so the minimum height is smaller than the natural height.
                     const monitorIndex = Main.layoutManager.findIndexForActor(this);
                     const workArea = Main.layoutManager.getWorkAreaForMonitor(monitorIndex);
-                    const position = Utils.getPosition();
+                    const position = Utils.getPosition(monitorIndex);
                     const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
                     const isHorizontal = position === St.Side.TOP || position === St.Side.BOTTOM;
                     // If horizontal also remove the height of the dash
@@ -1018,7 +1018,7 @@ export function makeAppIcon(app, monitorIndex, iconAnimator) {
  */
 const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
     constructor(source) {
-        super(source, 0.5, Utils.getPosition());
+        super(source, 0.5, Utils.getPosition(source.monitorIndex));
 
         this._signalsHandler = new Utils.GlobalSignalsHandler(this);
 
@@ -1590,7 +1590,8 @@ export function itemShowLabel() {
 
     let x, y, xOffset, yOffset;
 
-    const position = Utils.getPosition();
+    const position = Utils.getPosition(
+        this.monitorIndex ?? Main.layoutManager.findIndexForActor(this));
     const labelOffset = node.get_length('-x-offset');
 
     switch (position) {

--- a/dash.js
+++ b/dash.js
@@ -155,7 +155,7 @@ export const DockDash = GObject.registerClass({
         this._separator = null;
 
         this._monitorIndex = monitorIndex;
-        this._position = Utils.getPosition();
+        this._position = Utils.getPosition(this._monitorIndex);
         this._isHorizontal = (this._position === St.Side.TOP) ||
                                (this._position === St.Side.BOTTOM);
 

--- a/docking.js
+++ b/docking.js
@@ -222,7 +222,7 @@ const DockedDash = GObject.registerClass({
     },
 }, class DashToDock extends St.Bin {
     _init(params) {
-        this._position = Utils.getPosition();
+        this._position = Utils.getPosition(params?.monitorIndex);
 
         // This is the centering actor
         super._init({
@@ -2008,6 +2008,10 @@ export class DockManager {
         ], [
             this._settings,
             'changed::multi-monitor',
+            this._toggle.bind(this),
+        ], [
+            this._settings,
+            'changed::monitor-positions',
             this._toggle.bind(this),
         ], [
             this._settings,

--- a/prefs.js
+++ b/prefs.js
@@ -426,8 +426,9 @@ const DockSettings = GObject.registerClass({
                 continue;
 
             const label = new Gtk.Label({
-                label: `${__('Position on ')}${monitor.displayName} - ${
-                    monitor.connector}`,
+                // Translators: %s is the monitor name, e.g. "Dell 27 - DP-1"
+                label: __('Position on %s').replace('%s',
+                    `${monitor.displayName} - ${monitor.connector}`),
                 halign: Gtk.Align.START,
                 hexpand: true,
                 xalign: 0,
@@ -449,8 +450,12 @@ const DockSettings = GObject.registerClass({
                     positions[connector] = side;
                 else
                     delete positions[connector];
+                // The guard keeps our own (synchronously emitted) changed
+                // signal from rebuilding the rows under the focused combo
+                this._savingMonitorPositions = true;
                 this._settings.set_value('monitor-positions',
                     new GLib.Variant('a{ss}', positions));
+                this._savingMonitorPositions = false;
             });
 
             const grid = new Gtk.Grid({
@@ -485,6 +490,12 @@ const DockSettings = GObject.registerClass({
         this._monitorsConfig.connect('updated', () => {
             this._updateMonitorsSettings();
             this._updateMonitorPositionRows();
+        });
+        // Rebuild the rows when the stored overrides change behind our
+        // back (e.g. a dconf edit), but not for our own combo writes
+        this._settings.connect('changed::monitor-positions', () => {
+            if (!this._savingMonitorPositions)
+                this._updateMonitorPositionRows();
         });
         this._settings.connect('changed::preferred-monitor',
             () => this._updateMonitorsSettings());

--- a/prefs.js
+++ b/prefs.js
@@ -207,6 +207,7 @@ const DockSettings = GObject.registerClass({
         this._opacity_timeout = 0;
 
         this._monitorsConfig = new MonitorsConfig();
+        this._monitorPositionRows = [];
         this._bindSettings();
     }
 
@@ -400,6 +401,75 @@ const DockSettings = GObject.registerClass({
             dockMonitorCombo.set_active(primaryIndex);
     }
 
+    // One row per connected monitor to choose its dock position
+    // independently, inserted below the "Show the dock on" row.
+    _updateMonitorPositionRows() {
+        const anchorRow = this._builder.get_object('dock_monitor_listboxrow');
+        const listbox = anchorRow.get_parent();
+
+        this._monitorPositionRows.forEach(row => listbox.remove(row));
+        this._monitorPositionRows = [];
+
+        const stored =
+            this._settings.get_value('monitor-positions').deep_unpack();
+        // Combo ids are the schema side names, resolved via St.Side[side]
+        const sideLabels = {
+            TOP: __('Top'),
+            RIGHT: __('Right'),
+            BOTTOM: __('Bottom'),
+            LEFT: __('Left'),
+        };
+
+        let insertAt = anchorRow.get_index() + 1;
+        for (const monitor of this._monitorsConfig.monitors) {
+            if (!monitor.active)
+                continue;
+
+            const label = new Gtk.Label({
+                label: `${__('Position on ')}${monitor.displayName} - ${
+                    monitor.connector}`,
+                halign: Gtk.Align.START,
+                hexpand: true,
+                xalign: 0,
+            });
+
+            const combo = new Gtk.ComboBoxText({valign: Gtk.Align.CENTER});
+            combo.append('', __('Follow global setting'));
+            for (const [side, sideLabel] of Object.entries(sideLabels))
+                combo.append(side, sideLabel);
+            if (!combo.set_active_id(stored[monitor.connector] ?? ''))
+                combo.set_active_id('');
+
+            const {connector} = monitor;
+            combo.connect('changed', () => {
+                const positions = this._settings
+                    .get_value('monitor-positions').deep_unpack();
+                const side = combo.get_active_id();
+                if (side)
+                    positions[connector] = side;
+                else
+                    delete positions[connector];
+                this._settings.set_value('monitor-positions',
+                    new GLib.Variant('a{ss}', positions));
+            });
+
+            const grid = new Gtk.Grid({
+                column_spacing: 32,
+                margin_start: 12,
+                margin_end: 12,
+                margin_top: 6,
+                margin_bottom: 6,
+            });
+            grid.attach(label, 0, 0, 1, 1);
+            grid.attach(combo, 1, 0, 1, 1);
+
+            const row = new Gtk.ListBoxRow({activatable: false});
+            row.set_child(grid);
+            listbox.insert(row, insertAt++);
+            this._monitorPositionRows.push(row);
+        }
+    }
+
     _update_scroll_action_warning() {
         const sensitive = !this._builder.get_object('icon_size_fixed_checkbutton').get_active();
         this._builder.get_object('note_about_fixed_size_icon').set_visible(!sensitive);
@@ -409,8 +479,13 @@ const DockSettings = GObject.registerClass({
         // Position and size panel
 
         this._updateMonitorsSettings();
-        this._monitorsConfig.connect('updated',
-            () => this._updateMonitorsSettings());
+        // The position rows only depend on the monitor list, not on the
+        // preferred-monitor keys, so they are rebuilt here only
+        this._updateMonitorPositionRows();
+        this._monitorsConfig.connect('updated', () => {
+            this._updateMonitorsSettings();
+            this._updateMonitorPositionRows();
+        });
         this._settings.connect('changed::preferred-monitor',
             () => this._updateMonitorsSettings());
         this._settings.connect('changed::preferred-monitor-by-connector',

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -332,6 +332,11 @@
       <summary>Enable multi-monitor docks</summary>
       <description>Show a dock on every monitor</description>
     </key>
+    <key type="a{ss}" name="monitor-positions">
+      <default>{}</default>
+      <summary>Per-monitor dock position overrides</summary>
+      <description>Map from monitor connector name (for example 'DP-1') to the side of that monitor the dock is shown on: 'TOP', 'RIGHT', 'BOTTOM' or 'LEFT'. Monitors without an entry follow the 'dock-position' setting. Overrides are applied as-is, without swapping left and right in right-to-left locales.</description>
+    </key>
     <key type="b" name="minimize-shift">
       <default>true</default>
       <summary>Minimize on shift+click</summary>

--- a/theming.js
+++ b/theming.js
@@ -153,7 +153,7 @@ export class ThemeManager {
         // We want to find the inside border-color of the dock because it is
         // the side most visible to the user. We do this by finding the side
         // opposite the position
-        const position = Utils.getPosition();
+        const position = Utils.getPosition(this._actor.monitorIndex);
         let side = position + 2;
         if (side > 3)
             side = Math.abs(side - 4);
@@ -261,7 +261,7 @@ export class ThemeManager {
             return;
 
         let newStyle = '';
-        const position = Utils.getPosition(settings);
+        const position = Utils.getPosition(this._actor.monitorIndex);
 
         // obtain theme border settings
         const themeNode = this._dash._background.get_theme_node();
@@ -337,7 +337,7 @@ class Transparency {
         this._dockActor = dock;
         this._dock = dock;
         this._panel = Main.panel;
-        this._position = Utils.getPosition();
+        this._position = Utils.getPosition(dock.monitorIndex);
 
         // All these properties are replaced with the ones in the .dummy-opaque
         // and .dummy-transparent css classes

--- a/utils.js
+++ b/utils.js
@@ -451,9 +451,39 @@ export class PropertyInjectionsHandler extends BasicHandler {
 }
 
 /**
- * Return the actual position reverseing left and right in rtl
+ * Return the position override configured for a monitor in the
+ * monitor-positions setting, or null if the monitor has none.
+ *
+ * @param monitorIndex the monitor to look up
  */
-export function getPosition() {
+function getMonitorPositionOverride(monitorIndex) {
+    // -1 means "no monitor": never match it against an override whose
+    // connector is currently unplugged (get_monitor_for_connector also
+    // returns -1 for those)
+    if (monitorIndex < 0)
+        return null;
+    const {monitorPositions} = Docking.DockManager.settings;
+    const monitorManager = getMonitorManager();
+    for (const [connector, side] of Object.entries(monitorPositions)) {
+        if (monitorManager.get_monitor_for_connector(connector) === monitorIndex)
+            return St.Side[side] ?? null;
+    }
+    return null;
+}
+
+/**
+ * Return the actual position reverseing left and right in rtl
+ *
+ * @param monitorIndex optional monitor to return the position for, honoring
+ *                     its monitor-positions override if one is set
+ */
+export function getPosition(monitorIndex) {
+    if (monitorIndex !== undefined && monitorIndex !== null) {
+        // Explicit per-monitor overrides are used as-is, without rtl flipping
+        const override = getMonitorPositionOverride(monitorIndex);
+        if (override !== null)
+            return override;
+    }
     const position = Docking.DockManager.settings.dockPosition;
     if (Clutter.get_default_text_direction() === Clutter.TextDirection.RTL) {
         if (position === St.Side.LEFT)

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -36,7 +36,7 @@ const MENU_MARGINS = 10;
 
 export class WindowPreviewMenu extends PopupMenu.PopupMenu {
     constructor(source) {
-        super(source, 0.5, Utils.getPosition());
+        super(source, 0.5, Utils.getPosition(source.monitorIndex));
 
         // We want to keep the item hovered while the menu is up
         this.blockSourceEvents = true;
@@ -105,8 +105,9 @@ class WindowPreviewList extends PopupMenu.PopupMenuSection {
 
         this.actor.connect('scroll-event', this._onScrollEvent.bind(this));
 
-        const position = Utils.getPosition();
-        this.isHorizontal = position === St.Side.BOTTOM || position === St.Side.TOP;
+        this._position = Utils.getPosition(source.monitorIndex);
+        this.isHorizontal = this._position === St.Side.BOTTOM ||
+            this._position === St.Side.TOP;
         this.box.set_vertical(!this.isHorizontal);
         this.box.set_name('dashtodockWindowList');
         Utils.addActor(this.actor, this.box);
@@ -179,7 +180,7 @@ class WindowPreviewList extends PopupMenu.PopupMenuSection {
     }
 
     _createPreviewItem(window) {
-        const preview = new WindowPreviewMenuItem(window, Utils.getPosition());
+        const preview = new WindowPreviewMenuItem(window, this._position);
         return preview;
     }
 


### PR DESCRIPTION
## What this does

With multi-monitor docks enabled, every dock currently sits on the same edge (`dock-position`) of its monitor. This PR lets each monitor override that: in **Position and size**, below *Show the dock on*, there is one row per connected monitor with a dropdown — **Follow global setting / Top / Right / Bottom / Left**.

Motivating setup: a laptop panel on the left of an external monitor. The dock on the laptop makes sense on the left edge, but on the external monitor the right edge is where the user actually is.

## Design

- New `monitor-positions` key of type `a{ss}`, mapping **monitor connector names** (e.g. `DP-1`) to `TOP`/`RIGHT`/`BOTTOM`/`LEFT`. Keying by connector (same approach as `preferred-monitor-by-connector`) means overrides survive unplug/replug and never leak onto other monitors. The default `{}` changes no behavior.
- `Utils.getPosition()` gains an optional `monitorIndex` argument, threaded through from all position-dependent code paths (dock placement, theming, running-indicator sides, app icon menus, window previews, tooltips). Callers that pass nothing behave exactly as before.
- The parsed map comes from `DockManager.settings.monitorPositions` via the existing `_mapSettingsValues()` machinery, so there is no new settings plumbing, caching, or cleanup; docks are rebuilt on `changed::monitor-positions` like the other layout keys.
- A monitor index of -1 ("no monitor", e.g. from `findIndexForActor`) never matches an override, including overrides whose connector is currently unplugged (`get_monitor_for_connector` also returns -1 for those).
- Overrides are applied as-is, without the RTL left/right swap: the user picks a physical edge of a specific monitor. This is documented in the schema description.
- The existing *Position on screen* label is renamed to **Global position on screen** so its relationship with the per-monitor rows is explicit. (This changes one translatable string; existing translations of it will fall back to English until catalogs are updated.)
- Drive-by fix: `ThemeManager._adjustTheme` passed a stray `settings` argument to the previously parameterless `Utils.getPosition()`.

## Testing

Developed and daily-driven on GNOME Shell 50.3 (Wayland, CachyOS) on a two-monitor setup (laptop eDP-1 dock on the left, external DP-4 dock on the right), exercising dock placement, intellihide, theming/transparency, app icon menus, window previews and tooltips on both monitors, plus override add/change/remove from the prefs UI and monitor hotplug.

## Disclosure

This code was written by AI (Anthropic Claude, model Claude Fable 5, `claude-fable-5`, running in Claude Code) under my direction and review, and is stated as such in the commit message. Happy to adjust anything — naming, schema shape, UI placement — to fit the project's preferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
