### PR TITLE
Fix GNOME 51.rc compatibility

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -170,7 +170,6 @@ export const DockDash = GObject.registerClass({
             name: 'dashtodockDashContainer',
             x_align: Clutter.ActorAlign.CENTER,
             y_align: Clutter.ActorAlign.CENTER,
-            vertical: !this._isHorizontal,
             y_expand: this._isHorizontal,
             x_expand: !this._isHorizontal,
         });
@@ -190,13 +189,11 @@ export const DockDash = GObject.registerClass({
             name: 'dashtodockBoxContainer',
             x_align: Clutter.ActorAlign.FILL,
             y_align: Clutter.ActorAlign.FILL,
-            vertical: !this._isHorizontal,
         });
         this._boxContainer.add_style_class_name(Theming.PositionStyleClass[this._position]);
 
         const rtl = Clutter.get_default_text_direction() === Clutter.TextDirection.RTL;
         this._box = new St.BoxLayout({
-            vertical: !this._isHorizontal,
             clip_to_allocation: false,
             ...!this._isHorizontal ? {layout_manager: new DockDashIconsVerticalLayout()} : {},
             x_align: rtl ? Clutter.ActorAlign.END : Clutter.ActorAlign.START,
@@ -204,6 +201,19 @@ export const DockDash = GObject.registerClass({
             y_expand: !this._isHorizontal,
             x_expand: this._isHorizontal,
         });
+
+        if (this._dashContainer.orientation !== undefined) {
+            this._dashContainer.orientation =
+                this._boxContainer.orientation =
+                this._box.orientation = this._isHorizontal
+                    ? Clutter.Orientation.HORIZONTAL
+                    : Clutter.Orientation.VERTICAL;
+        } else {
+            this._dashContainer.vertical =
+                this._boxContainer.vertical =
+                this._box.vertical = !this._isHorizontal;
+        }
+
         this._box._delegate = this;
         this._boxContainer.add_child(this._box);
         Utils.addActor(this._scrollView, this._boxContainer);

--- a/dependencies/shell/ui.js
+++ b/dependencies/shell/ui.js
@@ -8,7 +8,6 @@ export * as Layout from 'resource:///org/gnome/shell/ui/layout.js';
 export * as Main from 'resource:///org/gnome/shell/ui/main.js';
 export * as Overview from 'resource:///org/gnome/shell/ui/overview.js';
 export * as OverviewControls from 'resource:///org/gnome/shell/ui/overviewControls.js';
-export * as PointerWatcher from 'resource:///org/gnome/shell/ui/pointerWatcher.js';
 export * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 export * as SearchController from 'resource:///org/gnome/shell/ui/searchController.js';
 export * as ShellMountOperation from 'resource:///org/gnome/shell/ui/shellMountOperation.js';

--- a/docking.js
+++ b/docking.js
@@ -16,7 +16,6 @@ import {
     Layout,
     Main,
     OverviewControls,
-    PointerWatcher,
     SwitcherPopup,
     Workspace,
     WorkspacesView,
@@ -512,11 +511,7 @@ const DockedDash = GObject.registerClass({
         // Remove existing barrier
         this._removeBarrier();
 
-        // Remove pointer watcher
-        if (this._dockWatch) {
-            PointerWatcher.getPointerWatcher()._removeWatch(this._dockWatch);
-            this._dockWatch = null;
-        }
+        this._removeDockWatch();
 
         if (this._optionalScrollWorkspaceSwitchDeadTimeId) {
             GLib.source_remove(this._optionalScrollWorkspaceSwitchDeadTimeId);
@@ -525,11 +520,7 @@ const DockedDash = GObject.registerClass({
     }
 
     _updateAutoHideBarriers() {
-        // Remove pointer watcher
-        if (this._dockWatch) {
-            PointerWatcher.getPointerWatcher()._removeWatch(this._dockWatch);
-            this._dockWatch = null;
-        }
+        this._removeDockWatch();
 
         // Setup pressure barrier (GS38+ only)
         this._updatePressureBarrier();
@@ -922,15 +913,27 @@ const DockedDash = GObject.registerClass({
         if (this._autohideIsEnabled &&
             (!Utils.supportsExtendedBarriers() ||
              !DockManager.settings.requirePressureToShow)) {
-            const pointerWatcher = PointerWatcher.getPointerWatcher();
-            this._dockWatch = pointerWatcher.addWatch(
-                DOCK_DWELL_CHECK_INTERVAL, this._checkDockDwell.bind(this));
+            this._dockWatch = Utils.getCursorTracker().connect(
+                'position-invalidated',
+                () => this._checkDockDwellLater(...global.get_pointer()));
             this._dockDwelling = false;
             this._dockDwellUserTime = 0;
         }
     }
 
-    _checkDockDwell(x, y) {
+    _checkDockDwellLater(x, y) {
+        if (this._checkDockDwellId > 0)
+            return;
+
+        this._checkDockDwellId = GLib.timeout_add(GLib.PRIORITY_DEFAULT,
+            DOCK_DWELL_CHECK_INTERVAL, () => {
+                this._checkDockDwellNow(x, y);
+                this._checkDockDwellId = 0;
+                return GLib.SOURCE_REMOVE;
+            });
+    }
+
+    _checkDockDwellNow(x, y) {
         const workArea = Main.layoutManager.getWorkAreaForMonitor(this._monitor.index);
         let shouldDwell;
         // Check for the correct screen edge, extending the sensitive area to the whole workarea,
@@ -1004,6 +1007,18 @@ const DockedDash = GObject.registerClass({
         // Reuse the pressure version function, the logic is the same
         this._onPressureSensed();
         return GLib.SOURCE_REMOVE;
+    }
+
+    _removeDockWatch() {
+        if (this._checkDockDwellId > 0) {
+            GLib.source_remove(this._checkDockDwellId);
+            this._checkDockDwellId = 0;
+        }
+
+        if (this._dockWatch) {
+            Utils.getCursorTracker().disconnect(this._dockWatch);
+            this._dockWatch = null;
+        }
     }
 
     _updatePressureBarrier() {

--- a/utils.js
+++ b/utils.js
@@ -729,6 +729,19 @@ export function getMonitorManager() {
 }
 
 /**
+ * Gets the cursor tracker, using the API available in the current
+ * GNOME Shell version: `global.backend.get_cursor_tracker()` is only
+ * available since GNOME Shell 48, while older versions require using
+ * `Meta.CursorTracker.get_for_display()`.
+ *
+ * @returns {Meta.CursorTracker} The cursor tracker.
+ */
+export function getCursorTracker() {
+    return global.backend.get_cursor_tracker?.() ??
+        Meta.CursorTracker.get_for_display(global.display);
+}
+
+/**
  * @param laterType
  * @param callback
  */

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -382,10 +382,14 @@ class WindowPreviewMenuItem extends PopupMenu.PopupBaseMenuItem {
         });
 
         const box = new St.BoxLayout({
-            vertical: true,
             reactive: true,
             x_expand: true,
         });
+
+        if (box.orientation !== undefined)
+            box.orientation = Clutter.Orientation.VERTICAL;
+        else
+            box.vertical = true;
 
         if (box.add) {
             box.add(overlayGroup);


### PR DESCRIPTION
The `PointerWatcher` class and `vertical` property no longer exist in 51.rc.

Closes #2670 and more