### PR TITLE
metadata: Enable support for GNOME 51

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
     "47",
     "48",
     "49",
-    "50"
+    "50",
+    "51"
 ],
 "uuid": "dash-to-dock@micxgx.gmail.com",
 "name": "Dash to Dock",


### PR DESCRIPTION
It appears to work with 51.alpha so let's get started.