### PR TITLE
extension: Disable the extension on shutdown

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -1717,6 +1717,7 @@ export class DockManager {
 
         this._desktopIconsUsableArea = new DesktopIconsIntegration.DesktopIconsUsableAreaClass(extension);
         this._oldDash = Main.overview.isDummy ? null : Main.overview.dash;
+        this._signalsHandler.add(this._oldDash, 'destroy', () => (this._oldDash = null));
         this._discreteGpuAvailable = AppDisplay.discreteGpuAvailable;
         this._appSpread = new AppSpread.AppSpread();
         this._notificationsMonitor = new NotificationsMonitor.NotificationsMonitor();

--- a/docking.js
+++ b/docking.js
@@ -2480,6 +2480,7 @@ export class DockManager {
                 this._propertyInjections.addWithLabel(Labels.STARTUP_ANIMATION,
                     OverviewAdjustment.prototype, 'value', {
                         get: () => OverviewControls.ControlsState.HIDDEN,
+                        set: () => {},
                     });
             }
 

--- a/docking.js
+++ b/docking.js
@@ -2501,7 +2501,7 @@ export class DockManager {
                     this._runStartupAnimation();
                     if (this._settings.disableOverviewOnStartup) {
                         this._propertyInjections.removeWithLabel(Labels.STARTUP_ANIMATION);
-                        Main.overview._overview.controls._stateAdjustment.value =
+                        this.overviewControls._stateAdjustment.value =
                             OverviewControls.ControlsState.HIDDEN;
                     }
                 });

--- a/extension.js
+++ b/extension.js
@@ -8,10 +8,15 @@ export let dockManager;
 
 export default class DashToDockExtension extends Extension.Extension {
     enable() {
+        // TODO: Remove this when upstream will disable extensions on shutdown
+        // See: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/4214
+        this._shutdownID = global.connect('shutdown', () => this.disable());
         dockManager = new DockManager(this);
     }
 
     disable() {
+        global.disconnect(this._shutdownID);
+        delete this._shutdownID;
         dockManager?.destroy();
         dockManager = null;
     }

--- a/utils.js
+++ b/utils.js
@@ -221,6 +221,8 @@ export class GlobalSignalsHandler extends BasicHandler {
         if (isDestroy && isParentObject) {
             this._parentObject.disconnect(this._destroyId);
             this._connectToParentDestroy();
+        } else if (!isParentObject && !isDestroy) {
+            this._monitorDestruction(object);
         }
 
         return [object, id];

--- a/utils.js
+++ b/utils.js
@@ -40,9 +40,19 @@ const BasicHandler = class DashToDockBasicHandler {
             if (!(parentObject instanceof GObject.Object) ||
                 GObject.signal_lookup('destroy', parentObject.constructor.$gtype)) {
                 this._parentObject = parentObject;
-                this._destroyId = parentObject.connect('destroy', () => this.destroy());
+                this._connectToParentDestroy();
             }
         }
+    }
+
+    _connectToParentDestroy() {
+        const parentObject = this._parentObject;
+        this._destroyId = parentObject.connect('destroy', () => {
+            this._onParentDestroy(parentObject);
+            this._parentObject = null;
+            this._destroyId = 0;
+            this.destroy();
+        });
     }
 
     add(...args) {
@@ -57,10 +67,18 @@ const BasicHandler = class DashToDockBasicHandler {
     }
 
     destroy() {
-        this._parentObject?.disconnect(this._destroyId);
+        const parentObject = this._parentObject;
+        const destroyId = this._destroyId;
         this._parentObject = null;
+        this._destroyId = 0;
+
+        if (destroyId)
+            parentObject.disconnect(destroyId);
 
         this.clear();
+    }
+
+    _onParentDestroy(_parentObject) {
     }
 
     block() {
@@ -202,21 +220,53 @@ export class GlobalSignalsHandler extends BasicHandler {
 
         if (isDestroy && isParentObject) {
             this._parentObject.disconnect(this._destroyId);
-            this._destroyId =
-                this._parentObject.connect('destroy', () => this.destroy());
+            this._connectToParentDestroy();
         }
 
         return [object, id];
     }
 
-    _removeForObject(object) {
+    _monitorDestruction(object) {
+        if (!(object instanceof GObject.Object) ||
+            !GObject.signal_lookup('destroy', object.constructor.$gtype))
+            return;
+
+        this._destroyHandlersIds ??= new Map();
+        if (this._destroyHandlersIds.has(object))
+            return;
+
+        const connector = object.connect_after ?? object.connect;
+        const id = connector.call(object, 'destroy',
+            () => this._removeForObject(object, false));
+        this._destroyHandlersIds.set(object, id);
+    }
+
+    _removeForObject(object, disconnect = true) {
         Object.getOwnPropertySymbols(this._storage).forEach(label =>
             (this._storage[label] = this._storage[label].filter(it => {
                 if (it[0] !== object)
                     return true;
-                this._remove(it);
+                if (disconnect)
+                    this._remove(it);
                 return false;
             })));
+
+        const monitorId = this._destroyHandlersIds?.get(object);
+        if (monitorId) {
+            this._destroyHandlersIds.delete(object);
+            if (disconnect)
+                object.disconnect(monitorId);
+        }
+    }
+
+    clear() {
+        super.clear();
+        this._destroyHandlersIds?.forEach((id, object) => object.disconnect(id));
+        this._destroyHandlersIds?.clear();
+    }
+
+    _onParentDestroy(parentObject) {
+        this._removeForObject(parentObject, false);
     }
 
     _remove(item) {

--- a/utils.js
+++ b/utils.js
@@ -591,16 +591,11 @@ export function splitHandler(handler) {
  */
 export function getWindowsByObjectPath() {
     const windowsByObjectPath = new Map();
-    const {workspaceManager} = global;
-    const workspaces = [...new Array(workspaceManager.nWorkspaces)].map(
-        (_c, i) => workspaceManager.get_workspace_by_index(i));
 
-    workspaces.forEach(ws => {
-        ws.list_windows().forEach(w => {
-            const path = w.get_gtk_window_object_path();
-            if (path)
-                windowsByObjectPath.set(path, w);
-        });
+    global.display.list_all_windows().forEach(w => {
+        const path = w.get_gtk_window_object_path();
+        if (path)
+            windowsByObjectPath.set(path, w);
     });
 
     return windowsByObjectPath;


### PR DESCRIPTION
When the shell is shut down we need to stop all the signals and idle's
that may still run, or we may access to invalid data.

The shell does not do it by default, so let's do it in any shell version
so that we won't cause potential crashes on shutdown

LP: #2150670
