### PR TITLE
intellihide: ignore wl-clipboard helper windows

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -46,6 +46,12 @@ const handledWindowTypes = [
 // List of applications, ignore windows of these applications in considering intellihide
 const ignoreApps = ['com.rastersoft.ding', 'com.desktop.ding'];
 
+// Clipboard tools like wl-clipboard map a short-lived invisible window on
+// every clipboard access; it briefly becomes the top/focused window, which
+// made the dock flash whenever an application polled the selection. Ignore
+// such helper windows entirely.
+const ignoreWMClasses = ['io.github.bugaevc.wl-clipboard'];
+
 /**
  * A rough and ugly implementation of the intellihide behaviour.
  * Intallihide object: emit 'status-changed' signal when the overlap of windows
@@ -318,6 +324,9 @@ export class Intellihide {
         // so we match its window by application id and window property.
         const wmApp = metaWindow.get_gtk_application_id();
         if (ignoreApps.includes(wmApp) && metaWindow.is_skip_taskbar())
+            return false;
+
+        if (ignoreWMClasses.includes(metaWindow.get_wm_class()))
             return false;
 
         // The DropDownTerminal extension uses the POPUP_MENU window type hint


### PR DESCRIPTION
wl-clipboard maps a short-lived invisible window on every clipboard access. It briefly becomes the top window and blips the focus-app tracking, so the focused window is filtered out of the overlap set and the dock flashes in and out whenever an application polls the selection (for example a terminal running a tool that watches the clipboard). Exclude such helper windows from intellihide entirely, like the existing DING and DropDownTerminal special cases.