### PR TITLE
cycle+minimize

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -74,6 +74,7 @@
                           <item translatable="yes">Minimize window</item>
                           <item translatable="yes">Launch new instance</item>
                           <item translatable="yes">Cycle through windows</item>
+                          <item translatable="yes">Cycle + Minimize</item>
                           <item translatable="yes">Minimize or overview</item>
                           <item translatable="yes">Show window previews</item>
                           <item translatable="yes">Minimize or show previews</item>
@@ -154,6 +155,7 @@
                           <item translatable="yes">Focus, minimize or show previews</item>
                           <item translatable="yes">Focus, minimize or app spread</item>
                           <item translatable="yes">Quit</item>
+                          <item translatable="yes">Cycle + Minimize</item>
                         </items>
                         <layout>
                           <property name="column">1</property>
@@ -218,6 +220,7 @@
                           <item translatable="yes">Minimize window</item>
                           <item translatable="yes">Launch new instance</item>
                           <item translatable="yes">Cycle through windows</item>
+                          <item translatable="yes">Cycle + Minimize</item>
                           <item translatable="yes">Minimize or overview</item>
                           <item translatable="yes">Show window previews</item>
                           <item translatable="yes">Minimize or show previews</item>
@@ -1685,6 +1688,7 @@
                                       <item translatable="yes">Minimize</item>
                                       <item translatable="yes">Launch new instance</item>
                                       <item translatable="yes">Cycle through windows</item>
+                                      <item translatable="yes">Cycle + Minimize</item>
                                       <item translatable="yes">Minimize or overview</item>
                                       <item translatable="yes">Show window previews</item>
                                       <item translatable="yes">Minimize or show previews</item>
@@ -1692,6 +1696,7 @@
                                       <item translatable="yes">Focus or app spread</item>
                                       <item translatable="yes">Focus, minimize or show previews</item>
                                       <item translatable="yes">Focus, minimize or app spread</item>
+                                      <item translatable="yes">Quit</item>
                                     </items>
                                   </object>
                                 </child>

--- a/appIcons.js
+++ b/appIcons.js
@@ -56,14 +56,15 @@ const clickAction = Object.freeze({
     MINIMIZE: 1,
     LAUNCH: 2,
     CYCLE_WINDOWS: 3,
-    MINIMIZE_OR_OVERVIEW: 4,
-    PREVIEWS: 5,
-    MINIMIZE_OR_PREVIEWS: 6,
-    FOCUS_OR_PREVIEWS: 7,
-    FOCUS_OR_APP_SPREAD: 8,
-    FOCUS_MINIMIZE_OR_PREVIEWS: 9,
-    FOCUS_MINIMIZE_OR_APP_SPREAD: 10,
-    QUIT: 11,
+    CYCLE_MINIMIZE: 4,
+    MINIMIZE_OR_OVERVIEW: 5,
+    PREVIEWS: 6,
+    MINIMIZE_OR_PREVIEWS: 7,
+    FOCUS_OR_PREVIEWS: 8,
+    FOCUS_OR_APP_SPREAD: 9,
+    FOCUS_MINIMIZE_OR_PREVIEWS: 10,
+    FOCUS_MINIMIZE_OR_APP_SPREAD: 11,
+    QUIT: 12,
 });
 
 const scrollAction = Object.freeze({
@@ -616,6 +617,13 @@ export const DockAbstractAppIcon = GObject.registerClass({
                 }
                 break;
 
+            case clickAction.CYCLE_MINIMIZE:
+                if (!Main.overview.visible)
+                    this._cycleThroughWindowsAndMinimize();
+                else
+                    this.app.activate();
+                break;
+
             case clickAction.FOCUS_OR_PREVIEWS:
                 if (this.focused && !hasUrgentWindows &&
                     (windows.length > 1 || modifiers || button !== 1)) {
@@ -919,6 +927,43 @@ export const DockAbstractAppIcon = GObject.registerClass({
         const window = recentlyClickedAppWindows[index];
 
         Main.activateWindow(window);
+    }
+
+    _cycleThroughWindowsAndMinimize(reversed) {
+        // getWindows() is the AppIcon accessor for the app's unfiltered window
+        // list. Sort by stable Mutter window IDs rather than MRU order.
+        const windows = [...this.getWindows()]
+            .sort((a, b) => a.get_id() - b.get_id());
+        if (!windows.length)
+            return;
+
+        const focusedWindow = windows.find(w => w.has_focus());
+
+        if (windows.length === 1) {
+            if (focusedWindow)
+                focusedWindow.minimize();
+            else
+                Main.activateWindow(windows[0]);
+            return;
+        }
+
+        // If this app is not focused, start its cycle at the appropriate end.
+        if (!focusedWindow) {
+            Main.activateWindow(windows[reversed ? windows.length - 1 : 0]);
+            return;
+        }
+
+        const focusedIndex = windows.indexOf(focusedWindow);
+        const nextIndex = focusedIndex + (reversed ? -1 : 1);
+        if (nextIndex >= 0 && nextIndex < windows.length) {
+            Main.activateWindow(windows[nextIndex]);
+            return;
+        }
+
+        // Minimize the focused window last: minimizing it first can cause
+        // GNOME to raise background windows during the animation.
+        windows.filter(w => w !== focusedWindow).forEach(w => w.minimize());
+        focusedWindow.minimize();
     }
 
     _resetRecentlyClickedApp() {

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -5,14 +5,15 @@
     <value value='1' nick='minimize'/>
     <value value='2' nick='launch'/>
     <value value='3' nick='cycle-windows'/>
-    <value value='4' nick='minimize-or-overview'/>
-    <value value='5' nick='previews'/>
-    <value value='6' nick='minimize-or-previews'/>
-    <value value='7' nick='focus-or-previews'/>
-    <value value='8' nick='focus-or-appspread'/>
-    <value value='9' nick='focus-minimize-or-previews'/>
-    <value value='10' nick='focus-minimize-or-appspread'/>
-    <value value='11' nick='quit'/>
+    <value value='4' nick='cycle-minimize'/>
+    <value value='5' nick='minimize-or-overview'/>
+    <value value='6' nick='previews'/>
+    <value value='7' nick='minimize-or-previews'/>
+    <value value='8' nick='focus-or-previews'/>
+    <value value='9' nick='focus-or-appspread'/>
+    <value value='10' nick='focus-minimize-or-previews'/>
+    <value value='11' nick='focus-minimize-or-appspread'/>
+    <value value='12' nick='quit'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-dock.scrollAction'>
     <value value='0' nick='do-nothing'/>


### PR DESCRIPTION
Closes  #431
<img width="733" height="900" alt="Screenshot From 2026-08-11 17-09-36" src="https://github.com/user-attachments/assets/3336a638-9b8f-4eff-9268-f19802dfcb96" />

### Overview:
Adds a new, dedicated click action for app icons that allows users to cycle through open windows and minimize the application at the end of the stack. This provides a more fluid, keyboard-free workflow for hiding apps compared to the default, endlessly looping "Cycle through windows" behavior.

### Behavior Breakdown:

Single Window: Acts as a standard toggle. Clicking focuses the window; clicking again minimizes it.

Multiple Windows: Clicking cycles focus to the next window in a consistent, predictable order.

End of Cycle: Once the cycle reaches the final window in the stack, the next click minimizes all windows for that application rather than looping back to the first window.