### PR TITLE
appIconIndicators: Announce unread notification count to screen readers

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -15,7 +15,10 @@ import {
     Utils,
 } from './imports.js';
 
+import {Extension} from './dependencies/shell/extensions/extension.js';
+
 const {cairo: Cairo} = imports;
+const {ngettext} = Extension;
 
 const RunningIndicatorStyle = Object.freeze({
     DEFAULT: 0,
@@ -790,6 +793,7 @@ export class UnityIndicator extends IndicatorBase {
     destroy() {
         this._notificationBadgeBin?.destroy();
         this._notificationBadgeBin = null;
+        this._updateNotificationAccessibility(0);
         this._hideProgressOverlay();
         this.setUrgent(false);
         this.setUpdating(false);
@@ -905,6 +909,30 @@ export class UnityIndicator extends IndicatorBase {
         ]);
     }
 
+    _updateNotificationAccessibility(count) {
+        const appName = this._source.app?.get_name();
+        if (!appName)
+            return;
+
+        const accessibleName = count > 0
+            ? ngettext('%s, %d unread notification', '%s, %d unread notifications', count)
+                .format(appName, count)
+            : appName;
+
+        if (this._source.label_actor === null) {
+            // Dock: name owned by parent DashItemContainer, see dash.js
+            const itemContainer = this._source.get_parent?.();
+            if (itemContainer)
+                itemContainer.accessible_name = accessibleName;
+            this._source.accessible_name = accessibleName;
+        } else {
+            // Overview: no per-icon parent, update icon and label directly
+            this._source.accessible_name = accessibleName;
+            if (this._source.label_actor)
+                this._source.label_actor.accessible_name = accessibleName;
+        }
+    }
+
     setNotificationCount(count) {
         if (count > 0) {
             const text = this._notificationBadgeCountToText(count);
@@ -914,6 +942,8 @@ export class UnityIndicator extends IndicatorBase {
             this._notificationBadgeBin.destroy();
             this._notificationBadgeBin = null;
         }
+
+        this._updateNotificationAccessibility(count);
     }
 
     _showProgressOverlay() {

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,6 +1,7 @@
 prefs.js
 docking.js
 appIcons.js
+appIconIndicators.js
 appIconsDecorator.js
 locations.js
 Settings.ui


### PR DESCRIPTION
Unread counts were only shown as a visual badge, so screen reader users had no way to know an app had pending notifications.

Update the accessible name whenever the count changes, using the parent DashItemContainer in the dock and the icon/label directly in the overview, since neither has a single shared actor that both contexts read from.

Closes #2665