### PR TITLE
docking: Avoid accessing to main dock before staging it

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -2265,6 +2265,9 @@ export class DockManager {
         };
 
         const maybeAdjustBoxToDock = (state, box, spacing) => {
+            if (Main.layoutManager._startingUp)
+                return box;
+
             maybeAdjustBoxSize(state, box, spacing);
 
             if (this.mainDock.isHorizontal || this.settings.dockFixed)

--- a/docking.js
+++ b/docking.js
@@ -2222,6 +2222,14 @@ export class DockManager {
         const replaceMainDash = () => {
             this.overviewControls.dash = this.mainDock.dash;
             this.searchController._showAppsButton = this.mainDock.dash.showAppsButton;
+
+            // And to return the preferred height depending on the state
+            this._methodInjections.addWithLabel(Labels.MAIN_DASH, this._oldDash,
+                'get_preferred_height', (_originalMethod, ...args) => {
+                    if (this.mainDock.isHorizontal && !this.settings.dockFixed)
+                        return this.mainDock.get_preferred_height(...args);
+                    return [0, 0];
+                });
         };
 
         // We also need to ignore max-size changes
@@ -2231,11 +2239,7 @@ export class DockManager {
             'allocate', () => {});
         // And to return the preferred height depending on the state
         this._methodInjections.addWithLabel(Labels.MAIN_DASH, this._oldDash,
-            'get_preferred_height', (_originalMethod, ...args) => {
-                if (this.mainDock.isHorizontal && !this.settings.dockFixed)
-                    return this.mainDock.get_preferred_height(...args);
-                return [0, 0];
-            });
+            'get_preferred_height', () => [0, 0]);
 
         // FIXME: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2890
         // const { ControlsManagerLayout } = OverviewControls;

--- a/docking.js
+++ b/docking.js
@@ -2493,6 +2493,11 @@ export class DockManager {
             // during the upstream startup animation, that still requires to
             // have a valid actor.
             const dummyDash = new Clutter.Actor({visible: false, opacity: 0});
+            dummyDash.showAppsButton = {};
+            Object.defineProperty(dummyDash.showAppsButton, 'checked', {
+                get: () => false,
+                set: () => {},
+            });
             this.overviewControls.dash = dummyDash;
             Main.uiGroup.add_child(dummyDash);
 


### PR DESCRIPTION
If the dock is horizontal we may try to access to the main dock height,
while the dash is not yet in the stage.

So override the get_preferred_height() method twice to ensure that we
never return a valid size but also that we handle it once our dash is
set

LP: #2150429