### PR TITLE
Downloads folder in the dock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ EXTRA_MODULES = \
 				appIconsDecorator.js \
                 appIconIndicators.js \
                 fileManager1API.js \
+                folderStack.js \
                 imports.js \
                 launcherAPI.js \
                 locations.js \

--- a/Settings.ui
+++ b/Settings.ui
@@ -1221,6 +1221,123 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkListBoxRow" id="show_downloads_row">
+                        <property name="child">
+                          <object class="GtkGrid" id="shrink_dash6">
+                            <property name="can_focus">0</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <property name="column_spacing">32</property>
+                            <child>
+                              <object class="GtkSwitch" id="show_downloads_switch">
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="shrink_dash_label6">
+                                <property name="can_focus">0</property>
+                                <property name="hexpand">1</property>
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">Show Downloads folder</property>
+
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="show_downloads_description">
+                                <property name="can_focus">0</property>
+                                <property name="hexpand">1</property>
+                                <property name="halign">start</property>
+                                <property name="wrap">1</property>
+                                <property name="label" translatable="yes">Click the icon to see the folder contents in a stack</property>
+                                <style>
+                                  <class name="dim-label"/>
+                                </style>
+
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">1</property>
+                                  <property name="column-span">2</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="downloads_stack_view_label">
+                                <property name="can_focus">0</property>
+                                <property name="hexpand">1</property>
+                                <property name="halign">start</property>
+                                <property name="margin_top">12</property>
+                                <property name="label" translatable="yes">View content as</property>
+
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">2</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkComboBoxText" id="downloads_stack_view_combo">
+                                <property name="can_focus">0</property>
+                                <property name="valign">center</property>
+                                <property name="margin_top">12</property>
+                                <items>
+                                  <item translatable="yes">Automatic</item>
+                                  <item translatable="yes">Fan</item>
+                                  <item translatable="yes">Grid</item>
+                                  <item translatable="yes">List</item>
+                                </items>
+
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">2</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="downloads_icon_display_label">
+                                <property name="can_focus">0</property>
+                                <property name="hexpand">1</property>
+                                <property name="halign">start</property>
+                                <property name="margin_top">12</property>
+                                <property name="label" translatable="yes">Display as</property>
+
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">3</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkComboBoxText" id="downloads_icon_display_combo">
+                                <property name="can_focus">0</property>
+                                <property name="valign">center</property>
+                                <property name="margin_top">12</property>
+                                <items>
+                                  <item translatable="yes">Stack</item>
+                                  <item translatable="yes">Folder</item>
+                                </items>
+
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">3</property>
+                                </layout>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkListBoxRow" id="listboxrow19">
                         <property name="child">
                           <object class="GtkGrid" id="shrink_dash5">

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -502,6 +502,97 @@ $dock_style_modes: null, shrink, extended, extended-shrink;
     border-radius: 0px;
 }
 
+/* Folder stack popup */
+$stack_item_padding: $base_padding;
+$stack_item_radius: $base_border_radius;
+
+.dashtodock-stack-grid {
+    padding: $base_padding * 2;
+    spacing-rows: $base_margin;
+    spacing-columns: $base_margin;
+}
+
+/* The fan floats free, the way it does on macOS. The bubble chrome is split
+ * across two selectors in the shell theme: the arrow and the minimum width sit
+ * on the boxpointer, the visible panel on .popup-menu-content. Both have to go. */
+.dashtodock-stack-menu-bare {
+    -arrow-rise: 0;
+    -arrow-base: 0;
+    min-width: 0;
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+
+    .popup-menu-content {
+        padding: 0;
+        border: none;
+        border-radius: 0;
+        background-color: transparent;
+        box-shadow: none;
+    }
+
+    .dashtodock-stack-item {
+        /* Without the panel behind them the tiles need their own backing to
+         * stay readable over an arbitrary wallpaper. */
+        background-color: rgba(0, 0, 0, 0.55);
+        border-radius: $base_border_radius;
+    }
+
+    /* The tile that caps the arc keeps the same dark backing as the file tiles
+     * (a light one washes out over a bright wallpaper and reads as disabled);
+     * its folder icon and label are what set it apart. */
+    .dashtodock-stack-open-tile {
+        background-color: rgba(0, 0, 0, 0.68);
+    }
+}
+
+.dashtodock-stack-item {
+    padding: $stack_item_padding;
+    border-radius: $stack_item_radius;
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+    transition-duration: 100ms;
+
+    &:hover,
+    &:focus {
+        background-color: $remark_color;
+    }
+
+    &:active {
+        background-color: transparentize($fg_color, 0.75);
+    }
+}
+
+.dashtodock-stack-list {
+    padding: $base_padding;
+}
+
+.dashtodock-stack-item-tile {
+    .dashtodock-stack-item-label {
+        margin-top: $base_margin;
+        max-width: 100px;
+    }
+}
+
+.dashtodock-stack-item-row {
+    padding: $base_margin $base_padding;
+
+    .dashtodock-stack-item-label {
+        margin-left: $base_padding + 2px;
+        max-width: 320px;
+    }
+}
+
+.dashtodock-stack-item-label {
+    font-size: 0.9em;
+}
+
+.dashtodock-stack-empty {
+    padding: $base_padding * 2;
+    font-style: italic;
+}
+
 @for $i from 2 through 4 {
     #dashtodockContainer.bottom .metro.running#{$i}.focused,
     #dashtodockContainer.top .metro.running#{$i}.focused {

--- a/appIcons.js
+++ b/appIcons.js
@@ -1189,6 +1189,52 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
         return item;
     }
 
+    /**
+     * A radio group backed by an enum setting, as a submenu.
+     *
+     * @param {string} title the submenu label
+     * @param {string} key the gschema key holding the enum
+     * @param {Array<{value: number, label: string}>} choices the options
+     */
+    _appendEnumSubMenu(title, key, choices) {
+        const {settings} = Docking.DockManager;
+        const submenu = new PopupMenu.PopupSubMenuMenuItem(title);
+
+        choices.forEach(({value, label}) => {
+            const item = new PopupMenu.PopupMenuItem(label);
+            item.setOrnament(settings.get_enum(key) === value
+                ? PopupMenu.Ornament.DOT
+                : PopupMenu.Ornament.NONE);
+            item.connect('activate', () => {
+                settings.set_enum(key, value);
+                this.emit('activate-window', null);
+            });
+            submenu.menu.addMenuItem(item);
+        });
+
+        this.addMenuItem(submenu);
+    }
+
+    /**
+     * The macOS-style "View content as" and "Display as" choices, shown only on
+     * a folder stack icon.
+     */
+    _appendFolderStackItems() {
+        this._appendSeparator();
+
+        this._appendEnumSubMenu(__('View content as'), 'downloads-stack-view', [
+            {value: FolderStack.ViewMode.AUTOMATIC, label: __('Automatic')},
+            {value: FolderStack.ViewMode.FAN, label: __('Fan')},
+            {value: FolderStack.ViewMode.GRID, label: __('Grid')},
+            {value: FolderStack.ViewMode.LIST, label: __('List')},
+        ]);
+
+        this._appendEnumSubMenu(__('Display as'), 'downloads-icon-display', [
+            {value: FolderStack.IconDisplay.STACK, label: __('Stack')},
+            {value: FolderStack.IconDisplay.FOLDER, label: __('Folder')},
+        ]);
+    }
+
     popup(_activatingButton) {
         this._rebuildMenu();
         this.open(BoxPointer.PopupAnimation.FULL);
@@ -1285,6 +1331,9 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
                     this.emit('activate-window', null);
                 });
             }
+
+            if (this.sourceActor instanceof DockFolderAppIcon)
+                this._appendFolderStackItems();
 
             const canFavorite = global.settings.is_writable('favorite-apps') &&
                 (this.sourceActor instanceof DockAppIcon) &&

--- a/appIcons.js
+++ b/appIcons.js
@@ -29,6 +29,7 @@ import {
     AppIconIndicators,
     DBusMenuUtils,
     Docking,
+    FolderStack,
     Locations,
     Theming,
     Utils,
@@ -745,10 +746,10 @@ export const DockAbstractAppIcon = GObject.registerClass({
     /**
      * Toggle one of this icon's auxiliary popups, building it on first use.
      *
-     * These popups are not the icon's context menu: they are lazily created,
-     * chained to the overview hiding, and report their state to the dash so it
-     * does not auto-hide out from under them. That bookkeeping is the same
-     * whichever popup it is.
+     * These popups (the window previews, the folder stack) are not the icon's
+     * context menu: they are lazily created, chained to the overview hiding,
+     * and report their state to the dash so it does not auto-hide out from
+     * under them. That bookkeeping is the same whichever popup it is.
      *
      * @param {string} kind which popup, so each keeps its own instance
      * @param {Function} createMenu builds the popup on first use
@@ -1028,12 +1029,89 @@ const DockLocationAppIcon = GObject.registerClass({
     }
 });
 
+const DockFolderAppIcon = GObject.registerClass({
+}, class DockFolderAppIcon extends DockLocationAppIcon {
+    _init(app, monitorIndex, iconAnimator) {
+        if (!(app.appInfo instanceof Locations.FolderAppInfo))
+            throw new Error('Provided application %s is not a folder'.format(app));
+
+        super._init(app, monitorIndex, iconAnimator);
+
+        this._signalsHandler.add(this.app.appInfo, 'items-changed', () => {
+            this._stack?.queueRedisplay();
+            this.icon.update();
+        });
+
+        // popup() rebuilds from the current setting, so closing is enough to
+        // make the next open pick up a new layout.
+        this._signalsHandler.add(Docking.DockManager.settings,
+            'changed::downloads-stack-view', () => this._stack?.close());
+
+        this._signalsHandler.add(Docking.DockManager.settings,
+            'changed::downloads-icon-display', () => this.icon.update());
+    }
+
+    /**
+     * Preview the folder's newest contents on the dock icon itself.
+     *
+     * This overrides the icon rather than the app's create_icon_texture on
+     * purpose: appIconIndicators.js calls create_icon_texture(16).get_gicon()
+     * for Unity7 backlit colours, so that has to keep returning a plain
+     * St.Icon.
+     *
+     * @param {number} iconSize the size the dash wants
+     * @returns {Clutter.Actor} the icon actor
+     */
+    _createIcon(iconSize) {
+        const items = this.app.appInfo.items ?? [];
+
+        if (items.length && Docking.DockManager.settings.downloadsIconDisplay ===
+            FolderStack.IconDisplay.STACK)
+            return FolderStack.makeStackIcon(items, iconSize);
+
+        return this.app.create_icon_texture(iconSize);
+    }
+
+    /**
+     * Unlike every other dock icon, a plain left-click here opens the stack
+     * instead of launching the app. Modifiers and the other buttons keep the
+     * inherited behaviour, so middle-click still opens the file manager.
+     *
+     * @param {number} button the pressed button, undefined for the keyboard
+     */
+    activate(button) {
+        const event = Clutter.get_current_event();
+        let modifiers = event ? event.get_state() : 0;
+        modifiers &= Clutter.ModifierType.SHIFT_MASK | Clutter.ModifierType.CONTROL_MASK;
+
+        if (!modifiers && (!button || button === 1)) {
+            this.toggleStack();
+            return;
+        }
+
+        super.activate(button);
+    }
+
+    get _stack() {
+        return this._auxMenu('stack');
+    }
+
+    toggleStack() {
+        return this._toggleAuxMenu('stack',
+            () => new FolderStack.FolderStackMenu(this));
+    }
+});
+
 /**
  * @param app
  * @param monitorIndex
  * @param iconAnimator
  */
 export function makeAppIcon(app, monitorIndex, iconAnimator) {
+    // Checked before LocationAppInfo: FolderAppInfo is a subclass of it.
+    if (app.appInfo instanceof Locations.FolderAppInfo)
+        return new DockFolderAppIcon(app, monitorIndex, iconAnimator);
+
     if (app.appInfo instanceof Locations.LocationAppInfo)
         return new DockLocationAppIcon(app, monitorIndex, iconAnimator);
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -128,6 +128,8 @@ export const DockAbstractAppIcon = GObject.registerClass({
         this.iconAnimator = iconAnimator;
         this._indicator = new AppIconIndicators.AppIconIndicator(this);
         this._urgentWindows = new Set();
+        // Lazily-built popups that are not the context menu, keyed by kind.
+        this._auxMenus = new Map();
 
         // Monitor windows-changes instead of app state.
         // Keep using the same Id and function callback (that is extended)
@@ -231,9 +233,6 @@ export const DockAbstractAppIcon = GObject.registerClass({
 
         this._updateState();
         this._numberOverlay();
-
-        this._previewMenuManager = null;
-        this._previewMenu = null;
     }
 
     _onDestroy() {
@@ -724,38 +723,72 @@ export const DockAbstractAppIcon = GObject.registerClass({
     }
 
     shouldShowTooltip() {
-        return super.shouldShowTooltip() && !this._previewMenu?.isOpen &&
+        return super.shouldShowTooltip() && !this._isAuxMenuOpen() &&
             !Docking.DockManager.settings.hideTooltip;
     }
 
-    _windowPreviews() {
-        if (!this._previewMenu) {
-            this._previewMenuManager = new PopupMenu.PopupMenuManager(this);
+    /**
+     * One of this icon's auxiliary popups, if it has been built.
+     *
+     * @param {string} kind which popup
+     * @returns {PopupMenu.PopupMenu | undefined} the popup
+     */
+    _auxMenu(kind) {
+        return this._auxMenus.get(kind)?.menu;
+    }
 
-            this._previewMenu = new WindowPreview.WindowPreviewMenu(this);
+    /** Whether any of this icon's auxiliary popups is up. */
+    _isAuxMenuOpen() {
+        return [...this._auxMenus.values()].some(({menu}) => menu.isOpen);
+    }
 
-            this._previewMenuManager.addMenu(this._previewMenu);
+    /**
+     * Toggle one of this icon's auxiliary popups, building it on first use.
+     *
+     * These popups are not the icon's context menu: they are lazily created,
+     * chained to the overview hiding, and report their state to the dash so it
+     * does not auto-hide out from under them. That bookkeeping is the same
+     * whichever popup it is.
+     *
+     * @param {string} kind which popup, so each keeps its own instance
+     * @param {Function} createMenu builds the popup on first use
+     * @returns {boolean} always false, so callers can return it directly
+     */
+    _toggleAuxMenu(kind, createMenu) {
+        let menu = this._auxMenu(kind);
 
-            this._previewMenu.connect('open-state-changed', (menu, isPoppedUp) => {
+        if (!menu) {
+            // The manager is kept alongside the menu so it stays alive for as
+            // long as the menu it arbitrates.
+            const menuManager = new PopupMenu.PopupMenuManager(this);
+            menu = createMenu();
+            this._auxMenus.set(kind, {menu, menuManager});
+            menuManager.addMenu(menu);
+
+            menu.connect('open-state-changed', (_menu, isPoppedUp) => {
                 if (!isPoppedUp)
                     this._onMenuPoppedDown();
             });
-            const id = Main.overview.connect('hiding', () => {
-                this._previewMenu.close();
-            });
-            this._previewMenu.actor.connect('destroy', () => {
+            const id = Main.overview.connect('hiding', () => menu.close());
+            menu.actor.connect('destroy', () => {
                 Main.overview.disconnect(id);
+                this._auxMenus.delete(kind);
             });
         }
 
-        this.emit('menu-state-changed', !this._previewMenu.isOpen);
+        this.emit('menu-state-changed', !menu.isOpen);
 
-        if (this._previewMenu.isOpen)
-            this._previewMenu.close();
+        if (menu.isOpen)
+            menu.close();
         else
-            this._previewMenu.popup();
+            menu.popup();
 
         return false;
+    }
+
+    _windowPreviews() {
+        return this._toggleAuxMenu('previews',
+            () => new WindowPreview.WindowPreviewMenu(this));
     }
 
     // Try to do the right thing when attempting to launch a new window of an app. In

--- a/dash.js
+++ b/dash.js
@@ -826,7 +826,17 @@ export const DockDash = GObject.registerClass({
                     newApps.push(removable);
             });
         } else {
-            oldApps = oldApps.filter(app => !app.location || app.isTrash);
+            oldApps = oldApps.filter(app =>
+                !app.location || app.isTrash || app.isFolder);
+        }
+
+        if (dockManager.downloads) {
+            dockManager.downloads.getApps().forEach(downloadsApp => {
+                if (!newApps.includes(downloadsApp))
+                    newApps.push(downloadsApp);
+            });
+        } else {
+            oldApps = oldApps.filter(app => !app.isFolder);
         }
 
         if (dockManager.trash) {

--- a/docking.js
+++ b/docking.js
@@ -580,6 +580,13 @@ const DockedDash = GObject.registerClass({
             Utils.SignalsHandlerFlags.CONNECT_AFTER,
         ], [
             settings,
+            'changed::show-downloads',
+            () => {
+                this.dash.resetAppIcons();
+            },
+            Utils.SignalsHandlerFlags.CONNECT_AFTER,
+        ], [
+            settings,
             'changed::isolate-locations',
             () => this.dash.resetAppIcons(),
             Utils.SignalsHandlerFlags.CONNECT_AFTER,
@@ -1830,6 +1837,10 @@ export class DockManager {
         return this._trash;
     }
 
+    get downloads() {
+        return this._downloads;
+    }
+
     get desktopIconsUsableArea() {
         return this._desktopIconsUsableArea;
     }
@@ -1851,9 +1862,10 @@ export class DockManager {
     }
 
     _ensureLocations() {
-        const {showMounts, showTrash} = this.settings;
+        const {showMounts, showTrash, showDownloads} = this.settings;
+        const anyLocation = showTrash || showMounts || showDownloads;
 
-        if (showTrash || showMounts) {
+        if (anyLocation) {
             if (!this._fm1Client)
                 this._fm1Client = new FileManager1API.FileManager1Client();
         } else if (this._fm1Client) {
@@ -1875,11 +1887,18 @@ export class DockManager {
             this._trash = null;
         }
 
+        if (showDownloads && !this._downloads) {
+            this._downloads = new Locations.Downloads();
+        } else if (!showDownloads && this._downloads) {
+            this._downloads.destroy();
+            this._downloads = null;
+        }
+
         Locations.unWrapFileManagerApp();
         [this._methodInjections, this._propertyInjections].forEach(
             injections => injections.removeWithLabel(Labels.LOCATIONS));
 
-        if (showMounts || showTrash) {
+        if (anyLocation) {
             if (this.settings.isolateLocations) {
                 const fileManagerApp = Locations.wrapFileManagerApp();
 
@@ -2036,6 +2055,10 @@ export class DockManager {
         ], [
             this._settings,
             'changed::show-mounts',
+            () => this._ensureLocations(),
+        ], [
+            this._settings,
+            'changed::show-downloads',
             () => this._ensureLocations(),
         ], [
             this._settings,

--- a/folderStack.js
+++ b/folderStack.js
@@ -1,0 +1,893 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+/*
+ * A macOS-like "stack": a popup anchored to a folder icon in the dock that
+ * shows the folder's contents.
+ *
+ * The popup is a PopupMenu so that grabbing, click-outside dismissal, Escape
+ * and keyboard navigation all come from the shell rather than being
+ * reimplemented here. Only the content layout and the reveal animation are
+ * ours.
+ */
+
+import {
+    Clutter,
+    Gio,
+    GObject,
+    Pango,
+    St,
+} from './dependencies/gi.js';
+
+import {
+    BoxPointer,
+    Main,
+    PopupMenu,
+} from './dependencies/shell/ui.js';
+
+import {
+    Docking,
+    Theming,
+    Utils,
+} from './imports.js';
+
+import {Extension} from './dependencies/shell/extensions/extension.js';
+
+const {gettext: __} = Extension;
+
+const ITEM_ICON_SIZE = 64;
+const ITEM_WIDTH = 116;
+// Roughly icon + label + padding; only used to cap how much of a large folder
+// is on screen at once, the grid itself is laid out by Clutter.
+const ITEM_HEIGHT = 104;
+const ROW_ICON_SIZE = 24;
+const ROW_HEIGHT = 40;
+const LIST_MAX_VISIBLE_ROWS = 12;
+const GRID_MAX_COLUMNS = 6;
+const GRID_MAX_VISIBLE_ROWS = 5;
+const MENU_MARGINS = 10;
+
+/** Mirrors the downloads-stack-view enum in the gschema. */
+export const ViewMode = Object.freeze({
+    AUTOMATIC: 0,
+    FAN: 1,
+    GRID: 2,
+    LIST: 3,
+});
+
+/** Mirrors the downloads-icon-display enum in the gschema. */
+export const IconDisplay = Object.freeze({
+    STACK: 0,
+    FOLDER: 1,
+});
+
+// The reveal. Items scale up from the dock-facing edge with a slight
+// overshoot, one shortly after the next, which is what reads as the macOS
+// "pop" without needing per-item paths.
+const POP_DURATION = 260;
+const POP_STAGGER = 26;
+// A hundred files staggered one by one would take over two seconds to finish.
+// Stagger by row instead, and compress the step so the whole cascade stays
+// inside this budget however many rows there are.
+const POP_MAX_TOTAL_STAGGER = 320;
+const POP_START_SCALE = 0.4;
+const POP_TRAVEL = 24;
+
+/** Above this many entries a fan stops being readable, and too tall to fit. */
+const FAN_MAX_ITEMS = 8;
+/** Tile pitch as a fraction of tile height; below 1 the tiles overlap. */
+const FAN_SPACING_RATIO = 0.82;
+/** Total sideways drift over the whole fan. */
+const FAN_DRIFT = 110;
+/** Degrees the last tile is tilted by. */
+const FAN_MAX_TILT = 9;
+
+/** Decode images up to this size inline when GIO has no cached thumbnail. */
+const PREVIEW_MAX_BYTES = 16 * 1024 * 1024;
+
+/** How many entries the dock icon previews when displaying as a stack. */
+const STACK_ICON_LAYERS = 3;
+/** Degrees each layer below the top is rotated by. */
+const STACK_ICON_TILT = 6;
+
+/**
+ * How many tiles a fan can show before it runs off the screen.
+ *
+ * FAN_MAX_ITEMS is a readability limit, but it is not a fit limit: the tiles
+ * grow with the display scale while the screen does not, so a fan that is
+ * comfortable at 100% runs past the top of the monitor at 200%.
+ *
+ * @param {St.Side} position the dock side
+ * @param {number} monitorIndex the monitor the dock is on
+ * @returns {number} the most tiles that fit, including the open-folder one
+ */
+function fanCapacity(position, monitorIndex) {
+    const workArea = Main.layoutManager.getWorkAreaForMonitor(monitorIndex);
+    const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
+    const horizontal = position === St.Side.BOTTOM || position === St.Side.TOP;
+
+    const available = horizontal ? workArea.height : workArea.width;
+    const itemHeight = ITEM_HEIGHT * scaleFactor;
+    const spacing = itemHeight * FAN_SPACING_RATIO;
+    const fits = Math.floor((available - itemHeight) / spacing) + 1;
+
+    return Utils.clamp(fits, 2, FAN_MAX_ITEMS + 1);
+}
+
+/**
+ * Resolve the configured view mode, turning AUTOMATIC into a concrete layout.
+ *
+ * Automatic follows macOS: a fan for a handful of files, a grid once there are
+ * too many for an arc to stay legible. A fan also only makes sense along the
+ * dock's free axis, so a vertical dock falls back to the grid.
+ *
+ * @param {number} configured the ViewMode the setting holds
+ * @param {number} itemCount how many entries the folder has
+ * @param {St.Side} position the dock side
+ * @param {number} capacity how many tiles the fan can fit on screen
+ * @returns {number} one of ViewMode.FAN, GRID or LIST
+ */
+function viewModeFor(configured, itemCount, position, capacity) {
+    if (configured !== ViewMode.AUTOMATIC)
+        return configured;
+
+    const horizontal = position === St.Side.BOTTOM || position === St.Side.TOP;
+    // The +1 is the open-folder tile, which the fan always adds.
+    return itemCount + 1 <= capacity && horizontal
+        ? ViewMode.FAN
+        : ViewMode.GRID;
+}
+
+/**
+ * Build the dock icon for "Display as: Stack": the most recent entries piled
+ * up, newest on top, the way macOS previews a stack's contents.
+ *
+ * @param {object[]} items folder contents, newest first, never empty
+ * @param {number} iconSize the dock's current icon size
+ * @returns {Clutter.Actor} the icon to display
+ */
+export function makeStackIcon(items, iconSize) {
+    const layers = items.slice(0, STACK_ICON_LAYERS);
+
+    const widget = new St.Widget({
+        layout_manager: new Clutter.BinLayout(),
+        style_class: 'dashtodock-stack-icon',
+        width: iconSize,
+        height: iconSize,
+    });
+
+    const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
+    // Leave room for the offsets so the pile still fits the icon slot.
+    const layerSize = Math.round(iconSize * 0.78);
+    const step = Math.round((iconSize - layerSize) / Math.max(1, layers.length - 1));
+
+    // Oldest first so the newest ends up drawn on top.
+    layers.slice().reverse().forEach((item, i) => {
+        const depth = layers.length - 1 - i;
+        let actor = null;
+
+        if (item.thumbnailPath) {
+            actor = St.TextureCache.get_default().load_file_async(
+                Gio.File.new_for_path(item.thumbnailPath),
+                -1, layerSize, scaleFactor, 1);
+        }
+
+        if (!actor) {
+            actor = new St.Icon({
+                gicon: item.icon,
+                icon_size: layerSize,
+            });
+        }
+
+        actor.set_pivot_point(0.5, 0.5);
+        actor.rotation_angle_z = depth * STACK_ICON_TILT;
+        actor.translation_x = -depth * step / 2;
+        actor.translation_y = -depth * step / 2;
+        actor.x_align = Clutter.ActorAlign.CENTER;
+        actor.y_align = Clutter.ActorAlign.CENTER;
+        widget.add_child(actor);
+    });
+
+    return widget;
+}
+
+/**
+ * Animate one entry from its pre-reveal state to its resting state.
+ *
+ * Geometry and opacity are eased separately on purpose. The overshoot is what
+ * makes an entry pop, but EASE_OUT_BACK carries the interpolation past its
+ * target (it peaks around 1.10), and opacity is a guint8: 255 * 1.10 is 280,
+ * which wraps to 24 rather than clamping. Easing both channels together left
+ * every entry nearly invisible for about 150ms of its 260ms reveal and then
+ * snapping to full, which is what read as the reveal flickering. So geometry
+ * overshoots and opacity does not.
+ *
+ * @param {Clutter.Actor} actor the entry
+ * @param {number} delay when this entry joins the cascade, in milliseconds
+ */
+function easeIn(actor, delay) {
+    actor.ease({
+        scale_x: 1,
+        scale_y: 1,
+        translation_x: 0,
+        translation_y: 0,
+        delay,
+        duration: POP_DURATION,
+        mode: Clutter.AnimationMode.EASE_OUT_BACK,
+    });
+    actor.ease({
+        opacity: 255,
+        delay,
+        duration: POP_DURATION,
+        mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+    });
+}
+
+/**
+ * The point an item grows out of, expressed as a pivot plus a starting offset,
+ * so the whole grid appears to come from the dock edge.
+ *
+ * @param {St.Side} position the dock side
+ * @returns {{pivot: number[], travel: number[]}} pivot and initial translation
+ */
+function revealGeometryFor(position) {
+    switch (position) {
+    case St.Side.TOP:
+        return {pivot: [0.5, 0], travel: [0, -POP_TRAVEL]};
+    case St.Side.LEFT:
+        return {pivot: [0, 0.5], travel: [-POP_TRAVEL, 0]};
+    case St.Side.RIGHT:
+        return {pivot: [1, 0.5], travel: [POP_TRAVEL, 0]};
+    case St.Side.BOTTOM:
+    default:
+        return {pivot: [0.5, 1], travel: [0, POP_TRAVEL]};
+    }
+}
+
+/**
+ * One entry in the stack. Tiles (icon above an elided name) are used by the
+ * grid and the fan; rows (small icon beside the name) by the list.
+ */
+const FolderStackItem = GObject.registerClass(
+class FolderStackItem extends St.Button {
+    _init(item, position, tiled = true) {
+        super._init({
+            style_class: 'dashtodock-stack-item',
+            reactive: true,
+            can_focus: true,
+            track_hover: true,
+            x_expand: !tiled,
+            y_expand: false,
+            // Rows span the popup so the whole strip is clickable and the
+            // names line up; tiles stay their natural size.
+            x_align: tiled ? Clutter.ActorAlign.CENTER : Clutter.ActorAlign.FILL,
+        });
+
+        this.item = item;
+        this.add_style_class_name(Theming.PositionStyleClass[position]);
+        this.add_style_class_name(tiled
+            ? 'dashtodock-stack-item-tile'
+            : 'dashtodock-stack-item-row');
+
+        const box = new St.BoxLayout({
+            vertical: tiled,
+            x_expand: !tiled,
+            x_align: tiled ? Clutter.ActorAlign.CENTER : Clutter.ActorAlign.FILL,
+            y_align: Clutter.ActorAlign.CENTER,
+            style_class: 'dashtodock-stack-item-box',
+        });
+
+        // The icon lives in a slot of fixed size rather than directly in the
+        // box. St.TextureCache.load_file_async hands back a zero-sized actor
+        // that only grows once the file has been decoded, so swapping the
+        // generic icon for a preview would otherwise collapse the tile and
+        // then snap it back, which is what the reveal looked like it was
+        // flickering.
+        // icon-size is logical and St scales it, but the slot's width and
+        // height are actor coordinates, so they have to be scaled by hand or
+        // the two disagree on anything but a 100% display.
+        const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
+        this._iconSize = tiled ? ITEM_ICON_SIZE : ROW_ICON_SIZE;
+        this._iconSlot = new St.Widget({
+            layout_manager: new Clutter.BinLayout(),
+            width: this._iconSize * scaleFactor,
+            height: this._iconSize * scaleFactor,
+            x_align: Clutter.ActorAlign.CENTER,
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+
+        this._icon = new St.Icon({
+            gicon: item.icon,
+            icon_size: this._iconSize,
+            x_align: Clutter.ActorAlign.CENTER,
+            y_align: Clutter.ActorAlign.CENTER,
+            style_class: 'dashtodock-stack-item-icon',
+        });
+        this._iconSlot.add_child(this._icon);
+        box.add_child(this._iconSlot);
+
+        this._label = new St.Label({
+            text: item.displayName,
+            x_align: tiled ? Clutter.ActorAlign.CENTER : Clutter.ActorAlign.START,
+            y_align: Clutter.ActorAlign.CENTER,
+            x_expand: !tiled,
+            style_class: 'dashtodock-stack-item-label',
+        });
+        this._label.clutter_text.set_line_wrap(false);
+        this._label.clutter_text.set_ellipsize(Pango.EllipsizeMode.MIDDLE);
+        box.add_child(this._label);
+
+        this.set_child(box);
+        if (tiled)
+            this.set_width(ITEM_WIDTH * scaleFactor);
+
+        this.accessible_name = item.displayName;
+
+        this._loadPreview(scaleFactor);
+    }
+
+    /**
+     * Swap the generic MIME icon for a real preview where one is available.
+     *
+     * Three tiers, cheapest first: the thumbnail GIO already has cached, then
+     * an on-the-fly decode for images small enough to be worth it, then
+     * nothing (the MIME icon stays). St.TextureCache decodes off the main
+     * thread, so neither path stalls the compositor.
+     *
+     * @param {number} scaleFactor the display scale
+     */
+    _loadPreview(scaleFactor) {
+        const {item} = this;
+        const decodable = !item.thumbnailFailed && !item.isDirectory &&
+            item.contentType?.startsWith('image/') &&
+            item.size > 0 && item.size <= PREVIEW_MAX_BYTES;
+
+        let file = null;
+        if (item.thumbnailPath)
+            file = Gio.File.new_for_path(item.thumbnailPath);
+        else if (decodable)
+            ({file} = item);
+
+        if (!file)
+            return;
+
+        const preview = St.TextureCache.get_default().load_file_async(
+            file, -1, this._iconSize, scaleFactor, 1);
+
+        if (preview)
+            this.setPreview(preview);
+    }
+
+    /**
+     * Replace the generic icon once a thumbnail has been produced.
+     *
+     * The preview goes into the same fixed-size slot and is constrained to it,
+     * so the tile's geometry never changes no matter when the decode lands.
+     *
+     * @param {Clutter.Actor} actor the thumbnail actor
+     */
+    setPreview(actor) {
+        if (!this._iconSlot)
+            return;
+
+        actor.x_align = Clutter.ActorAlign.CENTER;
+        actor.y_align = Clutter.ActorAlign.CENTER;
+
+        this._iconSlot.remove_all_children();
+        this._iconSlot.add_child(actor);
+        this._icon = actor;
+    }
+});
+
+/**
+ * Shared behaviour for every layout: a set of entries that pop in one band
+ * after another. Subclasses own their own actor and their own idea of what a
+ * band is; this holds only the reveal protocol FolderStackMenu drives.
+ */
+class FolderStackSection extends PopupMenu.PopupMenuSection {
+    constructor() {
+        super();
+
+        this.items = [];
+    }
+
+    /**
+     * Where an entry grows from. The default is the dock-facing edge, so the
+     * contents look like they are coming out of the icon.
+     *
+     * @param {St.Side} position the dock side
+     * @returns {number[]} the pivot point
+     */
+    _pivotFor(position) {
+        return revealGeometryFor(position).pivot;
+    }
+
+    /**
+     * Which band an entry belongs to. Entries sharing a band animate together.
+     * Subclasses override; the default is one entry per band.
+     *
+     * @param {number} index entry index
+     * @returns {number} band index, counting away from the dock
+     */
+    _bandOf(index) {
+        return index;
+    }
+
+    /** How many bands there are. */
+    get _bandCount() {
+        return this.items.length;
+    }
+
+    /**
+     * When an entry joins the cascade. The band nearest the dock leads, so the
+     * contents read as rising out of the icon.
+     *
+     * @param {number} index entry index
+     * @param {St.Side} position the dock side
+     * @returns {number} delay in milliseconds
+     */
+    _revealDelay(index, position) {
+        const last = Math.max(0, this._bandCount - 1);
+        let band = this._bandOf(index);
+
+        // The popup sits on the far side of the dock, so for a bottom or right
+        // dock the visually-nearest band is the last one.
+        if (position === St.Side.BOTTOM || position === St.Side.RIGHT)
+            band = last - band;
+
+        const step = last
+            ? Math.min(POP_STAGGER, POP_MAX_TOTAL_STAGGER / last)
+            : 0;
+        return Math.round(band * step);
+    }
+
+    /**
+     * Put every entry in its pre-reveal state. Called before the popup opens so
+     * nothing is ever painted at full size first.
+     *
+     * @param {St.Side} position the dock side
+     */
+    prepareReveal(position) {
+        const [pivotX, pivotY] = this._pivotFor(position);
+        const [travelX, travelY] = revealGeometryFor(position).travel;
+
+        this.items.forEach(actor => {
+            actor.set_pivot_point(pivotX, pivotY);
+            actor.set_scale(POP_START_SCALE, POP_START_SCALE);
+            actor.translation_x = travelX;
+            actor.translation_y = travelY;
+            actor.opacity = 0;
+        });
+    }
+
+    /**
+     * Run the staggered reveal.
+     *
+     * @param {St.Side} position the dock side
+     */
+    reveal(position) {
+        this.items.forEach((actor, i) => {
+            actor.remove_all_transitions();
+            easeIn(actor, this._revealDelay(i, position));
+        });
+    }
+}
+
+/**
+ * The layouts that scroll: entries inside a height-capped scroll view.
+ */
+class FolderStackScrollSection extends FolderStackSection {
+    constructor(maxHeight) {
+        super();
+
+        this.actor = new St.ScrollView({
+            name: 'dashtodockStackScrollview',
+            hscrollbar_policy: St.PolicyType.NEVER,
+            vscrollbar_policy: St.PolicyType.AUTOMATIC,
+            overlay_scrollbars: true,
+            enable_mouse_scrolling: true,
+        });
+        this.actor._delegate = this;
+
+        // A hundred files would otherwise fill the screen top to bottom, which
+        // reads as a sheet rather than a stack. Cap it and let the rest scroll.
+        this.actor.set_style(`max-height: ${maxHeight}px;`);
+    }
+}
+
+/**
+ * Entries as a roughly square grid of tiles.
+ */
+class FolderStackGrid extends FolderStackScrollSection {
+    constructor(items, position) {
+        super(GRID_MAX_VISIBLE_ROWS * ITEM_HEIGHT);
+
+        // St.Viewport rather than St.Widget: St.ScrollView only allocates
+        // children that implement StScrollable, and a plain widget silently
+        // collapses to zero height inside one.
+        this._grid = new St.Viewport({
+            layout_manager: new Clutter.GridLayout(),
+            style_class: 'dashtodock-stack-grid',
+        });
+        Utils.addActor(this.actor, this._grid);
+
+        // Roughly square, like the macOS grid, but never wider than the cap.
+        this._columns = Math.max(1,
+            Math.min(GRID_MAX_COLUMNS, Math.ceil(Math.sqrt(items.length))));
+
+        const layout = this._grid.layout_manager;
+        items.forEach((item, i) => {
+            const actor = new FolderStackItem(item, position);
+            actor.connect('clicked', () => this.emit('item-activated', item));
+            layout.attach(actor, i % this._columns,
+                Math.floor(i / this._columns), 1, 1);
+            this.items.push(actor);
+        });
+    }
+
+    /** A band is a grid row. */
+    _bandOf(index) {
+        return Math.floor(index / this._columns);
+    }
+
+    get _bandCount() {
+        return Math.ceil(this.items.length / this._columns);
+    }
+}
+
+/**
+ * The tile that caps the fan, opening the folder itself.
+ *
+ * It is a FolderStackItem so the arc geometry and the reveal treat it exactly
+ * like any other tile; it just carries a synthetic entry that has no file
+ * behind it, which also makes _loadPreview() a no-op.
+ */
+const FolderStackOpenTile = GObject.registerClass(
+class FolderStackOpenTile extends FolderStackItem {
+    _init(position) {
+        super._init({
+            // Short on purpose: the tile is ITEM_WIDTH wide like every other
+            // one, and the menu's longer "Open in File Manager" either elides
+            // to nonsense or wraps past the bottom of the arc.
+            icon: Gio.ThemedIcon.new('folder-open'),
+            displayName: __('Open Folder'),
+        }, position);
+
+        this.add_style_class_name('dashtodock-stack-open-tile');
+    }
+});
+
+/**
+ * Entries as an arc rising away from the dock, macOS "fan" style.
+ *
+ * Unlike the grid and the list this is not a scroll view: the arc is laid out
+ * by hand at fixed positions, capped at FAN_MAX_ITEMS so it stays legible, and
+ * sized to whatever the arc needs.
+ */
+class FolderStackFan extends FolderStackSection {
+    constructor(items, position, capacity) {
+        super();
+
+        // Keep PopupMenuSection's own box as the section actor (replacing it
+        // breaks the menu's scroll bookkeeping) and hang the arc inside it.
+        this._arc = new St.Widget({
+            layout_manager: new Clutter.FixedLayout(),
+            style_class: 'dashtodock-stack-fan',
+        });
+        this.box.add_child(this._arc);
+
+        this._position = position;
+
+        // Leave a slot for the open-folder tile. Anything that does not fit
+        // stays reachable through it.
+        const shown = items.slice(0, Math.max(1, capacity - 1));
+        shown.forEach(item => {
+            const actor = new FolderStackItem(item, position);
+            actor.connect('clicked', () => this.emit('item-activated', item));
+            this._arc.add_child(actor);
+            this.items.push(actor);
+        });
+
+        // macOS caps its fan with a button that opens the folder proper. The
+        // grid and the list get the same affordance as a footer row, but the
+        // fan has no bubble to put a footer in, so it becomes the last tile on
+        // the arc.
+        const openTile = new FolderStackOpenTile(position);
+        openTile.connect('clicked', () => this.emit('open-folder'));
+        this._arc.add_child(openTile);
+        this.items.push(openTile);
+
+        // Paint order is deliberately left as insertion order: tiles overlap,
+        // and each one's label sits along its dock-facing edge, so the tile
+        // further from the dock has to be the one in front. Reversing this so
+        // the nearest tile leads looks more like a pile of cards but buries
+        // every label under the tile below it.
+        this._layoutArc();
+    }
+
+    /**
+     * Place the entries as a column rising away from the dock, drifting
+     * sideways as it goes and tilting slightly with the curve.
+     *
+     * This is the macOS shape: not a wide rainbow (which puts the middle items
+     * furthest from the icon and leaves the ends pointing back at the dock) but
+     * a stack that leans. The drift is quadratic so the first few entries come
+     * straight out of the icon before the fan starts to bend.
+     *
+     * Geometry is computed in "along" (parallel to the dock edge) and "away"
+     * (perpendicular to it) coordinates, then mapped onto x/y per side, so one
+     * piece of maths covers all four dock positions.
+     */
+    _layoutArc() {
+        const n = this.items.length;
+        const horizontal = this._position === St.Side.BOTTOM ||
+            this._position === St.Side.TOP;
+        const nearFarFlipped = this._position === St.Side.BOTTOM ||
+            this._position === St.Side.RIGHT;
+
+        // set_position and set_size take actor coordinates, but icon-size and
+        // everything in the stylesheet are logical pixels that St scales. Mix
+        // the two and the arc drifts away from the dock icon on any display
+        // that is not at 100%.
+        const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
+        const itemWidth = ITEM_WIDTH * scaleFactor;
+
+        // Ask a tile how tall it is rather than assuming: its height comes from
+        // the label and the padding, which follow the theme and the text scale.
+        const [, measured] = this.items[0].get_preferred_height(itemWidth);
+        const itemHeight = measured || ITEM_HEIGHT * scaleFactor;
+        const spacing = itemHeight * FAN_SPACING_RATIO;
+
+        // Curve by how long the fan actually is. At full length it gets the
+        // whole drift and tilt; with two entries it is nearly straight, since
+        // applying the full curve across a single gap flings them apart.
+        const span = (n - 1) / Math.max(1, FAN_MAX_ITEMS);
+        const drift = FAN_DRIFT * scaleFactor * span;
+        const tilt = FAN_MAX_TILT * span;
+
+        const placed = this.items.map((actor, i) => {
+            const t = n > 1 ? i / (n - 1) : 0;
+            return {
+                actor,
+                along: drift * t * t,
+                away: spacing * i,
+                angle: tilt * t * t,
+            };
+        });
+
+        // Keep the container symmetric about the first entry. The boxpointer
+        // centres the popup on the dock icon, so the entry nearest the dock
+        // only lands over the icon if it sits at the container's midpoint; the
+        // drift then has room to run out to one side.
+        const alongExtent = itemWidth + 2 * Math.abs(drift);
+        const awayExtent = spacing * Math.max(0, n - 1) + itemHeight;
+        const alongOrigin = (alongExtent - itemWidth) / 2;
+
+        placed.forEach(({actor, along, away, angle}) => {
+            const alongPos = alongOrigin + along;
+            const awayPos = nearFarFlipped
+                ? awayExtent - away - itemHeight
+                : away;
+
+            if (horizontal)
+                actor.set_position(Math.round(alongPos), Math.round(awayPos));
+            else
+                actor.set_position(Math.round(awayPos), Math.round(alongPos));
+
+            actor.set_pivot_point(0.5, 0.5);
+            // Tilt follows the drift, and the drift direction flips with the
+            // axis, so the tiles always lean into the curve.
+            actor.rotation_angle_z = horizontal ? angle : -angle;
+        });
+
+        if (horizontal)
+            this._arc.set_size(alongExtent, awayExtent);
+        else
+            this._arc.set_size(awayExtent, alongExtent);
+    }
+
+    /**
+     * Keep the pivot centred: the arc rotation already uses it, and a corner
+     * pivot would make the tiles swing rather than grow.
+     *
+     * @returns {number[]} the pivot point
+     */
+    _pivotFor() {
+        return [0.5, 0.5];
+    }
+
+    /**
+     * The fan unfurls from the dock outwards, so the first entry leads
+     * regardless of dock side.
+     *
+     * @param {number} index entry index
+     * @returns {number} delay in milliseconds
+     */
+    _revealDelay(index) {
+        return index * POP_STAGGER;
+    }
+}
+
+/**
+ * Entries as a single column of icon-and-name rows.
+ */
+class FolderStackList extends FolderStackScrollSection {
+    constructor(items, position) {
+        super(LIST_MAX_VISIBLE_ROWS * ROW_HEIGHT);
+
+        this._box = new St.BoxLayout({
+            vertical: true,
+            x_expand: true,
+            style_class: 'dashtodock-stack-list',
+        });
+        Utils.addActor(this.actor, this._box);
+
+        items.forEach(item => {
+            const actor = new FolderStackItem(item, position, false);
+            actor.connect('clicked', () => this.emit('item-activated', item));
+            this._box.add_child(actor);
+            this.items.push(actor);
+        });
+    }
+}
+
+/**
+ * The stack popup itself.
+ */
+export class FolderStackMenu extends PopupMenu.PopupMenu {
+    constructor(source) {
+        super(source, 0.5, Utils.getPosition());
+
+        // Keep the dock icon looking hovered while the stack is up.
+        this.blockSourceEvents = true;
+
+        this._source = source;
+        this._position = Utils.getPosition();
+
+        this.actor.add_style_class_name('dashtodock-stack-menu');
+        this.actor.add_style_class_name(Theming.PositionStyleClass[this._position]);
+
+        const workArea = Main.layoutManager.getWorkAreaForMonitor(
+            this._source.monitorIndex);
+        const {scaleFactor} = St.ThemeContext.get_for_stage(global.stage);
+        this.actor.set_style(
+            `max-width: ${Math.round(workArea.width / scaleFactor) - MENU_MARGINS}px; ` +
+            `max-height: ${Math.round(workArea.height / scaleFactor) - MENU_MARGINS}px;`);
+        this.actor.hide();
+
+        // Chain our visibility and lifecycle to that of the source.
+        this._signalsHandler = new Utils.GlobalSignalsHandler(this);
+        this._signalsHandler.add(this._source, 'notify::mapped', () => {
+            if (!this._source.mapped)
+                this.close();
+        });
+        this._signalsHandler.add(this._source, 'destroy', () => this.destroy());
+
+        Utils.addActor(Main.uiGroup, this.actor);
+    }
+
+    get _appInfo() {
+        return this._source.app?.appInfo ?? null;
+    }
+
+    /** Whether the current contents are laid out as a free-floating arc. */
+    get _fanned() {
+        return this._contents instanceof FolderStackFan;
+    }
+
+    _rebuild() {
+        this.removeAll();
+        this._contents = null;
+
+        const appInfo = this._appInfo;
+        const items = appInfo?.items ?? [];
+
+        if (!items.length) {
+            const empty = new PopupMenu.PopupMenuItem(__('Folder is empty'), {
+                reactive: false,
+                can_focus: false,
+            });
+            empty.add_style_class_name('dashtodock-stack-empty');
+            this.addMenuItem(empty);
+        } else {
+            // fanCapacity() measures the screen, so only ask when a fan is
+            // actually on the table.
+            const configured = Docking.DockManager.settings.downloadsStackView;
+            const capacity = configured === ViewMode.AUTOMATIC ||
+                configured === ViewMode.FAN
+                ? fanCapacity(this._position, this._source.monitorIndex)
+                : 0;
+            const mode = viewModeFor(configured, items.length, this._position,
+                capacity);
+            const Section = {
+                [ViewMode.FAN]: FolderStackFan,
+                [ViewMode.LIST]: FolderStackList,
+            }[mode] ?? FolderStackGrid;
+
+            this._contents = new Section(items, this._position, capacity);
+            this._contents.connect('item-activated',
+                (_s, item) => this._activate(item));
+            this._contents.connect('open-folder', () => this._openFolder());
+            this.addMenuItem(this._contents);
+        }
+
+        // The fan floats free the way it does on macOS, so it gets no bubble
+        // and no footer row; everything else keeps both.
+        if (this._fanned) {
+            this.actor.add_style_class_name('dashtodock-stack-menu-bare');
+            return;
+        }
+
+        this.actor.remove_style_class_name('dashtodock-stack-menu-bare');
+
+        if (items.length || appInfo?.truncated)
+            this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        const open = new PopupMenu.PopupMenuItem(__('Open in File Manager'));
+        open.connect('activate', () => this._openFolder());
+        this.addMenuItem(open);
+    }
+
+    _openFolder() {
+        this._appInfo?.launchAction('open-folder', global.get_current_time());
+        this.close();
+    }
+
+    _activate(item) {
+        Gio.AppInfo.launch_default_for_uri_async(item.uri,
+            global.create_app_launch_context(global.get_current_time(), -1),
+            null, (_o, res) => {
+                try {
+                    Gio.AppInfo.launch_default_for_uri_finish(res);
+                } catch (e) {
+                    logError(e, 'Impossible to open %s'.format(item.uri));
+                }
+            });
+        this.close();
+    }
+
+    /**
+     * The folder changed underneath us. Rebuild in place if the stack is open,
+     * otherwise do nothing: popup() rebuilds from scratch anyway.
+     */
+    queueRedisplay() {
+        if (!this.isOpen)
+            return;
+
+        this._rebuild();
+
+        // _rebuild() throws the old entries away and constructs new ones, which
+        // come up at Clutter's defaults: full size, full opacity, in one frame.
+        // Fading them in keeps a download finishing while the stack is open
+        // from making the whole popup blink and snap. The cascade is skipped
+        // (every entry uses delay 0) because re-running it on each file change
+        // would be noise.
+        const contents = this._contents;
+        if (contents) {
+            contents.prepareReveal(this._position);
+            contents.items.forEach(actor => easeIn(actor, 0));
+        }
+    }
+
+    popup() {
+        this._rebuild();
+        this._contents?.prepareReveal(this._position);
+
+        // The items do the actual "pop". For the grid and the list the bubble
+        // fades in behind them; the fan has no bubble at all, and fading the
+        // (invisible) boxpointer as well just gave every tile a second,
+        // out-of-phase opacity ramp on top of its own.
+        this.open(this._fanned
+            ? BoxPointer.PopupAnimation.NONE
+            : BoxPointer.PopupAnimation.FADE);
+        this.actor.navigate_focus(null, St.DirectionType.TAB_FORWARD, false);
+
+        // Straight after open(), not from a later: opacity, scale and
+        // translation are not layout properties, so they do not need the
+        // actors to be allocated first, and deferring it left the grid stuck
+        // invisible whenever the menu actor already existed from a previous
+        // open.
+        this._contents?.reveal(this._position);
+
+        this._source.emit('sync-tooltip');
+    }
+}

--- a/imports.js
+++ b/imports.js
@@ -8,6 +8,7 @@ export * as DesktopIconsIntegration from './desktopIconsIntegration.js';
 export * as Docking from './docking.js';
 export * as Extension from './extension.js';
 export * as FileManager1API from './fileManager1API.js';
+export * as FolderStack from './folderStack.js';
 export * as Intellihide from './intellihide.js';
 export * as LauncherAPI from './launcherAPI.js';
 export * as Locations from './locations.js';

--- a/locations.js
+++ b/locations.js
@@ -30,7 +30,30 @@ const FILE_MANAGER_DESKTOP_APP_ID = 'org.gnome.Nautilus.desktop';
 const ATTRIBUTE_METADATA_CUSTOM_ICON = 'metadata::custom-icon';
 const TRASH_URI = 'trash://';
 const UPDATE_TRASH_DELAY = 1000;
+// Downloads churns more than the trash does, so wait a little longer before
+// re-reading the directory.
+const UPDATE_FOLDER_DELAY = 1500;
+// Beyond this the stack popup is unusable anyway, and the overflow stays
+// reachable through the "open folder" action.
+const MAX_FOLDER_ITEMS = 100;
 const LAUNCH_HANDLER_MAX_WAIT = 200;
+
+// Everything the stack popup needs about a folder entry, fetched in a single
+// enumeration pass.
+const FOLDER_ITEM_ATTRIBUTES = [
+    Gio.FILE_ATTRIBUTE_STANDARD_NAME,
+    Gio.FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME,
+    Gio.FILE_ATTRIBUTE_STANDARD_ICON,
+    Gio.FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE,
+    Gio.FILE_ATTRIBUTE_STANDARD_TYPE,
+    Gio.FILE_ATTRIBUTE_STANDARD_IS_HIDDEN,
+    Gio.FILE_ATTRIBUTE_STANDARD_IS_BACKUP,
+    Gio.FILE_ATTRIBUTE_STANDARD_SIZE,
+    Gio.FILE_ATTRIBUTE_TIME_MODIFIED,
+    Gio.FILE_ATTRIBUTE_THUMBNAIL_PATH,
+    Gio.FILE_ATTRIBUTE_THUMBNAIL_IS_VALID,
+    Gio.FILE_ATTRIBUTE_THUMBNAILING_FAILED,
+].join(',');
 
 const NautilusFileOperations2Interface = '<node>\
     <interface name="org.gnome.Nautilus.FileOperations2">\
@@ -880,6 +903,208 @@ class TrashAppInfo extends LocationAppInfo {
     }
 });
 
+const FOLDER_ACTION_OPEN = 'open-folder';
+const FALLBACK_FOLDER_ICON = 'folder';
+
+const FOLDER_ENUMERATION_BATCH = 50;
+
+export const FolderAppInfo = GObject.registerClass({
+    Implements: [Gio.AppInfo],
+    Signals: {
+        'items-changed': {},
+    },
+},
+class FolderAppInfo extends LocationAppInfo {
+    static initPromises(file) {
+        if (FolderAppInfo._promisified)
+            return;
+
+        const fileProto = file.constructor.prototype;
+        Gio._promisify(Gio.FileEnumerator.prototype, 'close_async', 'close_finish');
+        Gio._promisify(Gio.FileEnumerator.prototype, 'next_files_async', 'next_files_finish');
+        Gio._promisify(fileProto, 'enumerate_children_async', 'enumerate_children_finish');
+        Gio._promisify(fileProto, 'query_info_async', 'query_info_finish');
+        FolderAppInfo._promisified = true;
+    }
+
+    _init(location, {cancellable = null, iconName = FALLBACK_FOLDER_ICON} = {}) {
+        super._init({
+            location,
+            name: location.get_basename(),
+            icon: Gio.ThemedIcon.new(iconName),
+            cancellable,
+        });
+        FolderAppInfo.initPromises(this.location);
+
+        this._items = [];
+        this._truncated = false;
+
+        try {
+            // Watching moves matters here: downloads typically land as a
+            // temporary file that is renamed into place once complete.
+            this._monitor = this.location.monitor_directory(
+                Gio.FileMonitorFlags.WATCH_MOVES, this.cancellable);
+            this._schedUpdateId = 0;
+            this._monitorChangedId = this._monitor.connect('changed', () =>
+                this._onFolderChange());
+        } catch (e) {
+            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                return;
+            logError(e, 'Impossible to monitor %s'.format(location.get_uri()));
+        }
+
+        this._updateFolder();
+        this._updateLocationIcon();
+    }
+
+    destroy() {
+        if (this._schedUpdateId) {
+            GLib.source_remove(this._schedUpdateId);
+            this._schedUpdateId = 0;
+        }
+        this._updateFolderCancellable?.cancel();
+        this._monitor?.disconnect(this._monitorChangedId);
+        this._monitor = null;
+        this._items = [];
+
+        super.destroy();
+    }
+
+    /**
+     * The folder contents, newest first, capped to MAX_FOLDER_ITEMS.
+     */
+    get items() {
+        return this._items;
+    }
+
+    /**
+     * Whether the cap above actually dropped anything.
+     */
+    get truncated() {
+        return this._truncated;
+    }
+
+    list_actions() {
+        return [FOLDER_ACTION_OPEN];
+    }
+
+    get_action_name(action) {
+        return action === FOLDER_ACTION_OPEN ? __('Open in File Manager') : null;
+    }
+
+    launchAction(action, timestamp, workspace = -1) {
+        if (action !== FOLDER_ACTION_OPEN)
+            throw new Error('Action %s is not supported by %s'.format(action, this));
+
+        this.launch([], global.create_app_launch_context(timestamp, workspace));
+    }
+
+    _onFolderChange() {
+        if (this._schedUpdateId) {
+            GLib.source_remove(this._schedUpdateId);
+            this._schedUpdateId = 0;
+        }
+
+        if (this._monitor.is_cancelled())
+            return;
+
+        this._schedUpdateId = GLib.timeout_add(GLib.PRIORITY_LOW,
+            UPDATE_FOLDER_DELAY, () => {
+                this._schedUpdateId = 0;
+                this._updateFolder();
+                return GLib.SOURCE_REMOVE;
+            });
+    }
+
+    _makeItem(info) {
+        const name = info.get_name();
+        const file = this.location.get_child(name);
+        // GIO only reports a path once the cached thumbnail is up to date, so
+        // is-valid and a non-null path always travel together.
+        const thumbnailPath =
+            info.get_attribute_boolean(Gio.FILE_ATTRIBUTE_THUMBNAIL_IS_VALID)
+                ? info.get_attribute_byte_string(Gio.FILE_ATTRIBUTE_THUMBNAIL_PATH)
+                : null;
+
+        return {
+            file,
+            uri: file.get_uri(),
+            displayName: info.get_display_name(),
+            contentType: info.get_content_type(),
+            icon: info.get_icon(),
+            isDirectory: info.get_file_type() === Gio.FileType.DIRECTORY,
+            size: info.get_size(),
+            modified: info.get_attribute_uint64(Gio.FILE_ATTRIBUTE_TIME_MODIFIED),
+            thumbnailPath,
+            thumbnailFailed: info.get_attribute_boolean(
+                Gio.FILE_ATTRIBUTE_THUMBNAILING_FAILED),
+        };
+    }
+
+    async _updateFolder() {
+        const priority = GLib.PRIORITY_LOW;
+        this._updateFolderCancellable?.cancel();
+        const cancellable = new Utils.CancellableChild(this.cancellable);
+        this._updateFolderCancellable = cancellable;
+
+        const items = [];
+
+        try {
+            const enumerator = await this.location.enumerate_children_async(
+                FOLDER_ITEM_ATTRIBUTES, Gio.FileQueryInfoFlags.NONE,
+                priority, cancellable);
+
+            for (;;) {
+                // eslint-disable-next-line no-await-in-loop
+                const infos = await enumerator.next_files_async(
+                    FOLDER_ENUMERATION_BATCH, priority, cancellable);
+
+                if (!infos.length)
+                    break;
+
+                infos.forEach(info => {
+                    if (info.get_is_hidden() || info.get_is_backup())
+                        return;
+
+                    items.push(this._makeItem(info));
+                });
+            }
+
+            await enumerator.close_async(priority, null);
+        } catch (e) {
+            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) {
+                logError(e, 'Impossible to enumerate %s'.format(
+                    this.location.get_uri()));
+            }
+            return;
+        } finally {
+            cancellable.cancel();
+            if (this._updateFolderCancellable === cancellable)
+                delete this._updateFolderCancellable;
+        }
+
+        // Newest first, matching the macOS "Date Added" default for Downloads.
+        items.sort((a, b) => b.modified - a.modified);
+
+        const truncated = items.length > MAX_FOLDER_ITEMS;
+        const capped = items.slice(0, MAX_FOLDER_ITEMS);
+
+        // A file monitor fires for plenty of things that leave the listing
+        // identical, and every emission costs a dock icon rebuild plus, if the
+        // stack is open, a popup rebuild. Only report an actual change.
+        const changed = truncated !== this._truncated ||
+            capped.length !== this._items.length ||
+            capped.some((item, i) => item.uri !== this._items[i].uri ||
+                item.modified !== this._items[i].modified);
+
+        this._truncated = truncated;
+        this._items = capped;
+
+        if (changed)
+            this.emit('items-changed');
+    }
+});
+
 /**
  * @param shellApp
  */
@@ -1119,6 +1344,7 @@ function makeLocationApp(params) {
     shellApp._setDtdData({
         location: () => shellApp.appInfo.location,
         isTrash: shellApp.appInfo instanceof TrashAppInfo,
+        isFolder: shellApp.appInfo instanceof FolderAppInfo,
     }, {getter: true, enumerable: true});
 
     shellApp._mi('toString', defaultToString =>

--- a/locations.js
+++ b/locations.js
@@ -26,6 +26,7 @@ const {signals: Signals} = imports;
 
 const FALLBACK_REMOVABLE_MEDIA_ICON = 'drive-removable-media';
 const FALLBACK_TRASH_ICON = 'user-trash';
+const FALLBACK_DOWNLOADS_ICON = 'folder-download';
 const FILE_MANAGER_DESKTOP_APP_ID = 'org.gnome.Nautilus.desktop';
 const ATTRIBUTE_METADATA_CUSTOM_ICON = 'metadata::custom-icon';
 const TRASH_URI = 'trash://';
@@ -1577,6 +1578,61 @@ export class Trash {
 }
 
 /**
+ * Resolve the user's Downloads directory, falling back to the conventional
+ * path when XDG has nothing configured.
+ *
+ * @returns {Gio.File | null} the directory, or null when it does not exist
+ */
+function getDownloadsLocation() {
+    const path = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD) ??
+        GLib.build_filenamev([GLib.get_home_dir(), 'Downloads']);
+
+    if (!GLib.file_test(path, GLib.FileTest.IS_DIR))
+        return null;
+
+    return Gio.File.new_for_path(path);
+}
+
+/**
+ * This class maintains a Shell.App representing the Downloads folder, so that
+ * it can be shown in the dash as a macOS-like stack.
+ */
+export class Downloads {
+    destroy() {
+        this._downloadsApp?.destroy();
+        this._downloadsApp = null;
+    }
+
+    _ensureApp() {
+        if (this._downloadsApp)
+            return;
+
+        const location = getDownloadsLocation();
+        if (!location)
+            return;
+
+        this._downloadsApp = makeLocationApp({
+            appInfo: new FolderAppInfo(location, {
+                cancellable: new Gio.Cancellable(),
+                iconName: FALLBACK_DOWNLOADS_ICON,
+            }),
+            fallbackIconName: FALLBACK_DOWNLOADS_ICON,
+        });
+    }
+
+    /**
+     * Zero or one app, the way Removables reports zero or more: the folder may
+     * not exist, and that is not something every caller should have to check.
+     *
+     * @returns {Shell.App[]} the Downloads app, or nothing
+     */
+    getApps() {
+        this._ensureApp();
+        return this._downloadsApp ? [this._downloadsApp] : [];
+    }
+}
+
+/**
  * This class maintains Shell.App representations for removable devices
  * plugged into the system, and keeps the list of Apps up-to-date as
  * devices come and go and are mounted and unmounted.
@@ -1742,6 +1798,9 @@ function getApps() {
 
     if (dockManager.trash)
         locationApps.push(dockManager.trash.getApp());
+
+    if (dockManager.downloads)
+        locationApps.push(...dockManager.downloads.getApps());
 
     return locationApps;
 }

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -2,5 +2,6 @@ prefs.js
 docking.js
 appIcons.js
 appIconsDecorator.js
+folderStack.js
 locations.js
 Settings.ui

--- a/prefs.js
+++ b/prefs.js
@@ -695,11 +695,38 @@ const DockSettings = GObject.registerClass({
             this._builder.get_object('show_network_volumes_check'),
             'active',
             Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('show-downloads',
+            this._builder.get_object('show_downloads_switch'),
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        [
+            ['downloads-stack-view', 'downloads_stack_view_combo'],
+            ['downloads-icon-display', 'downloads_icon_display_combo'],
+        ].forEach(([key, widgetId]) => {
+            // Enum combos are driven by index, so the item order in Settings.ui
+            // has to match the nick order in the gschema.
+            const combo = this._builder.get_object(widgetId);
+            combo.set_active(this._settings.get_enum(key));
+            combo.connect('changed',
+                widget => this._settings.set_enum(key, widget.get_active()));
+        });
+        const downloadsOptions = ['downloads_stack_view_label',
+            'downloads_stack_view_combo', 'downloads_icon_display_label',
+            'downloads_icon_display_combo'];
+        const updateDownloadsOptions = () => {
+            const enabled = this._builder.get_object('show_downloads_switch').active;
+            downloadsOptions.forEach(id =>
+                (this._builder.get_object(id).sensitive = enabled));
+        };
+        updateDownloadsOptions();
+        this._builder.get_object('show_downloads_switch').connect(
+            'notify::active', () => updateDownloadsOptions());
         this._settings.bind('isolate-locations',
             this._builder.get_object('isolate_locations_switch'),
             'active',
             Gio.SettingsBindFlags.DEFAULT);
-        const isolateLocationsBindings = ['show_trash_switch', 'show_mounts_switch'];
+        const isolateLocationsBindings = ['show_trash_switch', 'show_mounts_switch',
+            'show_downloads_switch'];
         const updateIsolateLocations = () => {
             this._builder.get_object('isolate_locations_row').sensitive =
                 isolateLocationsBindings.some(s => this._builder.get_object(s).active);

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -50,6 +50,16 @@
     <value value='8' nick='BINARY'/>
     <value value='9' nick='DOT'/>
   </enum>
+  <enum id='org.gnome.shell.extensions.dash-to-dock.downloads-stack-view'>
+    <value value='0' nick='AUTOMATIC'/>
+    <value value='1' nick='FAN'/>
+    <value value='2' nick='GRID'/>
+    <value value='3' nick='LIST'/>
+  </enum>
+  <enum id='org.gnome.shell.extensions.dash-to-dock.downloads-icon-display'>
+    <value value='0' nick='STACK'/>
+    <value value='1' nick='FOLDER'/>
+  </enum>
   <schema path="/org/gnome/shell/extensions/dash-to-dock/" id="org.gnome.shell.extensions.dash-to-dock">
     <key name="dock-position" enum="org.gnome.shell.extensions.dash-to-dock.position">
       <default>'BOTTOM'</default>
@@ -260,6 +270,27 @@
       <default>true</default>
       <summary>Show trash can</summary>
       <description>Show or hide the trash can icon in the dash</description>
+    </key>
+    <key type="b" name="show-downloads">
+      <default>false</default>
+      <summary>Show the Downloads folder</summary>
+      <description>Show or hide the Downloads folder icon in the dash</description>
+    </key>
+    <key name="downloads-stack-view" enum="org.gnome.shell.extensions.dash-to-dock.downloads-stack-view">
+      <default>'AUTOMATIC'</default>
+      <summary>How the Downloads stack shows its contents</summary>
+      <description>
+        Lay the folder contents out as a fan, a grid or a list. Automatic picks
+        a fan for a handful of files and a grid for more.
+      </description>
+    </key>
+    <key name="downloads-icon-display" enum="org.gnome.shell.extensions.dash-to-dock.downloads-icon-display">
+      <default>'STACK'</default>
+      <summary>How the Downloads dock icon looks</summary>
+      <description>
+        Show the plain folder icon, or preview the most recent contents on top
+        of it as a stack.
+      </description>
     </key>
     <key type="b" name="show-mounts">
       <default>true</default>


### PR DESCRIPTION
Adds a MacOS-like downloads stack to the dock. Clicking the folder icon opens the folder's contents as a fan, a grid or a list instead of launching the file manager.

https://github.com/user-attachments/assets/527e07d8-52b6-4436-9473-260237945732

Off by default. Enable it in Preferences under Launchers, where the layout and the icon style can also be set; both also appear on the icon's context menu.

- **View content as**: Automatic, Fan, Grid or List. Automatic picks a fan for a handful of files and a grid beyond that, or whenever the dock is vertical and an arc has nowhere to rise.
- **Display as**: Stack, which previews the newest entries piled on the dock icon, or the plain folder icon.

<img width="1600" height="1200" alt="05-view-fan" src="https://github.com/user-attachments/assets/42f4890b-9231-4de5-9aa2-964476f52304" />

---

<img width="1600" height="1200" alt="06-view-grid" src="https://github.com/user-attachments/assets/1c4a02a2-85e3-4d1d-90db-6af5a1c40014" />
(contents blurred for privacy)

---

<img width="1600" height="1200" alt="07-view-list" src="https://github.com/user-attachments/assets/6fb83368-2c32-4c20-b23b-4e2b424460ae" />
(contents blurred for privacy)

---

I tested this as much as I could on my system (CachyOS + GNOME 50.4) at different display scales (100%, 125% and 200%).  
But since this only covers a tiny portion of the dash-to-dock users, some verification on other people's systems would be nice. :)

---

Fixes https://github.com/micheleg/dash-to-dock/issues/417