### PR TITLE
appIcons: fix stale cached focus state breaking click actions

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -137,7 +137,13 @@ export const DockAbstractAppIcon = GObject.registerClass({
         }
 
         this._signalsHandler.add(this.app, 'windows-changed', () => this._updateWindows());
-        this._signalsHandler.add(this.app, 'notify::state', () => this._updateRunningState());
+        this._signalsHandler.add(this.app, 'notify::state', () => {
+            this._updateRunningState();
+            // The focus state depends on the running state, and may have
+            // been computed while the app was still starting: recompute it
+            // now that the state changed (e.g. STARTING -> RUNNING).
+            this._updateFocusState();
+        });
         this._signalsHandler.add(global.display, 'window-demands-attention', (_dpy, window) =>
             this._onWindowDemandsAttention(window));
         this._signalsHandler.add(global.display, 'window-marked-urgent', (_dpy, window) =>
@@ -541,6 +547,12 @@ export const DockAbstractAppIcon = GObject.registerClass({
             break;
         }
 
+        // The cached running/focused/urgent state can be stale if the
+        // tracking events arrived in an unlucky order while the app was
+        // starting: recompute it at click time so the action always
+        // matches the actual state (see issues #2377 and #2468).
+        this._updateState();
+
         // We check if the app is running, and that the # of windows is > 0 in
         // case we use workspace isolation.
         const windows = this.getInterestingWindows();
@@ -565,7 +577,7 @@ export const DockAbstractAppIcon = GObject.registerClass({
                         // minimize all windows on double click and always in
                         // the case of primary click without additional modifiers
                         let clickCount = 0;
-                        if (Clutter.EventType.CLUTTER_BUTTON_PRESS)
+                        if (event?.type() === Clutter.EventType.BUTTON_PRESS)
                             clickCount = event.get_click_count();
                         const allWindows = (button === 1 && !modifiers) || clickCount > 1;
                         this._minimizeWindow(allWindows);


### PR DESCRIPTION
## What this fixes

Fixes #2468 and #2377: click actions (most visibly `minimize`) intermittently do nothing, until the app loses and regains focus.

## Root cause

The click actions rely on the icon's cached `focused` flag, computed in `_updateFocusState()` as `tracker.focus_app === this.app && this.running`. During app startup the tracking events can arrive in an order that leaves it permanently stale:

1. The icon is created while the app is `STARTING` (`running = false`).
2. `notify::focus-app` fires when the new window takes focus — `tracker.focus_app` is right, but `running` is still `false`, so `focused` is computed `false`.
3. `notify::state` fires for `STARTING → RUNNING`, but its handler only called `_updateRunningState()` — nothing re-evaluates `focused`.

The icon now believes the app is unfocused. Clicking it takes the activate branch, which is a no-op on an already-focused window, and since that doesn't change `tracker.focus_app`, no event ever heals the flag. Only a real focus change (switching to another window) fixes it — matching the reproduction steps in both issues.

## The fix

- **Root cause**: recompute the focus state in the `notify::state` handler, since `focused` depends on `running`.
- **Defense in depth**: refresh the icon's cached state once at the top of `activate()`, so any other stale path (e.g. the minimized-single-window case reported in #2468, and the workaround suggested in the #2377 discussion) self-corrects at click time. This is one extra state computation per click, so the cost is negligible.
- **Drive-by fix** in the same code path: the double-click detection in the `MINIMIZE` action tested `Clutter.EventType.CLUTTER_BUTTON_PRESS`, which doesn't exist in GJS (the member is `BUTTON_PRESS`), so it was always falsy and `event.get_click_count()` was never called. It now checks the current event's type.

## Testing

Bug reproduced reliably on GNOME Shell 50.3 (Wayland, two-monitor setup) with `click-action=minimize`: open GNOME Settings for the first time, click its dock icon — nothing happens until you switch focus away and back, after which minimize works. The patched build is shipping in a fork I maintain and is being verified on the same setup; I'll report back on this PR if anything shakes out.

## Disclosure

This code was written by AI (Anthropic Claude, model Claude Fable 5, `claude-fable-5`, running in Claude Code) under my direction and review, and is stated as such in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
