### PR TITLE
Add option to hide dock when preferred monitor is unavailable

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,34 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-import {DockManager} from './docking.js';
+import {DockManager as BaseDockManager} from './docking.js';
+import {Utils} from './imports.js';
 import {Extension} from './dependencies/shell/extensions/extension.js';
+
+class DockManager extends BaseDockManager {
+    _bindSettingsChanges() {
+        super._bindSettingsChanges();
+        this._signalsHandler.add(
+            this._settings,
+            'changed::hide-if-monitor-unavailable',
+            this._toggle.bind(this));
+    }
+
+    _createDocks() {
+        if (this.settings.hideIfMonitorUnavailable &&
+            !this.settings.multiMonitor &&
+            this.settings.preferredMonitor === -2 &&
+            this.settings.preferredMonitorByConnector !== 'primary') {
+            const monitorManager = Utils.getMonitorManager();
+            const preferredMonitorIndex = monitorManager.get_monitor_for_connector(
+                this.settings.preferredMonitorByConnector);
+
+            if (preferredMonitorIndex < 0)
+                return;
+        }
+
+        super._createDocks();
+    }
+}
 
 // We export this so it can be accessed by other extensions
 export let dockManager;

--- a/prefs.js
+++ b/prefs.js
@@ -371,9 +371,13 @@ const DockSettings = GObject.registerClass({
         dockMonitorCombo.remove_all();
         let primaryIndex = -1;
 
-        // Add connected monitors
+        // Add connected monitors and retain the selected monitor when inactive
         for (const monitor of this._monitorsConfig.monitors) {
-            if (!monitor.active && monitor.index !== preferredMonitor)
+            const isPreferredMonitor = monitor.index === preferredMonitor ||
+                (preferredMonitor === -2 &&
+                    preferredMonitorByConnector === monitor.connector);
+
+            if (!monitor.active && !isPreferredMonitor)
                 continue;
 
             if (monitor.isPrimary) {
@@ -391,8 +395,7 @@ const DockSettings = GObject.registerClass({
 
             this._monitors.push(monitor);
 
-            if (monitor.index === preferredMonitor ||
-                (preferredMonitor === -2 && preferredMonitorByConnector === monitor.connector))
+            if (isPreferredMonitor)
                 dockMonitorCombo.set_active(this._monitors.length - 1);
         }
 
@@ -415,6 +418,21 @@ const DockSettings = GObject.registerClass({
             () => this._updateMonitorsSettings());
         this._settings.connect('changed::preferred-monitor-by-connector',
             () => this._updateMonitorsSettings());
+
+        const hideUnavailableMonitorButton = new Gtk.CheckButton({
+            label: __('Hide when this monitor is unavailable'),
+            margin_top: 12,
+        });
+        this._builder.get_object('dock_monitor_grid').attach(
+            hideUnavailableMonitorButton, 0, 3, 2, 1);
+        this._settings.bind('hide-if-monitor-unavailable',
+            hideUnavailableMonitorButton,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('multi-monitor',
+            hideUnavailableMonitorButton,
+            'sensitive',
+            Gio.SettingsBindFlags.INVERT_BOOLEAN);
 
         // Position option
         const position = this._settings.get_enum('dock-position');

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -327,6 +327,11 @@
       <summary>Monitor on which putting the dock (by connector)</summary>
       <description>Set on which monitor to put the dock, for example 'DisplayPort-0'. Use 'primary' for primary one. This setting is only used if 'preferred-monitor' is -2.</description>
     </key>
+    <key type="b" name="hide-if-monitor-unavailable">
+      <default>false</default>
+      <summary>Hide dock when the preferred monitor is unavailable</summary>
+      <description>Do not fall back to another monitor when the preferred monitor is disconnected or disabled.</description>
+    </key>
     <key type="b" name="multi-monitor">
       <default>false</default>
       <summary>Enable multi-monitor docks</summary>


### PR DESCRIPTION
## Summary

Add an optional **"Hide when this monitor is unavailable"** setting for single-monitor dock configurations.

Currently, when the preferred monitor is disconnected or disabled, Dash to Dock falls back to the primary monitor. This adds an option to instead hide the dock until the preferred monitor becomes available again.

The option defaults to disabled, so existing behavior is unchanged.

## Motivation

This is useful for setups where the dock should only appear on a specific display.

For example, on a laptop with an external dock:

- With the laptop display enabled, the dock can be shown on the laptop display.
- When the lid is closed, that display becomes unavailable.
- Instead of moving the dock to an external monitor, the dock can remain hidden.
- When the laptop display becomes available again, the dock is recreated there automatically.

The behavior is based only on monitor availability and does not require any laptop-, lid-, or docking-specific logic.

## Changes

- Add a `hide-if-monitor-unavailable` setting, disabled by default.
- Add a **"Hide when this monitor is unavailable"** checkbox to the monitor settings.
- Do not fall back to the primary monitor when the preferred monitor is unavailable and the option is enabled.
- Recreate the dock automatically when the preferred monitor becomes available again.
- Keep the configured monitor visible in the preferences selector while it is inactive.
- Disable the option when **"Show on all monitors"** is enabled.

## Behavior

| Preferred monitor | Option disabled | Option enabled |
| --- | --- | --- |
| Available | Show dock on preferred monitor | Show dock on preferred monitor |
| Unavailable | Fall back to primary monitor | Hide dock |

## Compatibility

The new setting defaults to `false`, preserving the current behavior for existing users.