### PR TITLE
appIcons: focus the already-open prefs window from the Settings item

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -1560,8 +1560,19 @@ class DockShowAppsIconMenu extends DockAppIconMenu {
         this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem(__('Dash to Dock')));
 
         const item = this._appendMenuItem(_('Settings'));
-        item.connect('activate', () =>
-            Docking.DockManager.extension.openPreferences());
+        item.connect('activate', () => {
+            // The Shell prefs service refuses to open a second prefs dialog
+            // without presenting the existing one, so requesting it again
+            // would silently do nothing: if our prefs window (whose title is
+            // set to the extension name) is already open, focus it instead.
+            const {extension} = Docking.DockManager;
+            const prefsWindow = global.get_window_actors().map(a => a.meta_window)
+                .find(w => w.get_title() === extension.metadata.name);
+            if (prefsWindow)
+                Main.activateWindow(prefsWindow);
+            else
+                extension.openPreferences();
+        });
     }
 }
 


### PR DESCRIPTION
## What this fixes

With the Dash to Dock settings window already open but not focused, right-clicking the Show Apps button and clicking **Settings** silently does nothing — the existing window is not raised, and the journal gets an unhandled promise rejection from `openExtensionPrefs`.

## Root cause

GNOME Shell's `org.gnome.Shell.Extensions` D-Bus service allows a single prefs dialog at a time; a second `OpenExtensionPrefs` call is rejected with `Already showing a prefs dialog` **without presenting the existing dialog** (see `OpenExtensionPrefsAsync` in `js/dbusServices/extensions/extensionsService.js`). The menu item's `extension.openPreferences()` call has no way to catch this — the rejection happens inside the Shell's own async chain.

## The fix

The prefs dialog's title is set by the service to exactly `extension.metadata.name` (`ExtensionPrefsDialog`), so the extension can find its own already-open prefs window and focus it, only asking the service to open the dialog when none exists. This turns the no-op into the behavior users expect: the settings window comes to the front, on the current workspace.

The arguably *proper* fix is in GNOME Shell itself (present the existing dialog instead of throwing), but that only helps on future Shell releases; this makes the extension behave correctly on all currently supported ones (45+). If a *different* extension's prefs dialog is the one blocking the service, behavior is unchanged from today.

## Testing

Reproduced reliably on GNOME Shell 50.3 (Wayland): open the extension settings, focus another window, Show Apps right-click → Settings — nothing happens, with the matching unhandled rejection in the journal (also reproducible from the CLI: a second `gnome-extensions prefs <uuid>` fails with "Already showing a prefs dialog"). The patch is shipping in a fork I maintain and is being verified on the same setup; I'll report back here.

## Disclosure

This code was written by AI (Anthropic Claude, model Claude Fable 5, `claude-fable-5`, running in Claude Code) under my direction and review, and is stated as such in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
